### PR TITLE
Make stdio MCPs Editable

### DIFF
--- a/apps/cli/src/service.ts
+++ b/apps/cli/src/service.ts
@@ -595,8 +595,8 @@ const windowsTaskUserId = (): string => {
  *
  * - `boot: true` (requires an elevated/Administrator shell): a BootTrigger + an
  *   S4U principal at HighestAvailable. Runs the daemon AS THE USER at boot, with
- *   no stored password and no interactive logon — survives a real reboot with no
- *   login on a headless host. Task Scheduler only lets an elevated shell create
+ *   no stored password and no interactive logon. This survives a real reboot with
+ *   no login on a headless host. Task Scheduler only lets an elevated shell create
  *   a boot/S4U task, which is why this path costs the UAC prompt.
  *
  * We register via `schtasks.exe` rather than the PowerShell `*-ScheduledTask`
@@ -668,7 +668,7 @@ export const generateWindowsHiddenLauncherVbs = (wrapperPath: string): string =>
 const runSchtasks = (args: ReadonlyArray<string>): Effect.Effect<CommandResult, Error> =>
   runCommand("schtasks.exe", args);
 
-/** Write a UTF-16LE (BOM-prefixed) file — the encoding schtasks expects for XML. */
+/** Write a UTF-16LE (BOM-prefixed) file, the encoding schtasks expects for XML. */
 const writeUtf16File = (
   path: string,
   contents: string,
@@ -680,7 +680,7 @@ const writeUtf16File = (
   });
 
 /**
- * SCHED_S_TASK_RUNNING — the Task Scheduler HRESULT a task reports as its "Last
+ * SCHED_S_TASK_RUNNING is the Task Scheduler HRESULT a task reports as its "Last
  * Result" while it is currently running (0x00041301 == 267009). schtasks prints
  * this in the verbose listing as a decimal; some Windows builds/locales print the
  * hex form. The numeric code is locale-invariant even though the surrounding
@@ -810,7 +810,7 @@ const makeWindowsBackend = (): ServiceBackend => {
           const detail = (create.stderr.trim() || create.stdout.trim()).replace(/\.\s*$/, "");
           // The default (logon) task needs no elevation. Only the --boot path
           // registers a boot/S4U task, which Task Scheduler refuses without
-          // Administrator — so point access-denial at the relevant fix.
+          // Administrator, so point access-denial at the relevant fix.
           const hint = /denied|0x80070005|administrator|elevat/i.test(detail)
             ? descriptor.boot
               ? " `--boot` registers a boot task, which needs an Administrator shell. Re-run elevated, or drop `--boot` to install a no-elevation login task."

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -3308,6 +3308,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           remove: (ref) => connectionsRemove(ref),
           refresh: (ref) => connectionsRefresh(ref),
           resolveValue: (ref) => resolveConnectionValueByRef(ref),
+          resolveValues: (ref) => resolveConnectionValuesByRef(ref),
         },
         providers: {
           list: () => providersList(),

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -219,9 +219,13 @@ export interface PluginCtx<TStore = unknown> {
       readonly Tool[],
       ConnectionNotFoundError | IntegrationNotFoundError | StorageFailure
     >;
-    /** Resolve a connection's value through its provider (and OAuth refresh).
+    /** Resolve a connection's primary value through its provider (and OAuth refresh).
      *  null if the provider can't produce one. */
     readonly resolveValue: (ref: ConnectionRef) => Effect.Effect<string | null, StorageFailure>;
+    /** Resolve every named input for a connection through its provider. */
+    readonly resolveValues: (
+      ref: ConnectionRef,
+    ) => Effect.Effect<Record<string, string | null>, StorageFailure>;
   };
 
   /** Registered credential backends — for discovery (browse a backend's items). */

--- a/packages/plugins/mcp/src/api/group.ts
+++ b/packages/plugins/mcp/src/api/group.ts
@@ -4,6 +4,7 @@ import {
   IntegrationSlug,
   InternalError,
   IntegrationAlreadyExistsError,
+  IntegrationNotFoundError,
 } from "@executor-js/sdk/shared";
 
 import { McpConnectionError, McpToolDiscoveryError } from "../sdk/errors";
@@ -21,6 +22,7 @@ import {
 const SlugParams = { slug: IntegrationSlug };
 
 const StringMap = Schema.Record(Schema.String, Schema.String);
+const IntegrationNotFound = IntegrationNotFoundError.annotate({ httpApiStatus: 404 });
 
 // ---------------------------------------------------------------------------
 // Add server — discriminated union on transport. An MCP server is registered
@@ -52,9 +54,9 @@ const AddStdioServerPayload = Schema.Struct({
   command: Schema.String,
   args: Schema.optional(Schema.Array(Schema.String)),
   /** Declare the secret env vars this server needs, by name. Their values are
-   *  supplied as the connection's secrets (the connect step), not here. */
+   *  supplied as the connection's secrets. */
   envVars: Schema.optional(Schema.Array(Schema.String)),
-  /** One-shot secret env values (programmatic). The UI sends `envVars`. */
+  /** Static, non-credential environment variables injected into the subprocess. */
   env: Schema.optional(StringMap),
   cwd: Schema.optional(Schema.String),
   slug: Schema.optional(Schema.String),
@@ -171,7 +173,7 @@ export const McpGroup = HttpApiGroup.make("mcp")
       params: SlugParams,
       payload: ConfigureServerPayload,
       success: ConfigureServerResponse,
-      error: [InternalError, McpConnectionError, McpToolDiscoveryError],
+      error: [InternalError, McpConnectionError, McpToolDiscoveryError, IntegrationNotFound],
     }),
   )
   .add(

--- a/packages/plugins/mcp/src/api/group.ts
+++ b/packages/plugins/mcp/src/api/group.ts
@@ -101,6 +101,11 @@ const ConfigureServerPayload = Schema.Struct({
 
 const ConfigureServerResponse = Schema.Struct({
   config: McpIntegrationConfig,
+  toolsRefreshFailed: Schema.Boolean,
+});
+
+const RefreshServerToolsResponse = Schema.Struct({
+  toolsRefreshFailed: Schema.Boolean,
 });
 
 // The configureAuth payload/response — custom auth methods to merge-append
@@ -173,6 +178,13 @@ export const McpGroup = HttpApiGroup.make("mcp")
       params: SlugParams,
       payload: ConfigureServerPayload,
       success: ConfigureServerResponse,
+      error: [InternalError, McpConnectionError, McpToolDiscoveryError, IntegrationNotFound],
+    }),
+  )
+  .add(
+    HttpApiEndpoint.post("refreshServerTools", "/mcp/servers/:slug/tools/refresh", {
+      params: SlugParams,
+      success: RefreshServerToolsResponse,
       error: [InternalError, McpConnectionError, McpToolDiscoveryError, IntegrationNotFound],
     }),
   )

--- a/packages/plugins/mcp/src/api/handlers.test.ts
+++ b/packages/plugins/mcp/src/api/handlers.test.ts
@@ -14,6 +14,7 @@ import { Effect, Layer, Schema } from "effect";
 
 import { addGroup, observabilityMiddleware } from "@executor-js/api";
 import { CoreHandlers, ExecutionEngineService, ExecutorService } from "@executor-js/api/server";
+import { IntegrationNotFoundError, IntegrationSlug } from "@executor-js/sdk/shared";
 import type { McpPluginExtension } from "../sdk/plugin";
 import { McpConnectionError } from "../sdk/errors";
 import { McpExtensionService, McpHandlers } from "./handlers";
@@ -69,6 +70,11 @@ const McpConnectionErrorResponse = Schema.Struct({
   message: Schema.String,
 });
 
+const IntegrationNotFoundErrorResponse = Schema.Struct({
+  _tag: Schema.Literal("IntegrationNotFoundError"),
+  slug: Schema.String,
+});
+
 describe("McpHandlers", () => {
   it.effect("defect-returning methods produce an opaque InternalError, no leakage", () =>
     Effect.gen(function* () {
@@ -117,6 +123,38 @@ describe("McpHandlers", () => {
         yield* Effect.promise(() => response.json()),
       );
       expect(body.message).toContain("Do you need to provide an API key");
+    }),
+  );
+
+  it.effect("configureServer IntegrationNotFoundError is encoded as a 404 response", () =>
+    Effect.gen(function* () {
+      const slug = IntegrationSlug.make("missing_mcp");
+      const web = yield* webHandlerFor({
+        ...failingExtension,
+        configureServer: () => Effect.fail(new IntegrationNotFoundError({ slug })),
+      });
+      const response = yield* Effect.promise(() =>
+        (web.handler as (request: Request) => Promise<Response>)(
+          new Request("http://localhost/mcp/servers/missing_mcp/config", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              config: {
+                transport: "remote",
+                endpoint: "https://example.com/mcp",
+                remoteTransport: "auto",
+                authenticationTemplate: [{ slug: "none", kind: "none" }],
+              },
+            }),
+          }),
+        ),
+      );
+
+      expect(response.status).toBe(404);
+      const body = yield* Schema.decodeUnknownEffect(IntegrationNotFoundErrorResponse)(
+        yield* Effect.promise(() => response.json()),
+      );
+      expect(body.slug).toBe("missing_mcp");
     }),
   );
 });

--- a/packages/plugins/mcp/src/api/handlers.test.ts
+++ b/packages/plugins/mcp/src/api/handlers.test.ts
@@ -30,6 +30,7 @@ const failingExtension: McpPluginExtension = {
   reconcileStdioConnections: () => unused,
   getServer: () => Effect.succeed(null),
   configureServer: () => unused,
+  refreshServerTools: () => unused,
   configureAuth: () => unused,
 };
 

--- a/packages/plugins/mcp/src/api/handlers.ts
+++ b/packages/plugins/mcp/src/api/handlers.ts
@@ -139,8 +139,15 @@ export const McpHandlers = HttpApiBuilder.group(ExecutorApiWithMcp, "mcp", (hand
       capture(
         Effect.gen(function* () {
           const ext = yield* McpExtensionService;
-          yield* ext.configureServer(path.slug, payload.config);
-          return { config: payload.config };
+          return yield* ext.configureServer(path.slug, payload.config);
+        }),
+      ),
+    )
+    .handle("refreshServerTools", ({ params: path }) =>
+      capture(
+        Effect.gen(function* () {
+          const ext = yield* McpExtensionService;
+          return yield* ext.refreshServerTools(path.slug);
         }),
       ),
     )

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -17,7 +17,7 @@ import {
 } from "@executor-js/react/components/card-stack";
 import { FloatActions } from "@executor-js/react/components/float-actions";
 import { Input } from "@executor-js/react/components/input";
-import { TagInput } from "@executor-js/react/components/tag-input";
+import { Textarea } from "@executor-js/react/components/textarea";
 import {
   integrationDisplayNameFromStdio,
   integrationDisplayNameFromUrl,
@@ -39,6 +39,7 @@ import { probeMcpEndpoint, addMcpServer } from "./atoms";
 import { McpRemoteSourceFields } from "./McpRemoteSourceFields";
 import { mcpAuthMethodInputFromEditorValue, mcpWireAuthInput } from "./auth-method-config";
 import { mcpPresets, type McpPreset } from "../sdk/presets";
+import { parseStdioArgs, parseStdioEnv, stdioEnvParseErrorMessage } from "../sdk/stdio-config";
 
 // The remote add flow REGISTERS the server's declared auth methods through the
 // shared `AuthMethodListEditor` — accounts (the API key value / OAuth sign-in)
@@ -55,19 +56,6 @@ import { mcpPresets, type McpPreset } from "../sdk/presets";
 function findPreset(id: string | undefined): McpPreset | undefined {
   if (!id) return undefined;
   return mcpPresets.find((p) => p.id === id);
-}
-
-// Splits the raw args field into tokens, honoring double-quoted groups so an
-// argument with spaces stays intact.
-function parseStdioArgs(raw: string): string[] {
-  if (!raw.trim()) return [];
-  const args: string[] = [];
-  const regex = /[^\s"]+|"([^"]*)"/g;
-  let match;
-  while ((match = regex.exec(raw)) !== null) {
-    args.push(match[1] ?? match[0]);
-  }
-  return args;
 }
 
 // ---------------------------------------------------------------------------
@@ -185,7 +173,8 @@ export default function AddMcpSource(props: {
   const [stdioArgs, setStdioArgs] = useState(
     isStdioPreset && preset.args ? preset.args.join(" ") : "",
   );
-  const [stdioEnvVars, setStdioEnvVars] = useState<string[]>([]);
+  const [stdioEnvText, setStdioEnvText] = useState("");
+  const [stdioCwd, setStdioCwd] = useState("");
   const stdioIdentity = useIntegrationIdentity({
     fallbackName: isStdioPreset
       ? preset.name
@@ -352,18 +341,26 @@ export default function AddMcpSource(props: {
   const handleAddStdio = useCallback(async () => {
     const cmd = stdioCommand.trim();
     if (!cmd) return;
+    const parsedEnv = parseStdioEnv(stdioEnvText);
+    if (!parsedEnv.ok) {
+      setStdioError(stdioEnvParseErrorMessage(parsedEnv.error));
+      return;
+    }
     setStdioAdding(true);
     setStdioError(null);
     const displayName = stdioIdentity.name.trim() || cmd;
     const slug = slugifyNamespace(stdioIdentity.namespace) || undefined;
+    const parsedArgs = parseStdioArgs(stdioArgs);
+    const trimmedCwd = stdioCwd.trim();
     const exit = await doAddServer({
       payload: {
         transport: "stdio" as const,
         name: displayName,
         ...(slug ? { slug } : {}),
         command: cmd,
-        args: parseStdioArgs(stdioArgs),
-        envVars: stdioEnvVars.length > 0 ? stdioEnvVars : undefined,
+        ...(parsedArgs.length > 0 ? { args: parsedArgs } : {}),
+        ...(parsedEnv.env !== undefined ? { env: parsedEnv.env } : {}),
+        ...(trimmedCwd.length > 0 ? { cwd: trimmedCwd } : {}),
       },
       reactivityKeys: integrationWriteKeys,
     });
@@ -373,7 +370,7 @@ export default function AddMcpSource(props: {
       return;
     }
     props.onComplete(exit.value.slug);
-  }, [stdioCommand, stdioArgs, stdioEnvVars, stdioIdentity, doAddServer, props]);
+  }, [stdioCommand, stdioArgs, stdioEnvText, stdioCwd, stdioIdentity, doAddServer, props]);
 
   // ---- Render ----
 
@@ -508,13 +505,28 @@ export default function AddMcpSource(props: {
               </CardStackEntryField>
 
               <CardStackEntryField
-                label="Environment variables"
-                description="- Names only; secret values are entered when you connect."
+                label="Working directory"
+                description="Optional directory to run the command from."
               >
-                <TagInput
-                  values={stdioEnvVars}
-                  onChange={setStdioEnvVars}
-                  placeholder="Add an env var, e.g. GITHUB_TOKEN"
+                <Input
+                  value={stdioCwd}
+                  onChange={(e) => setStdioCwd((e.target as HTMLInputElement).value)}
+                  placeholder="/path/to/project"
+                  className="font-mono text-sm"
+                  data-ph-block
+                />
+              </CardStackEntryField>
+
+              <CardStackEntryField
+                label="Environment variables"
+                description="Additional variables, one KEY=value per line."
+              >
+                <Textarea
+                  value={stdioEnvText}
+                  onChange={(e) => setStdioEnvText((e.target as HTMLTextAreaElement).value)}
+                  placeholder={"DEBUG=true\nAPI_BASE_URL=https://example.com"}
+                  className="font-mono text-sm"
+                  data-ph-block
                 />
               </CardStackEntryField>
             </CardStackContent>

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -39,7 +39,12 @@ import { probeMcpEndpoint, addMcpServer } from "./atoms";
 import { McpRemoteSourceFields } from "./McpRemoteSourceFields";
 import { mcpAuthMethodInputFromEditorValue, mcpWireAuthInput } from "./auth-method-config";
 import { mcpPresets, type McpPreset } from "../sdk/presets";
-import { parseStdioArgs, parseStdioEnv, stdioEnvParseErrorMessage } from "../sdk/stdio-config";
+import {
+  parseStdioArgs,
+  parseStdioEnv,
+  stdioArgsToText,
+  stdioEnvParseErrorMessage,
+} from "../sdk/stdio-config";
 
 // The remote add flow REGISTERS the server's declared auth methods through the
 // shared `AuthMethodListEditor` — accounts (the API key value / OAuth sign-in)
@@ -171,7 +176,7 @@ export default function AddMcpSource(props: {
   // --- Stdio state ---
   const [stdioCommand, setStdioCommand] = useState(isStdioPreset ? preset.command : "");
   const [stdioArgs, setStdioArgs] = useState(
-    isStdioPreset && preset.args ? preset.args.join(" ") : "",
+    isStdioPreset && preset.args ? stdioArgsToText(preset.args) : "",
   );
   const [stdioEnvText, setStdioEnvText] = useState("");
   const [stdioCwd, setStdioCwd] = useState("");

--- a/packages/plugins/mcp/src/react/EditMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/EditMcpSource.tsx
@@ -13,10 +13,12 @@ import {
   type AuthMethodRow,
   type AuthMethodSeed,
 } from "@executor-js/react/components/auth-method-list-editor";
-import { Badge } from "@executor-js/react/components/badge";
-import { FormErrorAlert } from "@executor-js/react/lib/integration-add";
+import { Input } from "@executor-js/react/components/input";
+import { Label } from "@executor-js/react/components/label";
+import { Textarea } from "@executor-js/react/components/textarea";
+import { errorMessageFromExit, FormErrorAlert } from "@executor-js/react/lib/integration-add";
 
-import { configureMcpAuth, mcpServerAtom } from "./atoms";
+import { configureMcpAuth, configureMcpServer, mcpServerAtom } from "./atoms";
 import type {
   McpAuthMethod,
   McpCanonicalAuthMethodInput,
@@ -27,6 +29,15 @@ import {
   mcpAuthMethodInputFromEditorValue,
   mcpWireAuthInput,
 } from "./auth-method-config";
+import {
+  canonicalizeStdioConfig,
+  canonicalizeStdioDraft,
+  parseStdioArgs,
+  parseStdioEnv,
+  sameCanonicalStdioConfig,
+  stdioEnvParseErrorMessage,
+  stdioEnvToText,
+} from "../sdk/stdio-config";
 
 type McpServer = {
   readonly slug: IntegrationSlug;
@@ -174,30 +185,176 @@ function RemoteEdit(props: {
 }
 
 // ---------------------------------------------------------------------------
-// Stdio read-only view
+// Stdio edit
 // ---------------------------------------------------------------------------
 
-function StdioReadOnly(props: {
+function StdioEdit(props: {
   server: McpServer & { config: Extract<McpIntegrationConfig, { transport: "stdio" }> };
+  onPendingChange?: EditSheetSectionProps["onPendingChange"];
 }) {
-  const { command, args } = props.server.config;
+  const { server } = props;
+  const doConfigure = useAtomSet(configureMcpServer, { mode: "promiseExit" });
+
+  const [commandDraft, setCommandDraft] = useState(server.config.command);
+  const [argsDraft, setArgsDraft] = useState((server.config.args ?? []).join(" "));
+  const [cwdDraft, setCwdDraft] = useState(server.config.cwd ?? "");
+  const [envDraft, setEnvDraft] = useState(stdioEnvToText(server.config.env));
+  const [error, setError] = useState<string | null>(null);
+
+  const lastResetSlug = useRef<IntegrationSlug | null>(null);
+  useEffect(() => {
+    if (lastResetSlug.current === server.slug) return;
+    lastResetSlug.current = server.slug;
+    setCommandDraft(server.config.command);
+    setArgsDraft((server.config.args ?? []).join(" "));
+    setCwdDraft(server.config.cwd ?? "");
+    setEnvDraft(stdioEnvToText(server.config.env));
+    setError(null);
+  }, [
+    server.config.args,
+    server.config.command,
+    server.config.cwd,
+    server.config.env,
+    server.slug,
+  ]);
+
+  const stdioDraftChanged = useMemo(
+    () =>
+      commandDraft !== server.config.command ||
+      argsDraft !== (server.config.args ?? []).join(" ") ||
+      cwdDraft !== (server.config.cwd ?? "") ||
+      envDraft !== stdioEnvToText(server.config.env),
+    [argsDraft, commandDraft, cwdDraft, envDraft, server.config],
+  );
+
+  const parsedEnvForComparison = useMemo(() => parseStdioEnv(envDraft), [envDraft]);
+  const processConfigChanged = useMemo(() => {
+    if (!parsedEnvForComparison.ok) return false;
+    return !sameCanonicalStdioConfig(
+      canonicalizeStdioConfig(server.config),
+      canonicalizeStdioDraft({
+        command: commandDraft,
+        args: parseStdioArgs(argsDraft),
+        env: parsedEnvForComparison.env,
+        cwd: cwdDraft,
+      }),
+    );
+  }, [argsDraft, commandDraft, cwdDraft, parsedEnvForComparison, server.config]);
+
+  const applyStaged = useCallback(async (): Promise<EditSheetApplyResult> => {
+    setError(null);
+    const command = commandDraft.trim();
+    if (command.length === 0) {
+      setError("Command is required.");
+      return { ok: false };
+    }
+
+    const parsedEnv = parseStdioEnv(envDraft);
+    if (!parsedEnv.ok) {
+      setError(stdioEnvParseErrorMessage(parsedEnv.error));
+      return { ok: false };
+    }
+
+    const args = parseStdioArgs(argsDraft);
+    const cwd = cwdDraft.trim();
+    const nextConfig: Extract<McpIntegrationConfig, { transport: "stdio" }> = {
+      transport: "stdio",
+      command,
+      ...(args.length > 0 ? { args } : {}),
+      ...(parsedEnv.env !== undefined ? { env: parsedEnv.env } : {}),
+      ...(cwd.length > 0 ? { cwd } : {}),
+      ...(server.config.authenticationTemplate !== undefined
+        ? { authenticationTemplate: server.config.authenticationTemplate }
+        : {}),
+    };
+
+    if (
+      sameCanonicalStdioConfig(
+        canonicalizeStdioConfig(server.config),
+        canonicalizeStdioConfig(nextConfig),
+      )
+    ) {
+      return { ok: true, summary: null };
+    }
+
+    const exit = await doConfigure({
+      params: { slug: server.slug },
+      payload: { config: nextConfig },
+      reactivityKeys: integrationWriteKeys,
+    });
+    if (Exit.isFailure(exit)) {
+      setError(errorMessageFromExit(exit, "Failed to update command settings"));
+      return { ok: false };
+    }
+    return { ok: true, summary: "Command settings updated." };
+  }, [argsDraft, commandDraft, cwdDraft, doConfigure, envDraft, server.config, server.slug]);
+
+  const onPendingChangeRef = useRef(props.onPendingChange);
+  onPendingChangeRef.current = props.onPendingChange;
+  useEffect(() => {
+    onPendingChangeRef.current?.(stdioDraftChanged ? applyStaged : null);
+    return () => onPendingChangeRef.current?.(null);
+  }, [stdioDraftChanged, applyStaged]);
+
   return (
-    <div className="space-y-3 border-t border-border/60 pt-5">
+    <div className="space-y-4 border-t border-border/60 pt-5">
       <div className="space-y-1">
-        <p className="text-sm font-medium text-foreground">Server command</p>
-        <p className="text-xs text-muted-foreground">
-          Stdio MCP sources cannot be edited. Remove and recreate the source with the updated
-          command.
-        </p>
+        <p className="text-sm font-medium text-foreground">Command settings</p>
+        <p className="text-xs text-muted-foreground">Changes apply when you save.</p>
       </div>
-      <div className="flex items-center gap-3 rounded-md border border-border/60 bg-muted/40 px-3 py-2">
-        <p className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
-          {command} {(args ?? []).join(" ")}
-        </p>
-        <Badge variant="secondary" className="text-xs">
-          stdio
-        </Badge>
+
+      <div className="space-y-3">
+        <Label className="block space-y-1.5">
+          <span className="text-xs font-medium text-foreground">Command</span>
+          <Input
+            value={commandDraft}
+            onChange={(e) => setCommandDraft((e.target as HTMLInputElement).value)}
+            placeholder="npx"
+            className="font-mono text-sm"
+          />
+        </Label>
+
+        <Label className="block space-y-1.5">
+          <span className="text-xs font-medium text-foreground">Arguments</span>
+          <Input
+            value={argsDraft}
+            onChange={(e) => setArgsDraft((e.target as HTMLInputElement).value)}
+            placeholder="-y chrome-devtools-mcp@latest"
+            className="font-mono text-sm"
+          />
+        </Label>
+
+        <Label className="block space-y-1.5">
+          <span className="text-xs font-medium text-foreground">Working directory</span>
+          <Input
+            value={cwdDraft}
+            onChange={(e) => setCwdDraft((e.target as HTMLInputElement).value)}
+            placeholder="/path/to/project"
+            className="font-mono text-sm"
+            data-ph-block
+          />
+        </Label>
+
+        <Label className="block space-y-1.5">
+          <span className="text-xs font-medium text-foreground">Environment variables</span>
+          <Textarea
+            value={envDraft}
+            onChange={(e) => setEnvDraft((e.target as HTMLTextAreaElement).value)}
+            placeholder={"DEBUG=true\nAPI_BASE_URL=https://example.com"}
+            className="font-mono text-sm"
+            data-ph-block
+          />
+        </Label>
       </div>
+
+      {processConfigChanged && (
+        <p className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+          Saving these command settings will rediscover tools and reset policies scoped to this
+          source.
+        </p>
+      )}
+
+      {error && <FormErrorAlert message={error} />}
     </div>
   );
 }
@@ -216,10 +373,11 @@ export default function EditMcpSource({ sourceId, onPendingChange }: EditSheetSe
 
   if (server.config.transport === "stdio") {
     return (
-      <StdioReadOnly
+      <StdioEdit
         server={
           server as McpServer & { config: Extract<McpIntegrationConfig, { transport: "stdio" }> }
         }
+        {...(onPendingChange ? { onPendingChange } : {})}
       />
     );
   }

--- a/packages/plugins/mcp/src/react/EditMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/EditMcpSource.tsx
@@ -286,6 +286,13 @@ function StdioEdit(props: {
       setError(errorMessageFromExit(exit, "Failed to update command settings"));
       return { ok: false };
     }
+    if (exit.value.toolsRefreshFailed) {
+      return {
+        ok: true,
+        summary:
+          "Command settings updated, but tools could not be refreshed. Check secrets or retry.",
+      };
+    }
     return { ok: true, summary: "Command settings updated." };
   }, [argsDraft, commandDraft, cwdDraft, doConfigure, envDraft, server.config, server.slug]);
 

--- a/packages/plugins/mcp/src/react/EditMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/EditMcpSource.tsx
@@ -35,6 +35,7 @@ import {
   parseStdioArgs,
   parseStdioEnv,
   sameCanonicalStdioConfig,
+  stdioArgsToText,
   stdioEnvParseErrorMessage,
   stdioEnvToText,
 } from "../sdk/stdio-config";
@@ -196,9 +197,9 @@ function StdioEdit(props: {
   const doConfigure = useAtomSet(configureMcpServer, { mode: "promiseExit" });
 
   const [commandDraft, setCommandDraft] = useState(server.config.command);
-  const [argsDraft, setArgsDraft] = useState((server.config.args ?? []).join(" "));
+  const [argsDraft, setArgsDraft] = useState(() => stdioArgsToText(server.config.args));
   const [cwdDraft, setCwdDraft] = useState(server.config.cwd ?? "");
-  const [envDraft, setEnvDraft] = useState(stdioEnvToText(server.config.env));
+  const [envDraft, setEnvDraft] = useState(() => stdioEnvToText(server.config.env));
   const [error, setError] = useState<string | null>(null);
 
   const lastResetSlug = useRef<IntegrationSlug | null>(null);
@@ -206,7 +207,7 @@ function StdioEdit(props: {
     if (lastResetSlug.current === server.slug) return;
     lastResetSlug.current = server.slug;
     setCommandDraft(server.config.command);
-    setArgsDraft((server.config.args ?? []).join(" "));
+    setArgsDraft(stdioArgsToText(server.config.args));
     setCwdDraft(server.config.cwd ?? "");
     setEnvDraft(stdioEnvToText(server.config.env));
     setError(null);
@@ -218,13 +219,24 @@ function StdioEdit(props: {
     server.slug,
   ]);
 
+  const storedArgsText = useMemo(() => stdioArgsToText(server.config.args), [server.config.args]);
+  const storedEnvText = useMemo(() => stdioEnvToText(server.config.env), [server.config.env]);
   const stdioDraftChanged = useMemo(
     () =>
       commandDraft !== server.config.command ||
-      argsDraft !== (server.config.args ?? []).join(" ") ||
+      argsDraft !== storedArgsText ||
       cwdDraft !== (server.config.cwd ?? "") ||
-      envDraft !== stdioEnvToText(server.config.env),
-    [argsDraft, commandDraft, cwdDraft, envDraft, server.config],
+      envDraft !== storedEnvText,
+    [
+      argsDraft,
+      commandDraft,
+      cwdDraft,
+      envDraft,
+      server.config.command,
+      server.config.cwd,
+      storedArgsText,
+      storedEnvText,
+    ],
   );
 
   const parsedEnvForComparison = useMemo(() => parseStdioEnv(envDraft), [envDraft]);

--- a/packages/plugins/mcp/src/react/atoms.ts
+++ b/packages/plugins/mcp/src/react/atoms.ts
@@ -26,5 +26,6 @@ export const probeMcpEndpoint = McpClient.mutation("mcp", "probeEndpoint");
 export const addMcpServer = McpClient.mutation("mcp", "addServer");
 export const removeMcpServer = McpClient.mutation("mcp", "removeServer");
 export const configureMcpServer = McpClient.mutation("mcp", "configureServer");
+export const refreshMcpServerTools = McpClient.mutation("mcp", "refreshServerTools");
 // Merge-append auth methods onto an integration's `authenticationTemplate`.
 export const configureMcpAuth = McpClient.mutation("mcp", "configureAuth");

--- a/packages/plugins/mcp/src/sdk/connection.ts
+++ b/packages/plugins/mcp/src/sdk/connection.ts
@@ -177,19 +177,25 @@ const connectionFromClient = (client: Client): McpConnection => ({
   close: () => client.close(),
 });
 
-const connectionFailure = (
-  transport: string,
-  message: string,
-  cause: unknown,
-): McpConnectionError | McpOAuthReauthorizationRequired => {
-  if (Predicate.isTagged(cause, "McpOAuthReauthorizationRequired")) {
+const connectionFailure = (input: {
+  readonly transport: string;
+  readonly message: string;
+  readonly cause: unknown;
+  readonly command?: string;
+}): McpConnectionError | McpOAuthReauthorizationRequired => {
+  if (Predicate.isTagged(input.cause, "McpOAuthReauthorizationRequired")) {
     return new McpOAuthReauthorizationRequired({ message: "MCP OAuth re-authorization required" });
   }
-  return new McpConnectionError({ transport, message });
+  const message =
+    input.transport === "stdio" && input.command !== undefined
+      ? `Could not connect to stdio MCP server using "${input.command}"`
+      : input.message;
+  return new McpConnectionError({ transport: input.transport, message });
 };
 
 const connectClient = (input: {
   transport: string;
+  command?: string;
   createTransport: () => Parameters<Client["connect"]>[0];
 }): Effect.Effect<McpConnection, McpConnectionError | McpOAuthReauthorizationRequired> =>
   Effect.gen(function* () {
@@ -199,7 +205,12 @@ const connectClient = (input: {
     yield* Effect.tryPromise({
       try: () => client.connect(transportInstance),
       catch: (cause) =>
-        connectionFailure(input.transport, `Failed connecting via ${input.transport}`, cause),
+        connectionFailure({
+          transport: input.transport,
+          command: input.command,
+          message: `Failed connecting via ${input.transport}`,
+          cause,
+        }),
     }).pipe(
       Effect.withSpan("plugin.mcp.connection.handshake", {
         attributes: { "plugin.mcp.transport": input.transport },
@@ -239,6 +250,7 @@ export const createMcpConnector = (input: ConnectorInput): McpConnector => {
 
       return yield* connectClient({
         transport: "stdio",
+        command: [command, ...(input.args ?? [])].join(" "),
         createTransport: () =>
           createStdioTransport({
             command,

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -750,6 +750,45 @@ describe("mcpPlugin", () => {
     ),
   );
 
+  it.effect("configureServer preflights stdio auth template changes", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* withStdioFixtureScript;
+        const executor = yield* createExecutor(
+          makeTestConfig({
+            plugins: [
+              memoryCredentialsPlugin(),
+              mcpPlugin({ dangerouslyAllowStdioMCP: true }),
+            ] as const,
+          }),
+        );
+
+        yield* executor.mcp.addServer({
+          transport: "stdio",
+          name: "Stdio auth-only edit",
+          slug: "stdio_auth_only_edit",
+          command: process.execPath,
+          args: [fixture.script, "one"],
+        });
+
+        const result = yield* Effect.result(
+          executor.mcp.configureServer("stdio_auth_only_edit", {
+            transport: "stdio",
+            command: process.execPath,
+            args: [fixture.script, "one"],
+            authenticationTemplate: [{ slug: "env", kind: "stdio_env", vars: ["STDIO_SECRET"] }],
+          }),
+        );
+
+        expect(Result.isFailure(result)).toBe(true);
+        const integration = yield* executor.mcp.getServer("stdio_auth_only_edit");
+        expect(integration?.config).toMatchObject({
+          authenticationTemplate: [{ slug: "none", kind: "none" }],
+        });
+      }),
+    ),
+  );
+
   it.effect("configureServer reports missing stdio secret values before preflight", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Layer, Option, Predicate, Schema } from "effect";
+import { Effect, Layer, Option, Predicate, Result, Schema } from "effect";
+import * as Fs from "node:fs/promises";
+import * as Path from "node:path";
 import {
   HttpClient,
   HttpClientRequest,
@@ -118,6 +120,23 @@ const jsonRpcErrorCallTool =
       id: rpc.id ?? null,
       error: { code, message: "application-level do-not-leak" },
     });
+
+const withStdioFixtureScript = Effect.acquireRelease(
+  Effect.gen(function* () {
+    const root = Path.join(process.cwd(), ".tmp");
+    yield* Effect.promise(() => Fs.mkdir(root, { recursive: true }));
+    const dir = yield* Effect.promise(() => Fs.mkdtemp(Path.join(root, "mcp-stdio-")));
+    const script = Path.join(dir, "server.mjs");
+    yield* Effect.promise(() =>
+      Fs.writeFile(
+        script,
+        `import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";\nimport { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";\nconst toolName = process.argv[2] ?? "one";\nconst server = new McpServer({ name: "stdio-fixture", version: "1.0.0" }, { capabilities: {} });\nserver.registerTool(toolName, { description: "Stdio fixture tool", inputSchema: {} }, async () => ({ content: [{ type: "text", text: process.env.STDIO_VALUE ?? "ok" }] }));\nawait server.connect(new StdioServerTransport());\n`,
+      ),
+    );
+    return { dir, script } as const;
+  }),
+  ({ dir }) => Effect.promise(() => Fs.rm(dir, { recursive: true, force: true })),
+);
 
 const seedCallToolExecutor = (input: { slug: string; callTool: CallToolResponder }) =>
   Effect.acquireRelease(
@@ -500,6 +519,203 @@ describe("mcpPlugin", () => {
       });
 
       expect(merged.map((method) => method.slug)).toEqual(["oauth2", "header"]);
+    }),
+  );
+
+  it.effect("configureServer edits stdio config, refreshes tools, and stores static env", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* withStdioFixtureScript;
+        const executor = yield* createExecutor(
+          makeTestConfig({
+            plugins: [
+              memoryCredentialsPlugin(),
+              mcpPlugin({ dangerouslyAllowStdioMCP: true }),
+            ] as const,
+          }),
+        );
+
+        yield* executor.mcp.addServer({
+          transport: "stdio",
+          name: "Stdio edit",
+          slug: "stdio_edit",
+          command: process.execPath,
+          args: [fixture.script, "one"],
+          env: { STDIO_VALUE: "first" },
+        });
+        let tools = yield* executor.tools.list({ integration: IntegrationSlug.make("stdio_edit") });
+        expect(tools.map((tool) => String(tool.name))).toContain("one");
+
+        yield* executor.mcp.configureServer("stdio_edit", {
+          transport: "stdio",
+          command: process.execPath,
+          args: [fixture.script, "two"],
+          env: { STDIO_VALUE: "second" },
+          cwd: fixture.dir,
+          authenticationTemplate: [{ slug: "none", kind: "none" }],
+        });
+
+        const integration = yield* executor.mcp.getServer("stdio_edit");
+        expect(integration?.config).toMatchObject({
+          command: process.execPath,
+          args: [fixture.script, "two"],
+          env: { STDIO_VALUE: "second" },
+          cwd: fixture.dir,
+        });
+        tools = yield* executor.tools.list({ integration: IntegrationSlug.make("stdio_edit") });
+        expect(tools.map((tool) => String(tool.name))).toContain("two");
+        expect(tools.map((tool) => String(tool.name))).not.toContain("one");
+      }),
+    ),
+  );
+
+  it.effect("configureServer blocks invalid stdio configs without updating", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* withStdioFixtureScript;
+        const executor = yield* createExecutor(
+          makeTestConfig({
+            plugins: [
+              memoryCredentialsPlugin(),
+              mcpPlugin({ dangerouslyAllowStdioMCP: true }),
+            ] as const,
+          }),
+        );
+
+        yield* executor.mcp.addServer({
+          transport: "stdio",
+          name: "Stdio invalid",
+          slug: "stdio_invalid",
+          command: process.execPath,
+          args: [fixture.script, "one"],
+        });
+
+        const result = yield* Effect.result(
+          executor.mcp.configureServer("stdio_invalid", {
+            transport: "stdio",
+            command: Path.join(fixture.dir, "missing-command"),
+            authenticationTemplate: [{ slug: "none", kind: "none" }],
+          }),
+        );
+        expect(Result.isFailure(result)).toBe(true);
+
+        const integration = yield* executor.mcp.getServer("stdio_invalid");
+        expect(integration?.config).toMatchObject({
+          command: process.execPath,
+          args: [fixture.script, "one"],
+        });
+      }),
+    ),
+  );
+
+  it.effect("configureServer removes source-scoped policies after valid stdio edits", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* withStdioFixtureScript;
+        const executor = yield* createExecutor(
+          makeTestConfig({
+            plugins: [
+              memoryCredentialsPlugin(),
+              mcpPlugin({ dangerouslyAllowStdioMCP: true }),
+            ] as const,
+          }),
+        );
+
+        yield* executor.mcp.addServer({
+          transport: "stdio",
+          name: "Stdio policies",
+          slug: "stdio_policies",
+          command: process.execPath,
+          args: [fixture.script, "one"],
+        });
+        yield* executor.policies.create({
+          owner: "org",
+          pattern: "stdio_policies.*",
+          action: "require_approval",
+        });
+        yield* executor.policies.create({
+          owner: "user",
+          pattern: "stdio_policies.org.default.one",
+          action: "block",
+        });
+        yield* executor.policies.create({
+          owner: "org",
+          pattern: "stdio_policies_extra.*",
+          action: "block",
+        });
+        yield* executor.policies.create({ owner: "org", pattern: "*", action: "approve" });
+
+        yield* executor.mcp.configureServer("stdio_policies", {
+          transport: "stdio",
+          command: process.execPath,
+          args: [fixture.script, "two"],
+          authenticationTemplate: [{ slug: "none", kind: "none" }],
+        });
+
+        const policies = yield* executor.policies.list();
+        expect(policies.map((policy) => policy.pattern).sort()).toEqual([
+          "*",
+          "stdio_policies_extra.*",
+        ]);
+      }),
+    ),
+  );
+
+  it.effect("configureServer preserves policies when stdio preflight fails", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* withStdioFixtureScript;
+        const executor = yield* createExecutor(
+          makeTestConfig({
+            plugins: [
+              memoryCredentialsPlugin(),
+              mcpPlugin({ dangerouslyAllowStdioMCP: true }),
+            ] as const,
+          }),
+        );
+
+        yield* executor.mcp.addServer({
+          transport: "stdio",
+          name: "Stdio failed policies",
+          slug: "stdio_failed_policies",
+          command: process.execPath,
+          args: [fixture.script, "one"],
+        });
+        yield* executor.policies.create({
+          owner: "org",
+          pattern: "stdio_failed_policies.*",
+          action: "require_approval",
+        });
+
+        const result = yield* Effect.result(
+          executor.mcp.configureServer("stdio_failed_policies", {
+            transport: "stdio",
+            command: Path.join(fixture.dir, "missing-command"),
+            authenticationTemplate: [{ slug: "none", kind: "none" }],
+          }),
+        );
+        expect(Result.isFailure(result)).toBe(true);
+
+        const policies = yield* executor.policies.list();
+        expect(policies.map((policy) => policy.pattern)).toContain("stdio_failed_policies.*");
+      }),
+    ),
+  );
+
+  it.effect("configureServer returns IntegrationNotFoundError for missing integrations", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(makeTestConfig({ plugins: [mcpPlugin()] as const }));
+      const result = yield* Effect.result(
+        executor.mcp.configureServer("missing_mcp", {
+          transport: "remote",
+          endpoint: "https://example.com/mcp",
+          remoteTransport: "auto",
+          authenticationTemplate: [{ slug: "none", kind: "none" }],
+        }),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+      const failure = Result.isFailure(result) ? result.failure : undefined;
+      expect(Predicate.isTagged(failure, "IntegrationNotFoundError")).toBe(true);
     }),
   );
 

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -155,6 +155,27 @@ const withStdioFixtureScript = Effect.acquireRelease(
   ({ dir }) => Effect.promise(() => Fs.rm(dir, { recursive: true, force: true })),
 );
 
+const withFlakyStdioRefreshScript = Effect.acquireRelease(
+  Effect.gen(function* () {
+    const root = Path.join(process.cwd(), ".tmp");
+    yield* Effect.promise(() => Fs.mkdir(root, { recursive: true }));
+    const dir = yield* Effect.promise(() => Fs.mkdtemp(Path.join(root, "mcp-stdio-flaky-")));
+    const script = Path.join(dir, "server.mjs");
+    const counter = Path.join(dir, "attempts.txt");
+    yield* Effect.promise(() =>
+      Fs.writeFile(
+        script,
+        `import fs from "node:fs";\nimport { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";\nimport { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";\nconst toolName = process.argv[2] ?? "two";\nconst counter = process.argv[3];\nconst previous = fs.existsSync(counter) ? Number(fs.readFileSync(counter, "utf8")) : 0;\nconst attempt = previous + 1;\nfs.writeFileSync(counter, String(attempt));\nif (attempt === 2) process.exit(1);\nconst server = new McpServer({ name: "stdio-flaky-fixture", version: "1.0.0" }, { capabilities: {} });\nserver.registerTool(toolName, { description: "Stdio flaky fixture tool", inputSchema: {} }, async () => ({ content: [{ type: "text", text: "ok" }] }));\nawait server.connect(new StdioServerTransport());\n`,
+      ),
+    );
+    return { dir, script, counter } as const;
+  }),
+  ({ dir }) => Effect.promise(() => Fs.rm(dir, { recursive: true, force: true })),
+);
+
+const readStdioAttemptCount = (counter: string) =>
+  Effect.promise(() => Fs.readFile(counter, "utf8")).pipe(Effect.map((value) => Number(value)));
+
 const seedCallToolExecutor = (input: { slug: string; callTool: CallToolResponder }) =>
   Effect.acquireRelease(
     Effect.gen(function* () {
@@ -647,6 +668,86 @@ describe("mcpPlugin", () => {
           expect(tools.map((tool) => String(tool.name))).not.toContain("one");
         }),
       ),
+  );
+
+  it.effect("configureServer reports post-commit stdio refresh failure as a warning result", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* withStdioFixtureScript;
+        const flaky = yield* withFlakyStdioRefreshScript;
+        const executor = yield* createExecutor(
+          makeTestConfig({
+            plugins: [
+              memoryCredentialsPlugin(),
+              mcpPlugin({ dangerouslyAllowStdioMCP: true }),
+            ] as const,
+          }),
+        );
+
+        yield* executor.mcp.addServer({
+          transport: "stdio",
+          name: "Stdio refresh warning",
+          slug: "stdio_refresh_warning",
+          command: process.execPath,
+          args: [fixture.script, "one"],
+        });
+
+        const result: unknown = yield* executor.mcp.configureServer("stdio_refresh_warning", {
+          transport: "stdio",
+          command: process.execPath,
+          args: [flaky.script, "two", flaky.counter],
+          authenticationTemplate: [{ slug: "none", kind: "none" }],
+        });
+
+        expect(result).toMatchObject({ toolsRefreshFailed: true });
+        expect(yield* readStdioAttemptCount(flaky.counter)).toBe(2);
+
+        const integration = yield* executor.mcp.getServer("stdio_refresh_warning");
+        expect(integration?.config).toMatchObject({
+          command: process.execPath,
+          args: [flaky.script, "two", flaky.counter],
+        });
+      }),
+    ),
+  );
+
+  it.effect("refreshServerTools retries stdio tool refresh after a warning result", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* withStdioFixtureScript;
+        const flaky = yield* withFlakyStdioRefreshScript;
+        const executor = yield* createExecutor(
+          makeTestConfig({
+            plugins: [
+              memoryCredentialsPlugin(),
+              mcpPlugin({ dangerouslyAllowStdioMCP: true }),
+            ] as const,
+          }),
+        );
+        const config = {
+          transport: "stdio" as const,
+          command: process.execPath,
+          args: [flaky.script, "two", flaky.counter],
+          authenticationTemplate: [{ slug: "none" as const, kind: "none" as const }],
+        };
+
+        yield* executor.mcp.addServer({
+          transport: "stdio",
+          name: "Stdio refresh retry",
+          slug: "stdio_refresh_retry",
+          command: process.execPath,
+          args: [fixture.script, "one"],
+        });
+
+        const configureResult = yield* executor.mcp.configureServer("stdio_refresh_retry", config);
+        expect(configureResult).toMatchObject({ toolsRefreshFailed: true });
+        expect(yield* readStdioAttemptCount(flaky.counter)).toBe(2);
+
+        const refreshResult = yield* executor.mcp.refreshServerTools("stdio_refresh_retry");
+        expect(refreshResult).toMatchObject({ toolsRefreshFailed: false });
+        expect(yield* readStdioAttemptCount(flaky.counter)).toBe(4);
+      }),
+    ),
   );
 
   it.effect("configureServer reports missing stdio secret values before preflight", () =>

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -366,6 +366,22 @@ describe("mcpPlugin", () => {
     }),
   );
 
+  it.effect("reports a clear stdio startup failure message", () =>
+    Effect.gen(function* () {
+      const error = yield* createMcpConnector({
+        transport: "stdio",
+        command: "__executor_missing_stdio_command__",
+        args: ["--flag"],
+      }).pipe(Effect.flip);
+
+      expect(error).toMatchObject({
+        _tag: "McpConnectionError",
+        message:
+          'Could not connect to stdio MCP server using "__executor_missing_stdio_command__ --flag"',
+      });
+    }),
+  );
+
   it.effect("integration catalog has no configured MCP integrations initially", () =>
     Effect.gen(function* () {
       const executor = yield* createExecutor(makeTestConfig({ plugins: [mcpPlugin()] as const }));
@@ -615,6 +631,11 @@ describe("mcpPlugin", () => {
           }),
         );
         expect(Result.isFailure(result)).toBe(true);
+        const failure = Result.isFailure(result) ? result.failure : null;
+        expect(failure).toMatchObject({
+          _tag: "McpToolDiscoveryError",
+          message: `Failed connecting to MCP server: Could not connect to stdio MCP server using "${Path.join(fixture.dir, "missing-command")}"`,
+        });
 
         const integration = yield* executor.mcp.getServer("stdio_invalid");
         expect(integration?.config).toMatchObject({

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -147,7 +147,7 @@ const withStdioFixtureScript = Effect.acquireRelease(
     yield* Effect.promise(() =>
       Fs.writeFile(
         script,
-        `import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";\nimport { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";\nconst toolName = process.argv[2] ?? "one";\nconst server = new McpServer({ name: "stdio-fixture", version: "1.0.0" }, { capabilities: {} });\nserver.registerTool(toolName, { description: "Stdio fixture tool", inputSchema: {} }, async () => ({ content: [{ type: "text", text: process.env.STDIO_VALUE ?? "ok" }] }));\nawait server.connect(new StdioServerTransport());\n`,
+        `import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";\nimport { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";\nconst toolName = process.argv[2] ?? "one";\nconst requiredEnv = process.argv[3];\nif (requiredEnv && process.env[requiredEnv] == null) process.exit(1);\nconst server = new McpServer({ name: "stdio-fixture", version: "1.0.0" }, { capabilities: {} });\nserver.registerTool(toolName, { description: "Stdio fixture tool", inputSchema: {} }, async () => ({ content: [{ type: "text", text: process.env.STDIO_VALUE ?? process.env.STDIO_SECRET ?? "ok" }] }));\nawait server.connect(new StdioServerTransport());\n`,
       ),
     );
     return { dir, script } as const;
@@ -598,6 +598,95 @@ describe("mcpPlugin", () => {
         tools = yield* executor.tools.list({ integration: IntegrationSlug.make("stdio_edit") });
         expect(tools.map((tool) => String(tool.name))).toContain("two");
         expect(tools.map((tool) => String(tool.name))).not.toContain("one");
+      }),
+    ),
+  );
+
+  it.effect(
+    "configureServer preflights stdio secret env sources with existing connection values",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fixture = yield* withStdioFixtureScript;
+          const executor = yield* createExecutor(
+            makeTestConfig({
+              plugins: [
+                memoryCredentialsPlugin(),
+                mcpPlugin({ dangerouslyAllowStdioMCP: true }),
+              ] as const,
+            }),
+          );
+
+          yield* executor.mcp.addServer({
+            transport: "stdio",
+            name: "Stdio secret edit",
+            slug: "stdio_secret_edit",
+            command: process.execPath,
+            args: [fixture.script, "one", "STDIO_SECRET"],
+            envVars: ["STDIO_SECRET"],
+          });
+          yield* executor.connections.create({
+            owner: "org",
+            name: ConnectionName.make("default"),
+            integration: IntegrationSlug.make("stdio_secret_edit"),
+            template: AuthTemplateSlug.make("env"),
+            values: { STDIO_SECRET: "secret-value" },
+          });
+
+          yield* executor.mcp.configureServer("stdio_secret_edit", {
+            transport: "stdio",
+            command: process.execPath,
+            args: [fixture.script, "two", "STDIO_SECRET"],
+            authenticationTemplate: [{ slug: "env", kind: "stdio_env", vars: ["STDIO_SECRET"] }],
+          });
+
+          const tools = yield* executor.tools.list({
+            integration: IntegrationSlug.make("stdio_secret_edit"),
+          });
+          expect(tools.map((tool) => String(tool.name))).toContain("two");
+          expect(tools.map((tool) => String(tool.name))).not.toContain("one");
+        }),
+      ),
+  );
+
+  it.effect("configureServer reports missing stdio secret values before preflight", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* withStdioFixtureScript;
+        const executor = yield* createExecutor(
+          makeTestConfig({
+            plugins: [
+              memoryCredentialsPlugin(),
+              mcpPlugin({ dangerouslyAllowStdioMCP: true }),
+            ] as const,
+          }),
+        );
+
+        yield* executor.mcp.addServer({
+          transport: "stdio",
+          name: "Stdio secret missing",
+          slug: "stdio_secret_missing",
+          command: process.execPath,
+          args: [fixture.script, "one", "STDIO_SECRET"],
+          envVars: ["STDIO_SECRET"],
+        });
+
+        const result = yield* Effect.result(
+          executor.mcp.configureServer("stdio_secret_missing", {
+            transport: "stdio",
+            command: process.execPath,
+            args: [fixture.script, "two", "STDIO_SECRET"],
+            authenticationTemplate: [{ slug: "env", kind: "stdio_env", vars: ["STDIO_SECRET"] }],
+          }),
+        );
+
+        expect(Result.isFailure(result)).toBe(true);
+        const failure = Result.isFailure(result) ? result.failure : null;
+        expect(failure).toMatchObject({
+          _tag: "McpConnectionError",
+          message:
+            "Cannot validate this command because no visible connection has values for required environment variables: STDIO_SECRET.",
+        });
       }),
     ),
   );

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   AuthTemplateSlug,
   ConnectionName,
+  definePlugin,
   IntegrationSlug,
   OAuthClientSlug,
   ToolAddress,
@@ -40,6 +41,22 @@ import { makeAnnotationsMcpServer, serveMcpServer } from "../testing";
 // elicitation.test.ts + owner-isolation.test.ts.
 
 const TEMPLATE = AuthTemplateSlug.make("none");
+
+const malformedMcpConfigSeedPlugin = definePlugin(() => ({
+  id: "malformedMcpConfigSeed" as const,
+  storage: () => ({}),
+  extension: (ctx) => ({
+    seedMalformedMcpConfig: (slug: string) =>
+      ctx.core.integrations.register({
+        slug: IntegrationSlug.make(slug),
+        name: "Malformed MCP config",
+        description: "Malformed MCP config",
+        config: { transport: "stdio", command: 123 },
+        canRemove: true,
+        canRefresh: true,
+      }),
+  }),
+}));
 
 const JsonRpcId = Schema.Union([Schema.String, Schema.Number, Schema.Null]);
 const JsonRpcRequest = Schema.Struct({
@@ -713,6 +730,27 @@ describe("mcpPlugin", () => {
           authenticationTemplate: [{ slug: "none", kind: "none" }],
         }),
       );
+      expect(Result.isFailure(result)).toBe(true);
+      const failure = Result.isFailure(result) ? result.failure : undefined;
+      expect(Predicate.isTagged(failure, "IntegrationNotFoundError")).toBe(true);
+    }),
+  );
+
+  it.effect("configureServer returns IntegrationNotFoundError for malformed stored configs", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [malformedMcpConfigSeedPlugin(), mcpPlugin()] as const }),
+      );
+      yield* executor.malformedMcpConfigSeed.seedMalformedMcpConfig("malformed_mcp");
+
+      const result = yield* Effect.result(
+        executor.mcp.configureServer("malformed_mcp", {
+          transport: "stdio",
+          command: process.execPath,
+          authenticationTemplate: [{ slug: "none", kind: "none" }],
+        }),
+      );
+
       expect(Result.isFailure(result)).toBe(true);
       const failure = Result.isFailure(result) ? result.failure : undefined;
       expect(Predicate.isTagged(failure, "IntegrationNotFoundError")).toBe(true);

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -890,15 +890,12 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
       // adding a stdio server registered only the integration, so it landed with
       // zero connections and therefore zero tools (the "no tools detected"
       // report). For each such integration with no connection, create the
-      // default one — and move any legacy inline `env` (then stored plaintext in
-      // the config blob) into the connection's secret store, rewriting the
-      // config to the canonical shape that only declares the var NAMES.
+      // default no-auth connection and preserve any inline `env` as static
+      // subprocess environment on the config.
       //
       // Idempotent and order-safe: once a connection exists the integration is
-      // skipped; the secret is persisted (connection.create) BEFORE the config
-      // is stripped, so a failure between the two leaves the env recoverable
-      // (the connection has it, and the still-inline config env also works). A
-      // single bad integration is logged and skipped, never failing the caller.
+      // skipped. A single bad integration is logged and skipped, never failing
+      // the caller.
       const reconcileStdioConnections = () =>
         Effect.gen(function* () {
           const integrations = yield* ctx.core.integrations.list();
@@ -1048,6 +1045,17 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
         requiredVars: readonly string[],
         values: Record<string, string | null>,
       ): readonly string[] => requiredVars.filter((variable) => values[variable] == null);
+
+      const sameStdioEnvVars = (
+        left: McpStdioIntegrationConfig,
+        right: McpStdioIntegrationConfig,
+      ): boolean => {
+        const leftVars = new Set(requiredStdioEnvVars(left));
+        const rightVars = new Set(requiredStdioEnvVars(right));
+        return (
+          leftVars.size === rightVars.size && [...leftVars].every((name) => rightVars.has(name))
+        );
+      };
 
       const preflightStdioConfig = (
         integration: IntegrationSlug,
@@ -1216,10 +1224,11 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
             });
           }
 
-          const processConfigChanged = !sameCanonicalStdioConfig(
-            canonicalizeStdioConfig(current),
-            canonicalizeStdioConfig(config),
-          );
+          const processConfigChanged =
+            !sameCanonicalStdioConfig(
+              canonicalizeStdioConfig(current),
+              canonicalizeStdioConfig(config),
+            ) || !sameStdioEnvVars(current, config);
           if (!processConfigChanged) {
             yield* ctx.core.integrations.update(integration, { config });
             return { config, toolsRefreshFailed: false } satisfies McpConfigureServerResult;

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Option, Predicate, Result, Schema } from "effect";
+import { Cause, Effect, Layer, Option, Predicate, Result, Schema } from "effect";
 import type { HttpClient } from "effect/unstable/http";
 
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
@@ -1106,8 +1106,25 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
 
       const refreshStdioConnections = (integration: IntegrationSlug) =>
         Effect.gen(function* () {
+          const record = yield* ctx.core.integrations.get(integration);
+          const config = record ? parseMcpIntegrationConfig(record.config) : null;
+          if (!config || config.transport !== "stdio") {
+            return yield* new McpConnectionError({
+              transport: "stdio",
+              message: `Cannot refresh tools for MCP integration ${integration}: stdio config not found.`,
+            });
+          }
+
           const connections = yield* ctx.connections.list({ integration });
           if (connections.length === 0) {
+            const requiredVars = requiredStdioEnvVars(config);
+            if (requiredVars.length > 0) {
+              return yield* new McpConnectionError({
+                transport: "stdio",
+                message: `Cannot refresh tools because no visible connection has values for required environment variables: ${requiredVars.join(", ")}.`,
+              });
+            }
+
             yield* ctx.connections
               .create({
                 owner: "org",
@@ -1136,7 +1153,18 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           }
 
           const failedNames = yield* Effect.forEach(connections, (connection) =>
-            ctx.connections.refresh(connection).pipe(
+            Effect.gen(function* () {
+              const values = yield* ctx.connections.resolveValues(connection);
+              const connectorInput = yield* buildConnectorInput(
+                config,
+                values,
+                String(connection.template),
+                allowStdio,
+                httpClientLayer,
+              );
+              yield* discoverTools(createMcpConnector(connectorInput));
+              yield* ctx.connections.refresh(connection);
+            }).pipe(
               Effect.as(null),
               Effect.catch(() => Effect.succeed(String(connection.name))),
             ),
@@ -1149,6 +1177,17 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
             });
           }
         });
+
+      const refreshStdioToolsBestEffort = (integration: IntegrationSlug) =>
+        refreshStdioConnections(integration).pipe(
+          Effect.as(false),
+          Effect.catchCause((cause) =>
+            Effect.logWarning("stdio tools refresh failed after config commit").pipe(
+              Effect.annotateLogs("cause", Cause.pretty(cause)),
+              Effect.as(true),
+            ),
+          ),
+        );
 
       const configureServer = (slug: string, config: McpIntegrationConfigType) =>
         Effect.gen(function* () {
@@ -1167,7 +1206,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
 
           if (current.transport !== "stdio") {
             yield* ctx.core.integrations.update(integration, { config });
-            return;
+            return { config, toolsRefreshFailed: false } satisfies McpConfigureServerResult;
           }
 
           if (config.transport !== "stdio") {
@@ -1183,7 +1222,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           );
           if (!processConfigChanged) {
             yield* ctx.core.integrations.update(integration, { config });
-            return;
+            return { config, toolsRefreshFailed: false } satisfies McpConfigureServerResult;
           }
 
           yield* preflightStdioConfig(integration, config);
@@ -1193,9 +1232,33 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
               yield* ctx.core.integrations.update(integration, { config });
             }),
           );
-          yield* refreshStdioConnections(integration);
+          const toolsRefreshFailed = yield* refreshStdioToolsBestEffort(integration);
+          return { config, toolsRefreshFailed } satisfies McpConfigureServerResult;
         }).pipe(
           Effect.withSpan("mcp.plugin.configure_server", {
+            attributes: { "mcp.integration.slug": slug },
+          }),
+        );
+
+      const refreshServerTools = (slug: string) =>
+        Effect.gen(function* () {
+          const integration = slugFrom(slug);
+          const record = yield* ctx.core.integrations.get(integration);
+          const current = record ? parseMcpIntegrationConfig(record.config) : null;
+          if (record === null || current === null) {
+            return yield* new IntegrationNotFoundError({ slug: integration });
+          }
+          if (current.transport !== "stdio") {
+            return yield* new McpConnectionError({
+              transport: "auto",
+              message:
+                "MCP tool refresh through the MCP server API is only supported for stdio servers.",
+            });
+          }
+          const toolsRefreshFailed = yield* refreshStdioToolsBestEffort(integration);
+          return { toolsRefreshFailed } satisfies McpRefreshServerToolsResult;
+        }).pipe(
+          Effect.withSpan("mcp.plugin.refresh_server_tools", {
             attributes: { "mcp.integration.slug": slug },
           }),
         );
@@ -1245,6 +1308,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
         reconcileStdioConnections,
         getServer,
         configureServer,
+        refreshServerTools,
         configureAuth,
       };
     },
@@ -1575,6 +1639,15 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
 
 export type McpExtensionFailure = McpConnectionError | McpToolDiscoveryError | StorageFailure;
 
+export interface McpConfigureServerResult {
+  readonly config: McpIntegrationConfigType;
+  readonly toolsRefreshFailed: boolean;
+}
+
+export interface McpRefreshServerToolsResult {
+  readonly toolsRefreshFailed: boolean;
+}
+
 export interface McpPluginExtension {
   readonly probeEndpoint: (
     input: string | McpProbeEndpointInput,
@@ -1598,7 +1671,10 @@ export interface McpPluginExtension {
   readonly configureServer: (
     slug: string,
     config: McpIntegrationConfigType,
-  ) => Effect.Effect<void, McpExtensionFailure | IntegrationNotFoundError>;
+  ) => Effect.Effect<McpConfigureServerResult, McpExtensionFailure | IntegrationNotFoundError>;
+  readonly refreshServerTools: (
+    slug: string,
+  ) => Effect.Effect<McpRefreshServerToolsResult, McpExtensionFailure | IntegrationNotFoundError>;
   readonly configureAuth: (
     slug: string,
     input: McpConfigureAuthInput,

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Option, Result, Schema } from "effect";
+import { Effect, Layer, Option, Predicate, Result, Schema } from "effect";
 import type { HttpClient } from "effect/unstable/http";
 
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
@@ -11,6 +11,7 @@ import {
   ConnectionName,
   definePlugin,
   IntegrationAlreadyExistsError,
+  IntegrationNotFoundError,
   IntegrationSlug,
   mergeAuthTemplates,
   OAuthClientSlug,
@@ -49,6 +50,7 @@ import { invokeMcpTool } from "./invoke";
 import { deriveMcpNamespace, type McpToolManifestEntry } from "./manifest";
 import { mcpPresets } from "./presets";
 import { probeMcpEndpointShape, type McpShapeProbeResult } from "./probe-shape";
+import { canonicalizeStdioConfig, sameCanonicalStdioConfig } from "./stdio-config";
 import {
   McpAuthMethodInput,
   McpAuthShorthand,
@@ -171,13 +173,10 @@ const McpStdioServerInputSchema = Schema.Struct({
   description: Schema.optional(Schema.String),
   command: Schema.String,
   args: Schema.optional(Schema.Array(Schema.String)),
-  /** DECLARE the secret env vars this server needs, by NAME. Their values are
-   *  supplied as the connection's secret credentials, not here — so the UI
-   *  defines what env vars exist and the connect step provides the secrets. */
+  /** Declare secret env vars this server needs, by name. Their values are
+   *  supplied as the connection's secret credentials. */
   envVars: Schema.optional(Schema.Array(Schema.String)),
-  /** Provide secret env values directly (programmatic / agent one-shot): the
-   *  add then auto-creates the connection holding them. The UI uses `envVars`
-   *  instead and leaves the values to the connect step. */
+  /** Static, non-credential environment variables injected into the subprocess. */
   env: Schema.optional(Schema.Record(Schema.String, Schema.String)),
   cwd: Schema.optional(Schema.String),
   slug: Schema.optional(Schema.String),
@@ -310,23 +309,20 @@ const STDIO_ENV_TEMPLATE = "env";
 /** The secret env var NAMES a stdio add declares: the explicit `envVars`
  *  declaration plus the keys of any one-shot `env` values, de-duplicated and
  *  order-preserving. */
-const stdioEnvVarNames = (input: McpStdioServerInput): readonly string[] => {
-  const names = new Set<string>(input.envVars ?? []);
-  for (const key of Object.keys(input.env ?? {})) names.add(key);
-  return [...names];
-};
+const stdioEnvVarNames = (input: McpStdioServerInput): readonly string[] => [
+  ...new Set(input.envVars ?? []),
+];
 
 const toIntegrationConfig = (input: McpServerInput): McpIntegrationConfigType => {
   if (input.transport === "stdio") {
-    // The config only DECLARES the secret env vars by NAME (a `stdio_env`
-    // method); their values are credentials and live on the connection, never
-    // in this blob. Names come from the explicit `envVars` declaration and/or
-    // the keys of any one-shot `env` values.
+    // Static env values live on the integration config. Secret env names are
+    // declared as a `stdio_env` method, and their values live on the connection.
     const vars = stdioEnvVarNames(input);
     return {
       transport: "stdio",
       command: input.command,
       args: input.args ? [...input.args] : undefined,
+      env: input.env && Object.keys(input.env).length > 0 ? { ...input.env } : undefined,
       cwd: input.cwd,
       authenticationTemplate:
         vars.length > 0
@@ -841,26 +837,19 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
             );
 
           // Auto-create the stdio server's default connection so its tools are
-          // discovered immediately (without it the integration lands with zero
-          // connections and therefore zero tools — the fresh-install "no tools
-          // detected" report). Two cases connect on add:
-          //   • one-shot `env` VALUES were supplied (agent path) → bind them as
-          //     the connection's secrets.
-          //   • the server needs NO secret env at all → a no-auth connection.
-          // When the server only DECLARES env var names (the UI path), the
-          // secrets are still missing, so we leave the connection to the connect
-          // step where the user enters one masked value per declared var.
+          // discovered immediately when it does not need secret env credentials.
+          // When the server declares env var names, the secrets are still
+          // missing, so the connection is left to the connect step.
           if (input.transport === "stdio") {
-            const hasValues = input.env != null && Object.keys(input.env).length > 0;
             const declaresSecrets = stdioEnvVarNames(input).length > 0;
-            if (hasValues || !declaresSecrets) {
+            if (!declaresSecrets) {
               yield* ctx.connections
                 .create({
                   owner: "org",
                   name: ConnectionName.make("default"),
                   integration: slugFrom(slug),
-                  template: AuthTemplateSlug.make(hasValues ? STDIO_ENV_TEMPLATE : "none"),
-                  values: hasValues ? { ...input.env } : {},
+                  template: AuthTemplateSlug.make("none"),
+                  values: {},
                 })
                 .pipe(
                   // These can't arise right after a successful register with
@@ -934,29 +923,21 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
               });
               if (connections.length > 0) return; // already connectable — nothing to heal.
 
-              const inlineEnv = config.env ?? {};
-              const envVars = Object.keys(inlineEnv);
-              const hasEnv = envVars.length > 0;
-
               yield* ctx.connections.create({
                 owner: "org",
                 name: ConnectionName.make("default"),
                 integration: integration.slug,
-                template: AuthTemplateSlug.make(hasEnv ? STDIO_ENV_TEMPLATE : "none"),
-                values: hasEnv ? { ...inlineEnv } : {},
+                template: AuthTemplateSlug.make("none"),
+                values: {},
               });
 
-              // The secret is now on the connection: canonicalize this legacy
-              // config (declare the var names as a stdio_env method, dropping the
-              // inline plaintext values; or `none` for a no-secret server).
               const nextConfig: McpIntegrationConfigType = {
                 transport: "stdio",
                 command: config.command,
                 args: config.args,
+                env: config.env,
                 cwd: config.cwd,
-                authenticationTemplate: hasEnv
-                  ? [{ slug: STDIO_ENV_TEMPLATE, kind: "stdio_env", vars: envVars }]
-                  : [{ slug: "none", kind: "none" }],
+                authenticationTemplate: [{ slug: "none", kind: "none" }],
               };
               yield* ctx.core.integrations.update(integration.slug, { config: nextConfig });
             }).pipe(
@@ -1055,8 +1036,120 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           }),
         );
 
+      const preflightStdioConfig = (config: McpIntegrationConfigType) =>
+        Effect.gen(function* () {
+          const connectorInput = yield* buildConnectorInput(
+            config,
+            {},
+            null,
+            allowStdio,
+            httpClientLayer,
+          );
+          yield* discoverTools(createMcpConnector(connectorInput));
+        });
+
+      const removePoliciesScopedToIntegration = (integration: IntegrationSlug) =>
+        Effect.gen(function* () {
+          const prefix = `${String(integration)}.`;
+          const policies = yield* ctx.core.policies.list();
+          for (const policy of policies) {
+            if (policy.pattern === String(integration) || policy.pattern.startsWith(prefix)) {
+              yield* ctx.core.policies.remove({ id: String(policy.id), owner: policy.owner });
+            }
+          }
+        });
+
+      const refreshStdioConnections = (integration: IntegrationSlug) =>
+        Effect.gen(function* () {
+          const connections = yield* ctx.connections.list({ integration });
+          if (connections.length === 0) {
+            yield* ctx.connections
+              .create({
+                owner: "org",
+                name: ConnectionName.make("default"),
+                integration,
+                template: AuthTemplateSlug.make("none"),
+                values: {},
+              })
+              .pipe(
+                Effect.catchTags({
+                  IntegrationNotFoundError: (cause) =>
+                    Effect.fail(
+                      new McpConnectionError({ transport: "stdio", message: cause.message }),
+                    ),
+                  CredentialProviderNotRegisteredError: (cause) =>
+                    Effect.fail(
+                      new McpConnectionError({ transport: "stdio", message: cause.message }),
+                    ),
+                  InvalidConnectionInputError: (cause) =>
+                    Effect.fail(
+                      new McpConnectionError({ transport: "stdio", message: cause.message }),
+                    ),
+                }),
+              );
+            return;
+          }
+
+          const failedNames = yield* Effect.forEach(connections, (connection) =>
+            ctx.connections.refresh(connection).pipe(
+              Effect.as(null),
+              Effect.catch(() => Effect.succeed(String(connection.name))),
+            ),
+          );
+          const failures = failedNames.filter(Predicate.isNotNull);
+          if (failures.length > 0) {
+            return yield* new McpToolDiscoveryError({
+              stage: "list_tools",
+              message: `MCP tools refreshed with failures for connection(s): ${failures.join(", ")}`,
+            });
+          }
+        });
+
       const configureServer = (slug: string, config: McpIntegrationConfigType) =>
-        ctx.core.integrations.update(slugFrom(slug), { config }).pipe(
+        Effect.gen(function* () {
+          const integration = slugFrom(slug);
+          const record = yield* ctx.core.integrations.get(integration);
+          const current = record ? parseMcpIntegrationConfig(record.config) : null;
+          if (record === null || current === null) {
+            return yield* new IntegrationNotFoundError({ slug: integration });
+          }
+          if (current.transport !== config.transport) {
+            return yield* new McpConnectionError({
+              transport: "auto",
+              message: "MCP transport cannot be changed. Remove and recreate the source.",
+            });
+          }
+
+          if (current.transport !== "stdio") {
+            yield* ctx.core.integrations.update(integration, { config });
+            return;
+          }
+
+          if (config.transport !== "stdio") {
+            return yield* new McpConnectionError({
+              transport: "auto",
+              message: "MCP transport cannot be changed. Remove and recreate the source.",
+            });
+          }
+
+          const processConfigChanged = !sameCanonicalStdioConfig(
+            canonicalizeStdioConfig(current),
+            canonicalizeStdioConfig(config),
+          );
+          if (!processConfigChanged) {
+            yield* ctx.core.integrations.update(integration, { config });
+            return;
+          }
+
+          yield* preflightStdioConfig(config);
+          yield* ctx.transaction(
+            Effect.gen(function* () {
+              yield* removePoliciesScopedToIntegration(integration);
+              yield* ctx.core.integrations.update(integration, { config });
+            }),
+          );
+          yield* refreshStdioConnections(integration);
+        }).pipe(
           Effect.withSpan("mcp.plugin.configure_server", {
             attributes: { "mcp.integration.slug": slug },
           }),
@@ -1460,7 +1553,7 @@ export interface McpPluginExtension {
   readonly configureServer: (
     slug: string,
     config: McpIntegrationConfigType,
-  ) => Effect.Effect<void, McpExtensionFailure>;
+  ) => Effect.Effect<void, McpExtensionFailure | IntegrationNotFoundError>;
   readonly configureAuth: (
     slug: string,
     input: McpConfigureAuthInput,

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -1036,16 +1036,61 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           }),
         );
 
-      const preflightStdioConfig = (config: McpIntegrationConfigType) =>
+      const requiredStdioEnvVars = (config: McpStdioIntegrationConfig): readonly string[] => [
+        ...new Set(
+          (config.authenticationTemplate ?? []).flatMap((method: McpAuthMethod) =>
+            method.kind === "stdio_env" ? method.vars : [],
+          ),
+        ),
+      ];
+
+      const missingStdioEnvVars = (
+        requiredVars: readonly string[],
+        values: Record<string, string | null>,
+      ): readonly string[] => requiredVars.filter((variable) => values[variable] == null);
+
+      const preflightStdioConfig = (
+        integration: IntegrationSlug,
+        config: McpStdioIntegrationConfig,
+      ) =>
         Effect.gen(function* () {
-          const connectorInput = yield* buildConnectorInput(
-            config,
-            {},
-            null,
-            allowStdio,
-            httpClientLayer,
-          );
-          yield* discoverTools(createMcpConnector(connectorInput));
+          const requiredVars = requiredStdioEnvVars(config);
+          if (requiredVars.length === 0) {
+            const connectorInput = yield* buildConnectorInput(
+              config,
+              {},
+              null,
+              allowStdio,
+              httpClientLayer,
+            );
+            yield* discoverTools(createMcpConnector(connectorInput));
+            return;
+          }
+
+          const connections = yield* ctx.connections.list({ integration });
+          for (const connection of connections) {
+            const template = String(connection.template);
+            const method = selectAuthMethod(config, template);
+            if (method?.kind !== "stdio_env") continue;
+
+            const values = yield* ctx.connections.resolveValues(connection);
+            if (missingStdioEnvVars(method.vars, values).length > 0) continue;
+
+            const connectorInput = yield* buildConnectorInput(
+              config,
+              values,
+              template,
+              allowStdio,
+              httpClientLayer,
+            );
+            yield* discoverTools(createMcpConnector(connectorInput));
+            return;
+          }
+
+          return yield* new McpConnectionError({
+            transport: "stdio",
+            message: `Cannot validate this command because no visible connection has values for required environment variables: ${requiredVars.join(", ")}.`,
+          });
         });
 
       const removePoliciesScopedToIntegration = (integration: IntegrationSlug) =>
@@ -1141,7 +1186,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
             return;
           }
 
-          yield* preflightStdioConfig(config);
+          yield* preflightStdioConfig(integration, config);
           yield* ctx.transaction(
             Effect.gen(function* () {
               yield* removePoliciesScopedToIntegration(integration);

--- a/packages/plugins/mcp/src/sdk/stdio-config.test.ts
+++ b/packages/plugins/mcp/src/sdk/stdio-config.test.ts
@@ -6,18 +6,38 @@ import {
   parseStdioArgs,
   parseStdioEnv,
   sameCanonicalStdioConfig,
+  stdioArgsToText,
   stdioEnvToText,
 } from "./stdio-config";
 
 describe("stdio config helpers", () => {
-  it.effect("preserves current argument parsing behavior", () =>
+  it.effect("parses shell-like argument text", () =>
     Effect.sync(() => {
       expect(parseStdioArgs('  -y "package with spaces" --flag=value  ')).toEqual([
         "-y",
         "package with spaces",
         "--flag=value",
       ]);
+      expect(parseStdioArgs("'single quoted' escaped\\ space C:\\tools\\bin")).toEqual([
+        "single quoted",
+        "escaped space",
+        "C:\\tools\\bin",
+      ]);
       expect(parseStdioArgs("   ")).toEqual([]);
+    }),
+  );
+
+  it.effect("serializes argument text that round trips through the parser", () =>
+    Effect.sync(() => {
+      const args = [
+        "-y",
+        "package with spaces",
+        "--flag=value",
+        "C:\\Program Files\\Executor\\tool.js",
+        "line\nnext",
+        "",
+      ];
+      expect(parseStdioArgs(stdioArgsToText(args))).toEqual(args);
     }),
   );
 
@@ -86,8 +106,10 @@ describe("stdio config helpers", () => {
         C: "plain",
         D: "'hello'",
         E: '"hello"',
+        F: "\\bar",
       };
       expect(parseStdioEnv(stdioEnvToText(env))).toEqual({ ok: true, env });
+      expect(stdioEnvToText({ F: "\\bar" })).toBe("F=\\bar");
     }),
   );
 

--- a/packages/plugins/mcp/src/sdk/stdio-config.test.ts
+++ b/packages/plugins/mcp/src/sdk/stdio-config.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import {
+  canonicalizeStdioConfig,
+  parseStdioArgs,
+  parseStdioEnv,
+  sameCanonicalStdioConfig,
+  stdioEnvToText,
+} from "./stdio-config";
+
+describe("stdio config helpers", () => {
+  it.effect("preserves current argument parsing behavior", () =>
+    Effect.sync(() => {
+      expect(parseStdioArgs('  -y "package with spaces" --flag=value  ')).toEqual([
+        "-y",
+        "package with spaces",
+        "--flag=value",
+      ]);
+      expect(parseStdioArgs("   ")).toEqual([]);
+    }),
+  );
+
+  it.effect("parses valid environment lines", () =>
+    Effect.sync(() => {
+      expect(parseStdioEnv("FOO=bar\nEMPTY=\n  SPACED = value  ")).toEqual({
+        ok: true,
+        env: { FOO: "bar", EMPTY: "", SPACED: "value" },
+      });
+    }),
+  );
+
+  it.effect("unwraps quoted values and double-quoted escapes", () =>
+    Effect.sync(() => {
+      expect(parseStdioEnv("A=' literal ' value '\nB=\"line\\n\\t\\r\\\\\\\"\"")).toEqual({
+        ok: true,
+        env: { A: " literal ' value ", B: 'line\n\t\r\\"' },
+      });
+    }),
+  );
+
+  it.effect("reports missing equals", () =>
+    Effect.sync(() => {
+      expect(parseStdioEnv("FOO")).toEqual({
+        ok: false,
+        error: { kind: "missing_equals", line: 1 },
+      });
+    }),
+  );
+
+  it.effect("reports empty keys", () =>
+    Effect.sync(() => {
+      expect(parseStdioEnv("=value")).toEqual({ ok: false, error: { kind: "empty_key", line: 1 } });
+    }),
+  );
+
+  it.effect("reports invalid keys", () =>
+    Effect.sync(() => {
+      expect(parseStdioEnv("1_BAD=value")).toEqual({
+        ok: false,
+        error: { kind: "invalid_key", line: 1, key: "1_BAD" },
+      });
+    }),
+  );
+
+  it.effect("reports duplicate keys", () =>
+    Effect.sync(() => {
+      expect(parseStdioEnv("FOO=one\nFOO=two")).toEqual({
+        ok: false,
+        error: { kind: "duplicate_key", line: 2, key: "FOO" },
+      });
+    }),
+  );
+
+  it.effect("returns undefined env for an empty textarea", () =>
+    Effect.sync(() => {
+      expect(parseStdioEnv("\n  \n")).toEqual({ ok: true, env: undefined });
+    }),
+  );
+
+  it.effect("serializes env text that round trips through the parser", () =>
+    Effect.sync(() => {
+      const env = { A: " value ", B: "line\nnext", C: "plain" };
+      expect(parseStdioEnv(stdioEnvToText(env))).toEqual({ ok: true, env });
+    }),
+  );
+
+  it.effect("compares canonical env independent of key order", () =>
+    Effect.sync(() => {
+      expect(
+        sameCanonicalStdioConfig(
+          canonicalizeStdioConfig({ command: " npx ", args: ["a"], env: { B: "2", A: "1" } }),
+          canonicalizeStdioConfig({ command: "npx", args: ["a"], env: { A: "1", B: "2" } }),
+        ),
+      ).toBe(true);
+    }),
+  );
+});

--- a/packages/plugins/mcp/src/sdk/stdio-config.test.ts
+++ b/packages/plugins/mcp/src/sdk/stdio-config.test.ts
@@ -80,7 +80,13 @@ describe("stdio config helpers", () => {
 
   it.effect("serializes env text that round trips through the parser", () =>
     Effect.sync(() => {
-      const env = { A: " value ", B: "line\nnext", C: "plain" };
+      const env = {
+        A: " value ",
+        B: "line\nnext",
+        C: "plain",
+        D: "'hello'",
+        E: '"hello"',
+      };
       expect(parseStdioEnv(stdioEnvToText(env))).toEqual({ ok: true, env });
     }),
   );

--- a/packages/plugins/mcp/src/sdk/stdio-config.ts
+++ b/packages/plugins/mcp/src/sdk/stdio-config.ts
@@ -1,0 +1,167 @@
+import type { McpStdioIntegrationConfig } from "./types";
+
+export type StdioEnvParseError =
+  | { readonly kind: "missing_equals"; readonly line: number }
+  | { readonly kind: "empty_key"; readonly line: number }
+  | { readonly kind: "invalid_key"; readonly line: number; readonly key: string }
+  | { readonly kind: "duplicate_key"; readonly line: number; readonly key: string };
+
+export type StdioEnvParseResult =
+  | { readonly ok: true; readonly env: Record<string, string> | undefined }
+  | { readonly ok: false; readonly error: StdioEnvParseError };
+
+export type CanonicalStdioConfig = {
+  readonly transport: "stdio";
+  readonly command: string;
+  readonly args?: readonly string[];
+  readonly env?: Record<string, string>;
+  readonly cwd?: string;
+};
+
+const STDIO_ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export const parseStdioArgs = (raw: string): string[] => {
+  if (!raw.trim()) return [];
+  const args: string[] = [];
+  const regex = /[^\s"]+|"([^"]*)"/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(raw)) !== null) {
+    args.push(match[1] ?? match[0]);
+  }
+  return args;
+};
+
+const parseStdioEnvValue = (raw: string): string => {
+  const trimmed = raw.trim();
+  if (trimmed.length >= 2 && trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1);
+  }
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed
+      .slice(1, -1)
+      .replace(/\\([\\nrt"])/g, (_match: string, escaped: string): string => {
+        if (escaped === "n") return "\n";
+        if (escaped === "r") return "\r";
+        if (escaped === "t") return "\t";
+        return escaped;
+      });
+  }
+  return trimmed;
+};
+
+export const parseStdioEnv = (raw: string): StdioEnvParseResult => {
+  const env: Record<string, string> = {};
+  const seen = new Set<string>();
+  const lines = raw.split(/\r?\n/);
+
+  for (const [index, line] of lines.entries()) {
+    const lineNumber = index + 1;
+    if (line.trim().length === 0) continue;
+
+    const equalsIndex = line.indexOf("=");
+    if (equalsIndex === -1) {
+      return { ok: false, error: { kind: "missing_equals", line: lineNumber } };
+    }
+
+    const key = line.slice(0, equalsIndex).trim();
+    if (key.length === 0) {
+      return { ok: false, error: { kind: "empty_key", line: lineNumber } };
+    }
+    if (!STDIO_ENV_KEY_PATTERN.test(key)) {
+      return { ok: false, error: { kind: "invalid_key", line: lineNumber, key } };
+    }
+    if (seen.has(key)) {
+      return { ok: false, error: { kind: "duplicate_key", line: lineNumber, key } };
+    }
+
+    seen.add(key);
+    env[key] = parseStdioEnvValue(line.slice(equalsIndex + 1));
+  }
+
+  return { ok: true, env: Object.keys(env).length > 0 ? env : undefined };
+};
+
+const formatStdioEnvValue = (value: string): string => {
+  if (value.length === 0) return "";
+  if (value.trim() === value && !/[\n\r\t"\\]/.test(value)) return value;
+  return `"${value
+    .replace(/\\/g, "\\\\")
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t")
+    .replace(/"/g, '\\"')}"`;
+};
+
+export const stdioEnvToText = (env: Record<string, string> | undefined): string => {
+  if (env === undefined || Object.keys(env).length === 0) return "";
+  return Object.entries(env)
+    .map(([key, value]) => `${key}=${formatStdioEnvValue(value)}`)
+    .join("\n");
+};
+
+const normalizeEnv = (
+  env: Record<string, string> | undefined,
+): Record<string, string> | undefined => {
+  if (env === undefined) return undefined;
+  const keys = Object.keys(env).sort();
+  if (keys.length === 0) return undefined;
+  const normalized: Record<string, string> = {};
+  for (const key of keys) normalized[key] = env[key] ?? "";
+  return normalized;
+};
+
+export const canonicalizeStdioConfig = (
+  config: Pick<McpStdioIntegrationConfig, "command" | "args" | "env" | "cwd">,
+): CanonicalStdioConfig => ({
+  transport: "stdio",
+  command: config.command.trim(),
+  ...(config.args !== undefined && config.args.length > 0 ? { args: [...config.args] } : {}),
+  ...(normalizeEnv(config.env) !== undefined ? { env: normalizeEnv(config.env) } : {}),
+  ...(config.cwd !== undefined && config.cwd.trim().length > 0 ? { cwd: config.cwd.trim() } : {}),
+});
+
+export const canonicalizeStdioDraft = (input: {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly env: Record<string, string> | undefined;
+  readonly cwd: string;
+}): CanonicalStdioConfig =>
+  canonicalizeStdioConfig({
+    command: input.command,
+    args: input.args.length > 0 ? [...input.args] : undefined,
+    env: input.env,
+    cwd: input.cwd,
+  });
+
+export const sameCanonicalStdioConfig = (
+  left: CanonicalStdioConfig,
+  right: CanonicalStdioConfig,
+): boolean => {
+  if (left.command !== right.command) return false;
+  if ((left.cwd ?? undefined) !== (right.cwd ?? undefined)) return false;
+
+  const leftArgs = left.args ?? [];
+  const rightArgs = right.args ?? [];
+  if (leftArgs.length !== rightArgs.length) return false;
+  if (leftArgs.some((value, index) => value !== rightArgs[index])) return false;
+
+  const leftEnv = left.env ?? {};
+  const rightEnv = right.env ?? {};
+  const leftKeys = Object.keys(leftEnv).sort();
+  const rightKeys = Object.keys(rightEnv).sort();
+  if (leftKeys.length !== rightKeys.length) return false;
+  return leftKeys.every((key, index) => key === rightKeys[index] && leftEnv[key] === rightEnv[key]);
+};
+
+export const stdioEnvParseErrorMessage = (error: StdioEnvParseError): string => {
+  if (error.kind === "missing_equals") {
+    return `Environment line ${error.line} must use KEY=value.`;
+  }
+  if (error.kind === "empty_key") {
+    return `Environment line ${error.line} is missing a variable name.`;
+  }
+  if (error.kind === "invalid_key") {
+    return `Environment line ${error.line} has invalid variable name ${error.key}.`;
+  }
+  return `Environment line ${error.line} repeats variable ${error.key}.`;
+};

--- a/packages/plugins/mcp/src/sdk/stdio-config.ts
+++ b/packages/plugins/mcp/src/sdk/stdio-config.ts
@@ -81,15 +81,24 @@ export const parseStdioEnv = (raw: string): StdioEnvParseResult => {
   return { ok: true, env: Object.keys(env).length > 0 ? env : undefined };
 };
 
-const formatStdioEnvValue = (value: string): string => {
-  if (value.length === 0) return "";
-  if (value.trim() === value && !/[\n\r\t"\\]/.test(value)) return value;
-  return `"${value
+const formatDoubleQuotedStdioEnvValue = (value: string): string =>
+  `"${value
     .replace(/\\/g, "\\\\")
     .replace(/\n/g, "\\n")
     .replace(/\r/g, "\\r")
     .replace(/\t/g, "\\t")
     .replace(/"/g, '\\"')}"`;
+
+const canFormatStdioEnvValueBare = (value: string): boolean => {
+  if (/[\n\r\t"\\]/.test(value)) return false;
+  const parsed = parseStdioEnv(`A=${value}`);
+  return parsed.ok && parsed.env?.A === value;
+};
+
+const formatStdioEnvValue = (value: string): string => {
+  if (value.length === 0) return "";
+  if (canFormatStdioEnvValueBare(value)) return value;
+  return formatDoubleQuotedStdioEnvValue(value);
 };
 
 export const stdioEnvToText = (env: Record<string, string> | undefined): string => {

--- a/packages/plugins/mcp/src/sdk/stdio-config.ts
+++ b/packages/plugins/mcp/src/sdk/stdio-config.ts
@@ -121,13 +121,17 @@ const normalizeEnv = (
 
 export const canonicalizeStdioConfig = (
   config: Pick<McpStdioIntegrationConfig, "command" | "args" | "env" | "cwd">,
-): CanonicalStdioConfig => ({
-  transport: "stdio",
-  command: config.command.trim(),
-  ...(config.args !== undefined && config.args.length > 0 ? { args: [...config.args] } : {}),
-  ...(normalizeEnv(config.env) !== undefined ? { env: normalizeEnv(config.env) } : {}),
-  ...(config.cwd !== undefined && config.cwd.trim().length > 0 ? { cwd: config.cwd.trim() } : {}),
-});
+): CanonicalStdioConfig => {
+  const env = normalizeEnv(config.env);
+  const cwd = config.cwd?.trim();
+  return {
+    transport: "stdio",
+    command: config.command.trim(),
+    ...(config.args !== undefined && config.args.length > 0 ? { args: [...config.args] } : {}),
+    ...(env !== undefined ? { env } : {}),
+    ...(cwd !== undefined && cwd.length > 0 ? { cwd } : {}),
+  };
+};
 
 export const canonicalizeStdioDraft = (input: {
   readonly command: string;

--- a/packages/plugins/mcp/src/sdk/stdio-config.ts
+++ b/packages/plugins/mcp/src/sdk/stdio-config.ts
@@ -20,16 +20,105 @@ export type CanonicalStdioConfig = {
 
 const STDIO_ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
+const decodeDoubleQuotedEscape = (escaped: string): string => {
+  if (escaped === "n") return "\n";
+  if (escaped === "r") return "\r";
+  if (escaped === "t") return "\t";
+  return escaped;
+};
+
 export const parseStdioArgs = (raw: string): string[] => {
-  if (!raw.trim()) return [];
   const args: string[] = [];
-  const regex = /[^\s"]+|"([^"]*)"/g;
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(raw)) !== null) {
-    args.push(match[1] ?? match[0]);
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let inToken = false;
+
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw.charAt(index);
+
+    if (quote === "'") {
+      if (char === "'") {
+        quote = null;
+      } else {
+        current += char;
+      }
+      inToken = true;
+      continue;
+    }
+
+    if (quote === '"') {
+      if (char === '"') {
+        quote = null;
+      } else if (char === "\\") {
+        const next = raw[index + 1];
+        if (next === undefined) {
+          current += "\\";
+        } else if (["\\", '"', "n", "r", "t"].includes(next)) {
+          current += decodeDoubleQuotedEscape(next);
+          index += 1;
+        } else {
+          current += `\\${next}`;
+          index += 1;
+        }
+      } else {
+        current += char;
+      }
+      inToken = true;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (inToken) {
+        args.push(current);
+        current = "";
+        inToken = false;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      quote = char;
+      inToken = true;
+      continue;
+    }
+
+    if (char === "\\") {
+      const next = raw[index + 1];
+      if (
+        next !== undefined &&
+        (/\s/.test(next) || next === "'" || next === '"' || next === "\\")
+      ) {
+        current += next;
+        index += 1;
+      } else {
+        current += char;
+      }
+      inToken = true;
+      continue;
+    }
+
+    current += char;
+    inToken = true;
   }
+
+  if (inToken) args.push(current);
   return args;
 };
+
+const canFormatStdioArgBare = (value: string): boolean => /^[^\s'"\\]+$/.test(value);
+
+export const stdioArgsToText = (args: readonly string[] | undefined): string =>
+  (args ?? [])
+    .map((value) => {
+      if (canFormatStdioArgBare(value)) return value;
+      return `"${value
+        .replace(/\\/g, "\\\\")
+        .replace(/\n/g, "\\n")
+        .replace(/\r/g, "\\r")
+        .replace(/\t/g, "\\t")
+        .replace(/"/g, '\\"')}"`;
+    })
+    .join(" ");
 
 const parseStdioEnvValue = (raw: string): string => {
   const trimmed = raw.trim();
@@ -39,12 +128,9 @@ const parseStdioEnvValue = (raw: string): string => {
   if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
     return trimmed
       .slice(1, -1)
-      .replace(/\\([\\nrt"])/g, (_match: string, escaped: string): string => {
-        if (escaped === "n") return "\n";
-        if (escaped === "r") return "\r";
-        if (escaped === "t") return "\t";
-        return escaped;
-      });
+      .replace(/\\([\\nrt"])/g, (_match: string, escaped: string): string =>
+        decodeDoubleQuotedEscape(escaped),
+      );
   }
   return trimmed;
 };
@@ -90,7 +176,7 @@ const formatDoubleQuotedStdioEnvValue = (value: string): string =>
     .replace(/"/g, '\\"')}"`;
 
 const canFormatStdioEnvValueBare = (value: string): boolean => {
-  if (/[\n\r\t"\\]/.test(value)) return false;
+  if (/[\n\r\t"]/.test(value)) return false;
   const parsed = parseStdioEnv(`A=${value}`);
   return parsed.ok && parsed.env?.A === value;
 };


### PR DESCRIPTION
Makes stdio MCP sources editable via the GUI. 

I tried to match existing behavior so it should be pretty intuitive. After a STDIO MCP config is changed, we validate first with tool discovery (require successful `tools/list`), then if that succeeds run a transaction to remove policies scoped to the integration and update the integration config. 

For legacy configs where there are no visible connections, connection `org/default` with template `none` and empty values will be created.