### PR TITLE
Separate catalog-sync status from connection health

### DIFF
--- a/.changeset/health-sync-separation.md
+++ b/.changeset/health-sync-separation.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Separate catalog-sync status from connection health: a failed tool sync no longer writes a degraded health verdict, and is instead tracked per connection with a consecutive-failure count surfaced as a muted stale-catalog hint.

--- a/apps/cloud/drizzle/0010_stormy_red_ghost.sql
+++ b/apps/cloud/drizzle/0010_stormy_red_ghost.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "connection" ADD COLUMN "tools_sync_error" json;--> statement-breakpoint
+UPDATE "connection"
+SET "last_health" = NULL
+WHERE "last_health"::jsonb ->> 'detail' LIKE 'Tool sync failing%';

--- a/apps/cloud/drizzle/meta/0010_snapshot.json
+++ b/apps/cloud/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1296 @@
+{
+  "id": "071638eb-2126-4eb4-bd0e-54aaeb22449a",
+  "prevId": "b07ddbda-be11-4679-9f00-16d1b3b5e879",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "memberships_account_id_accounts_id_fk": {
+          "name": "memberships_account_id_accounts_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_organization_id_organizations_id_fk": {
+          "name": "memberships_organization_id_organizations_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "memberships_account_id_organization_id_pk": {
+          "name": "memberships_account_id_organization_id_pk",
+          "columns": ["account_id", "organization_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blob": {
+      "name": "blob",
+      "schema": "",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "blob_id_uidx": {
+          "name": "blob_id_uidx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_label": {
+          "name": "identity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_health": {
+          "name": "last_health",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools_synced_at": {
+          "name": "tools_synced_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools_sync_error": {
+          "name": "tools_sync_error",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client": {
+          "name": "oauth_client",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_owner": {
+          "name": "oauth_client_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_item_id": {
+          "name": "refresh_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token_url": {
+          "name": "oauth_token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_state": {
+          "name": "provider_state",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "connection_uidx": {
+          "name": "connection_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.definition": {
+      "name": "definition",
+      "schema": "",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "definition_uidx": {
+          "name": "definition_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration": {
+      "name": "integration",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health_check": {
+          "name": "health_check",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_revised_at": {
+          "name": "config_revised_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_remove": {
+          "name": "can_remove",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "can_refresh": {
+          "name": "can_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "integration_uidx": {
+          "name": "integration_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant": {
+          "name": "grant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_item_id": {
+          "name": "client_secret_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_integration": {
+          "name": "origin_integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_issuer": {
+          "name": "origin_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_client_uidx": {
+          "name": "oauth_client_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_session": {
+      "name": "oauth_session",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_slug": {
+          "name": "client_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pkce_verifier": {
+          "name": "pkce_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_label": {
+          "name": "identity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_session_uidx": {
+          "name": "oauth_session_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugin_storage": {
+      "name": "plugin_storage",
+      "schema": "",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection": {
+          "name": "collection",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "plugin_storage_uidx": {
+          "name": "plugin_storage_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.private_executor_cloud_settings": {
+      "name": "private_executor_cloud_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool": {
+      "name": "tool",
+      "schema": "",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tool_uidx": {
+          "name": "tool_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_policy": {
+      "name": "tool_policy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tool_policy_uidx": {
+          "name": "tool_policy_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/cloud/drizzle/meta/_journal.json
+++ b/apps/cloud/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1783025157233,
       "tag": "0009_true_lake",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1783476768302,
+      "tag": "0010_stormy_red_ghost",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/cloud/src/db/executor-schema.ts
+++ b/apps/cloud/src/db/executor-schema.ts
@@ -45,6 +45,7 @@ export const connection = pgTable(
     description: text("description"),
     last_health: json("last_health"),
     tools_synced_at: bigint("tools_synced_at", { mode: "bigint" }),
+    tools_sync_error: json("tools_sync_error"),
     oauth_client: text("oauth_client"),
     oauth_client_owner: text("oauth_client_owner"),
     refresh_item_id: text("refresh_item_id"),
@@ -164,7 +165,9 @@ export const definition = pgTable(
     integration: varchar("integration", { length: 255 }).notNull(),
     connection: varchar("connection", { length: 255 }).notNull(),
     plugin_id: text("plugin_id").notNull(),
-    name: varchar("name", { length: 255 }).notNull(),
+    // Manually widened from the generated varchar(255): definition names can
+    // exceed 255 chars (see dd7aaf60). Re-apply if the generator overwrites.
+    name: text("name").notNull(),
     schema: json("schema").notNull(),
     created_at: timestamp("created_at").notNull(),
     row_id: varchar("row_id", { length: 255 })

--- a/apps/host-cloudflare/src/db/data-migrations.test.ts
+++ b/apps/host-cloudflare/src/db/data-migrations.test.ts
@@ -239,6 +239,7 @@ describe("runCloudflareDataMigrations", () => {
       const d1 = makeFakeD1(db.client);
       expect(yield* Effect.promise(() => runCloudflareDataMigrations(d1, bucket))).toEqual([
         "2026-06-20-google-openapi-ownership",
+        "2026-07-07-clear-tool-sync-health-verdicts",
       ]);
       expect(yield* Effect.promise(() => runCloudflareDataMigrations(d1, bucket))).toEqual([]);
 
@@ -280,6 +281,7 @@ describe("runCloudflareDataMigrations", () => {
       const d1 = makeFakeD1(db.client);
       expect(yield* Effect.promise(() => runCloudflareDataMigrations(d1, bucket))).toEqual([
         "2026-06-20-google-openapi-ownership",
+        "2026-07-07-clear-tool-sync-health-verdicts",
       ]);
       expect(yield* Effect.promise(() => runCloudflareDataMigrations(d1, bucket))).toEqual([]);
 

--- a/apps/host-cloudflare/src/db/data-migrations.ts
+++ b/apps/host-cloudflare/src/db/data-migrations.ts
@@ -4,6 +4,7 @@ import type { D1Database, D1DatabaseSession, R2Bucket } from "@cloudflare/worker
 import {
   DataMigrationError,
   runSqliteDataMigrations,
+  toolSyncHealthCleanupDataMigration,
   type SqliteDataMigration,
   type SqliteDataMigrationClient,
 } from "@executor-js/sdk";
@@ -170,6 +171,9 @@ const cloudflareDataMigrations = (bucket: R2Bucket | undefined): readonly Sqlite
         yield* googleOpenApiOwnershipDataMigration.run(client);
       }),
   },
+  // Clear "Tool sync failing" pseudo-verdicts out of last_health (sync status
+  // moved to its own tools_sync_error column; mirrors cloud drizzle 0010).
+  toolSyncHealthCleanupDataMigration,
 ];
 
 export const runCloudflareDataMigrations = (

--- a/apps/host-selfhost/src/db/data-migrations.ts
+++ b/apps/host-selfhost/src/db/data-migrations.ts
@@ -5,7 +5,11 @@
 // renamed.
 // ---------------------------------------------------------------------------
 
-import { sqliteDataMigration, type SqliteDataMigration } from "@executor-js/sdk";
+import {
+  sqliteDataMigration,
+  toolSyncHealthCleanupDataMigration,
+  type SqliteDataMigration,
+} from "@executor-js/sdk";
 import { runSqliteAuthConfigMigration } from "@executor-js/sdk/http-auth";
 import {
   openApiOutputSchemaDataMigration,
@@ -31,4 +35,7 @@ export const selfHostDataMigrations: readonly SqliteDataMigration[] = [
   openApiSpecBlobDataMigration,
   graphqlIntrospectionBlobDataMigration,
   googleOpenApiOwnershipDataMigration,
+  // Clear "Tool sync failing" pseudo-verdicts out of last_health (sync status
+  // moved to its own tools_sync_error column; mirrors cloud drizzle 0010).
+  toolSyncHealthCleanupDataMigration,
 ];

--- a/apps/local/src/db/data-migrations.ts
+++ b/apps/local/src/db/data-migrations.ts
@@ -9,6 +9,7 @@ import {
   Effect,
   oauthClientGcSqliteMigration,
   sqliteDataMigration,
+  toolSyncHealthCleanupDataMigration,
   type SqliteDataMigration,
 } from "@executor-js/sdk";
 import { runSqliteAuthConfigMigration } from "@executor-js/sdk/http-auth";
@@ -45,4 +46,7 @@ export const localDataMigrations: readonly SqliteDataMigration[] = [
   // GC dead DCR oauth_client rows (old always-register duplicates) and backfill
   // the surviving DCR rows' origin_issuer from token_url (issue #1120, Part C).
   oauthClientGcSqliteMigration,
+  // Clear "Tool sync failing" pseudo-verdicts out of last_health (sync status
+  // moved to its own tools_sync_error column; mirrors cloud drizzle 0010).
+  toolSyncHealthCleanupDataMigration,
 ];

--- a/e2e/scenarios/mcp-catalog-sync.test.ts
+++ b/e2e/scenarios/mcp-catalog-sync.test.ts
@@ -491,6 +491,26 @@ scenario(
           "beta",
         ]);
 
+        // The failed sync is recorded as CATALOG trouble on the connection —
+        // a consecutive-failure record with the plugin's reason — and stays
+        // out of `lastHealth`: a down server says nothing about the credential.
+        const findRow = Effect.map(client.connections.list({ query: {} }), (rows) =>
+          rows.find((c) => String(c.integration) === String(slug) && String(c.name) === "main"),
+        );
+        const duringOutage = yield* findRow;
+        expect(
+          duringOutage?.toolsSyncError?.failures,
+          "the failed sync starts a failure streak",
+        ).toBe(1);
+        expect(
+          duringOutage?.toolsSyncError?.reason,
+          "the sync-error record carries the plugin's reason",
+        ).toContain("MCP");
+        expect(
+          duringOutage?.lastHealth ?? null,
+          "a sync failure never forges a health verdict",
+        ).toBeNull();
+
         // The server comes back CHANGED (beta retired, delta added). A
         // refresh now converges to the live catalog.
         fixture.setDead(false);
@@ -503,6 +523,13 @@ scenario(
           "refresh after recovery serves the server's new catalog",
         ).toEqual(["alpha", "delta"]);
         expect(yield* toolNames, "the read surface follows").toEqual(["alpha", "delta"]);
+
+        // Recovery clears the streak: the sync-error record is gone.
+        const afterRecovery = yield* findRow;
+        expect(
+          afterRecovery?.toolsSyncError ?? null,
+          "a successful sync clears the failure record",
+        ).toBeNull();
       }).pipe(
         Effect.ensuring(
           Effect.gen(function* () {

--- a/packages/core/api/src/connections/api.ts
+++ b/packages/core/api/src/connections/api.ts
@@ -26,6 +26,7 @@ import {
   Owner,
   ProviderItemId,
   ProviderKey,
+  ToolsSyncError,
 } from "@executor-js/sdk/shared";
 
 // ---------------------------------------------------------------------------
@@ -61,6 +62,9 @@ const ConnectionResponse = Schema.Struct({
   // Last persisted health-check verdict (written by every checkHealth run),
   // so the list can show alive/expired at a glance without probing.
   lastHealth: Schema.NullOr(HealthCheckResult),
+  // Catalog-sync trouble (consecutive failed syncs + reason), independent of
+  // credential health. Null when the last sync was authoritative.
+  toolsSyncError: Schema.NullOr(ToolsSyncError),
 });
 
 const ToolResponse = Schema.Struct({

--- a/packages/core/api/src/handlers/connections.ts
+++ b/packages/core/api/src/handlers/connections.ts
@@ -29,6 +29,7 @@ const toResponse = (c: Connection) => ({
   oauthClientOwner: c.oauthClientOwner ?? null,
   oauthScope: c.oauthScope ?? null,
   lastHealth: c.lastHealth ?? null,
+  toolsSyncError: c.toolsSyncError ?? null,
 });
 
 const toolToResponse = (t: Tool) => ({

--- a/packages/core/sdk/src/connection.ts
+++ b/packages/core/sdk/src/connection.ts
@@ -9,6 +9,7 @@ import type {
   ProviderKey,
 } from "./ids";
 import type { HealthCheckResult, HealthCheckSpec } from "./health-check";
+import type { ToolsSyncError } from "./tools-sync";
 
 /* A Connection is THE saved credential — secret, account, and connection are one
  * concept — bound to exactly ONE integration (born wired; there is no unwired
@@ -56,8 +57,14 @@ export interface Connection {
   readonly oauthScope?: string | null;
   /** Last health-check verdict, persisted by every `checkHealth` run. Answers
    *  "has this expired?" at a glance in the connections list without probing.
-   *  Null/absent = never checked. */
+   *  Null/absent = never checked. Written by health probes ONLY — catalog-sync
+   *  trouble lives on `toolsSyncError`, never here. */
   readonly lastHealth?: HealthCheckResult | null;
+  /** Catalog-sync trouble: set when the last tool sync was non-authoritative
+   *  (source unreachable, spec unloadable), cleared by any successful sync.
+   *  Carries a consecutive-failure count so surfaces can debounce transient
+   *  blips (see `isToolsSyncStale`). Independent of credential health. */
+  readonly toolsSyncError?: ToolsSyncError | null;
 }
 
 /** Identify one connection — unique by (owner, integration, name). */

--- a/packages/core/sdk/src/connections.test.ts
+++ b/packages/core/sdk/src/connections.test.ts
@@ -416,9 +416,11 @@ describe("tool catalog sync safety", () => {
           });
 
           expect(tools.map((tool) => String(tool.name)).sort()).toEqual(["deploy", "list"]);
-          expect(connection?.lastHealth).toMatchObject({
-            status: "degraded",
-            detail: expect.stringContaining("authoritative empty catalog"),
+          // Sync trouble is recorded on its own column, never as a health verdict.
+          expect(connection?.lastHealth ?? null).toBeNull();
+          expect(connection?.toolsSyncError).toMatchObject({
+            failures: 1,
+            reason: expect.stringContaining("authoritative empty catalog"),
           });
         }),
       ),
@@ -477,7 +479,7 @@ describe("tool catalog sync safety", () => {
     ),
   );
 
-  it.effect("successful sync clears a prior tool-sync failure health record", () =>
+  it.effect("failed syncs extend a consecutive-failure streak; success clears it", () =>
     Effect.scoped(
       Effect.gen(function* () {
         let incomplete = false;
@@ -521,40 +523,41 @@ describe("tool catalog sync safety", () => {
           value: "secret-token",
         });
 
-        incomplete = true;
-        yield* Effect.promise(() =>
-          config.db.updateMany("connection", {
-            where: (b) => b.and(b("integration", "=", String(INTEG)), b("name", "=", "main")),
-            set: { tools_synced_at: null },
-          }),
-        );
-        yield* executor.tools.list({ integration: INTEG });
-        expect(
-          (yield* executor.connections.get({
+        const markStale = () =>
+          Effect.promise(() =>
+            config.db.updateMany("connection", {
+              where: (b) => b.and(b("integration", "=", String(INTEG)), b("name", "=", "main")),
+              set: { tools_synced_at: null },
+            }),
+          );
+        const getConnection = () =>
+          executor.connections.get({
             owner: "org",
             integration: INTEG,
             name: ConnectionName.make("main"),
-          }))?.lastHealth,
-        ).toMatchObject({
-          status: "degraded",
-          detail: expect.stringContaining("temporary catalog outage"),
-        });
+          });
 
-        incomplete = false;
-        yield* Effect.promise(() =>
-          config.db.updateMany("connection", {
-            where: (b) => b.and(b("integration", "=", String(INTEG)), b("name", "=", "main")),
-            set: { tools_synced_at: null },
-          }),
-        );
+        // Two failed syncs in a row: the streak counts up, health is untouched.
+        incomplete = true;
+        yield* markStale();
         yield* executor.tools.list({ integration: INTEG });
-        const connection = yield* executor.connections.get({
-          owner: "org",
-          integration: INTEG,
-          name: ConnectionName.make("main"),
+        expect((yield* getConnection())?.toolsSyncError).toMatchObject({
+          failures: 1,
+          reason: expect.stringContaining("temporary catalog outage"),
         });
+        yield* markStale();
+        yield* executor.tools.list({ integration: INTEG });
+        const failing = yield* getConnection();
+        expect(failing?.toolsSyncError).toMatchObject({ failures: 2 });
+        expect(failing?.lastHealth ?? null).toBeNull();
 
-        expect(connection?.lastHealth).toBeNull();
+        // One successful sync ends the streak entirely.
+        incomplete = false;
+        yield* markStale();
+        yield* executor.tools.list({ integration: INTEG });
+        const recovered = yield* getConnection();
+        expect(recovered?.toolsSyncError ?? null).toBeNull();
+        expect(recovered?.lastHealth ?? null).toBeNull();
       }),
     ),
   );

--- a/packages/core/sdk/src/core-schema.ts
+++ b/packages/core/sdk/src/core-schema.ts
@@ -176,6 +176,13 @@ export const coreTables = defineTables({
       // Epoch ms of the last tool (re)production for this connection. Stale
       // vs the integration's `config_revised_at` → re-produced on next read.
       tools_synced_at: nullableBigintColumn("tools_synced_at"),
+      // Catalog-sync trouble (ToolsSyncError JSON: at, failures, reason) —
+      // deliberately a SEPARATE column from `last_health`: a failed sync means
+      // the tool catalog may be stale, not that the credential is unhealthy,
+      // and the two signals must never overwrite each other. Null = the last
+      // sync was authoritative. Cleared by any successful sync; failures
+      // increment a consecutive count so display can debounce transients.
+      tools_sync_error: nullableJsonColumn("tools_sync_error"),
       oauth_client: nullableTextColumn("oauth_client"),
       // The OWNER of `oauth_client` (a Personal connection may be minted through
       // a shared Workspace app), set together with `oauth_client`; null for

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -29,6 +29,7 @@ import type {
 } from "./connection";
 import { HealthCheckResult, HealthCheckSpec } from "./health-check";
 import type { HealthCheckCandidate } from "./health-check";
+import { ToolsSyncError } from "./tools-sync";
 import {
   coreSchema,
   isToolPolicyAction,
@@ -546,6 +547,7 @@ const rowToIntegrationRecord = (
 });
 
 const decodeLastHealth = Schema.decodeUnknownOption(HealthCheckResult);
+const decodeToolsSyncError = Schema.decodeUnknownOption(ToolsSyncError);
 const decodeHealthCheckSpec = Schema.decodeUnknownOption(HealthCheckSpec);
 
 const rowToConnection = (row: ConnectionRow): Connection => {
@@ -567,6 +569,7 @@ const rowToConnection = (row: ConnectionRow): Connection => {
       row.oauth_client_owner == null ? null : (String(row.oauth_client_owner) as Owner),
     oauthScope: row.oauth_scope == null ? null : String(row.oauth_scope),
     lastHealth: Option.getOrNull(decodeLastHealth(row.last_health)),
+    toolsSyncError: Option.getOrNull(decodeToolsSyncError(row.tools_sync_error)),
   };
 };
 
@@ -2002,16 +2005,17 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     // Per-connection tool production
     // ------------------------------------------------------------------
 
-    const toolSyncHealthDetailPrefix = "Tool sync failing";
-
-    const toolSyncHealth = (reason: string): HealthCheckResult => ({
-      status: "degraded",
-      checkedAt: Date.now(),
-      detail: `${toolSyncHealthDetailPrefix}: ${reason}`,
-    });
-
-    const syncHealthReason = (result: ResolveToolsResult): string =>
+    const syncErrorReason = (result: ResolveToolsResult): string =>
       result.incompleteReason ?? "plugin returned an incomplete tool catalog";
+
+    /** The next `tools_sync_error` value after one more failed sync: first
+     *  failure starts the streak, subsequent ones extend it. The count is what
+     *  lets display debounce a single transient blip while a genuine outage
+     *  (several consecutive failures) still surfaces. */
+    const nextToolsSyncError = (row: ConnectionRow | null, reason: string): ToolsSyncError => {
+      const prior = row ? Option.getOrNull(decodeToolsSyncError(row.tools_sync_error)) : null;
+      return { at: Date.now(), failures: (prior?.failures ?? 0) + 1, reason };
+    };
 
     const produceConnectionTools = (
       integrationRow: IntegrationRow,
@@ -2037,30 +2041,26 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             b("integration", "=", String(ref.integration)),
             b("name", "=", String(ref.name)),
           );
-        const isToolSyncHealth = (health: HealthCheckResult | null): boolean =>
-          health?.detail?.startsWith(toolSyncHealthDetailPrefix) === true;
-        const syncedSet = (row: ConnectionRow | null) => {
-          const health = row ? Option.getOrNull(decodeLastHealth(row.last_health)) : null;
-          return isToolSyncHealth(health)
-            ? { tools_synced_at: Date.now(), last_health: null, updated_at: new Date() }
-            : { tools_synced_at: Date.now() };
-        };
         // Every exit stamps the sync time — including the cleanup paths that
         // produce zero tools — so the stale-catalog check (`config_revised_at`
         // vs `tools_synced_at`) doesn't re-attempt this connection per read.
-        // Successful syncs also clear stale sync-failure health records, while
-        // preserving genuine health-check outcomes.
+        // A successful (authoritative) sync also ends any failure streak.
+        // `last_health` is NEVER written here: catalog sync and credential
+        // health are separate signals with separate columns.
         const stampSynced = (row: ConnectionRow | null) =>
           core.updateMany("connection", {
             where: connectionWhere,
-            set: syncedSet(row),
+            set:
+              row != null && row.tools_sync_error != null
+                ? { tools_synced_at: Date.now(), tools_sync_error: null, updated_at: new Date() }
+                : { tools_synced_at: Date.now() },
           });
-        const stampSyncedWithHealth = (reason: string) =>
+        const stampSyncedWithError = (row: ConnectionRow | null, reason: string) =>
           core.updateMany("connection", {
             where: connectionWhere,
             set: {
               tools_synced_at: Date.now(),
-              last_health: toolSyncHealth(reason),
+              tools_sync_error: nextToolsSyncError(row, reason),
               updated_at: new Date(),
             },
           });
@@ -2124,9 +2124,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           // Keep the existing catalog — replacing it would wipe working tools
           // over a transient outage — and stamp the sync time anyway so a down
           // server isn't re-dialed on every read; the freshness TTL re-attempts
-          // later.
-          const reason = syncHealthReason(result);
-          yield* stampSyncedWithHealth(reason);
+          // later. The failure is recorded on `tools_sync_error` (extending
+          // the consecutive-failure streak), NOT as a health verdict.
+          const reason = syncErrorReason(result);
+          yield* stampSyncedWithError(existingRow, reason);
           yield* Effect.logWarning("executor tool sync preserved catalog", {
             reason,
             integration: String(ref.integration),
@@ -2141,7 +2142,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           if (keptRows.length > 0) {
             const reason =
               "background tool sync produced an authoritative empty catalog for a connection with existing tools";
-            yield* stampSyncedWithHealth(reason);
+            yield* stampSyncedWithError(existingRow, reason);
             yield* Effect.logWarning("executor tool sync preserved nonzero catalog", {
               reason,
               integration: String(ref.integration),

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -124,6 +124,9 @@ export {
   rankResponseSample,
 } from "./health-check";
 
+// Tool-sync status vocabulary (catalog freshness, distinct from health).
+export { ToolsSyncError, TOOLS_SYNC_STALE_THRESHOLD, isToolsSyncStale } from "./tools-sync";
+
 // Core schema.
 export {
   bigintColumn,
@@ -401,6 +404,7 @@ export {
   oauthClientGcSqliteMigration,
   runSqliteOAuthClientGcMigration,
 } from "./sqlite-oauth-client-gc-migration";
+export { toolSyncHealthCleanupDataMigration } from "./sqlite-tool-sync-health-migration";
 export {
   authToolFailure,
   type AuthToolFailureCode,

--- a/packages/core/sdk/src/shared.ts
+++ b/packages/core/sdk/src/shared.ts
@@ -124,6 +124,9 @@ export {
   rankResponseSample,
 } from "./health-check";
 
+// Tool-sync status vocabulary (catalog freshness, distinct from health).
+export { ToolsSyncError, TOOLS_SYNC_STALE_THRESHOLD, isToolsSyncStale } from "./tools-sync";
+
 // OAuth wire contracts (data + tagged errors; the flow impl is server-only).
 export {
   type OAuthGrant,

--- a/packages/core/sdk/src/sqlite-tool-sync-health-migration.ts
+++ b/packages/core/sdk/src/sqlite-tool-sync-health-migration.ts
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------------------
+// libSQL boot migration: clear tool-sync verdicts out of `last_health`.
+//
+// Before catalog-sync status got its own column (`tools_sync_error`), a failed
+// tool sync wrote a degraded HealthCheckResult onto `last_health` with a
+// "Tool sync failing: …" detail. Those rows were never credential-health
+// verdicts, so they are cleared rather than translated: the next sync failure
+// (if the trouble is real and persistent) re-records itself on the new column
+// with an honest consecutive-failure count. The cloud arm is drizzle 0010.
+// Idempotent: the predicate matches nothing after the first run.
+// ---------------------------------------------------------------------------
+
+import { sqliteDataMigration, type SqliteDataMigration } from "./sqlite-data-migrations";
+
+export const toolSyncHealthCleanupDataMigration: SqliteDataMigration = sqliteDataMigration(
+  "2026-07-07-clear-tool-sync-health-verdicts",
+  async (client) => {
+    // Legacy databases can predate the `last_health` column entirely (it is
+    // boot-ensured later in startup, after data migrations run) — nothing to
+    // clean there.
+    const columns = await client.execute(`PRAGMA table_info('connection')`);
+    if (!columns.rows.some((row) => row.name === "last_health")) return;
+    await client.execute(
+      `UPDATE connection
+       SET last_health = NULL
+       WHERE last_health IS NOT NULL
+         AND json_valid(last_health)
+         AND json_extract(last_health, '$.detail') LIKE 'Tool sync failing%'`,
+    );
+  },
+);

--- a/packages/core/sdk/src/tools-sync.test.ts
+++ b/packages/core/sdk/src/tools-sync.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { isToolsSyncStale, TOOLS_SYNC_STALE_THRESHOLD } from "./tools-sync";
+
+describe("isToolsSyncStale", () => {
+  it("no record (last sync authoritative) is not stale", () => {
+    expect(isToolsSyncStale(null)).toBe(false);
+    expect(isToolsSyncStale(undefined)).toBe(false);
+  });
+
+  it("a below-threshold streak is a blip, not staleness", () => {
+    expect(isToolsSyncStale({ at: 1, failures: 1, reason: "server down" })).toBe(false);
+    expect(
+      isToolsSyncStale({ at: 1, failures: TOOLS_SYNC_STALE_THRESHOLD - 1, reason: "server down" }),
+    ).toBe(false);
+  });
+
+  it("a streak at or past the threshold is stale", () => {
+    expect(
+      isToolsSyncStale({ at: 1, failures: TOOLS_SYNC_STALE_THRESHOLD, reason: "server down" }),
+    ).toBe(true);
+    expect(
+      isToolsSyncStale({
+        at: 1,
+        failures: TOOLS_SYNC_STALE_THRESHOLD + 5,
+        reason: "server down",
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/core/sdk/src/tools-sync.ts
+++ b/packages/core/sdk/src/tools-sync.ts
@@ -1,0 +1,42 @@
+// ---------------------------------------------------------------------------
+// @executor-js/sdk tool-sync status vocabulary (browser-safe).
+//
+// Catalog sync and credential health are DIFFERENT signals. A health check
+// answers "is this credential alive, and whose account is it?" — an explicit,
+// authenticated probe whose verdict lives in `last_health`. A failed tool sync
+// answers a different question entirely: "is this connection's tool catalog
+// current?" — the credential may be perfectly fine while an MCP server is
+// slow to dial once, or a spec blob read hiccups.
+//
+// Conflating them (writing a degraded health verdict on sync failure) painted
+// amber DEGRADED across whole connection lists over single transient blips.
+// So sync trouble is persisted on its own column (`tools_sync_error`), with a
+// consecutive-failure count: the raw data is honest (every failure recorded,
+// success clears it), and DISPLAY applies the debounce — a stale-catalog hint
+// renders only after several consecutive failures, and always as a muted
+// annotation, never as the credential-health treatment.
+// ---------------------------------------------------------------------------
+
+import { Schema } from "effect";
+
+export const ToolsSyncError = Schema.Struct({
+  /** Epoch ms of the most recent failed sync attempt. */
+  at: Schema.Number,
+  /** How many syncs in a row have failed. Reset to zero (the whole record is
+   *  cleared) by any successful sync. */
+  failures: Schema.Number,
+  /** Human-readable reason from the plugin (why the listing was
+   *  non-authoritative), for operators. */
+  reason: Schema.String,
+});
+export type ToolsSyncError = typeof ToolsSyncError.Type;
+
+/** How many consecutive sync failures before the UI hints that the catalog
+ *  may be stale. At the 15-minute background sweep TTL this is ~45 minutes of
+ *  continuous failure — a real outage, not a blip. */
+export const TOOLS_SYNC_STALE_THRESHOLD = 3;
+
+/** Whether a connection's sync state should surface as "catalog may be stale".
+ *  Null (last sync authoritative) or a below-threshold streak render nothing. */
+export const isToolsSyncStale = (error: ToolsSyncError | null | undefined): boolean =>
+  error != null && error.failures >= TOOLS_SYNC_STALE_THRESHOLD;

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -1168,8 +1168,17 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
     // -----------------------------------------------------------------------
     resolveTools: ({ config, connection, template, getValues, httpClientLayer }) =>
       Effect.gen(function* () {
+        // Each non-authoritative exit says WHY: the reason is persisted on the
+        // connection's sync-error record, and a bare "incomplete" told
+        // operators nothing about whether the server was down, auth-walled,
+        // or misconfigured.
+        const incomplete = (reason: string) => ({
+          tools: [] as readonly ToolDef[],
+          incomplete: true,
+          incompleteReason: reason,
+        });
         const parsed = parseMcpIntegrationConfig(config);
-        if (!parsed) return { tools: [] as readonly ToolDef[], incomplete: true };
+        if (!parsed) return incomplete("MCP integration config could not be parsed.");
 
         // Discovery tolerates unresolved credentials (an open server lists
         // tools unauthenticated; a bad value just yields zero tools).
@@ -1188,18 +1197,27 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           Effect.result,
         );
 
-        const manifest = Result.isSuccess(built)
-          ? yield* discoverTools(built.success).pipe(
-              Effect.map((m) => ({ ok: true as const, manifest: m })),
-              Effect.catch(() => Effect.succeed({ ok: false as const, manifest: null })),
-              Effect.withSpan("mcp.plugin.discover_tools", {
-                attributes: { "mcp.connection.name": String(connection.name) },
-              }),
-            )
-          : { ok: false as const, manifest: null };
+        if (!Result.isSuccess(built)) {
+          // buildConnectorInput fails only with McpConnectionError: `message`
+          // is a typed field, not an unknown-error read.
+          return incomplete(`MCP connector could not be constructed: ${built.failure.message}`);
+        }
+        const manifest = yield* discoverTools(built.success).pipe(
+          Effect.map((m) => ({ ok: true as const, manifest: m, reason: null })),
+          Effect.catchTag("McpToolDiscoveryError", (cause) =>
+            Effect.succeed({
+              ok: false as const,
+              manifest: null,
+              reason: `${cause.stage === "connect" ? "server connect failed" : "tool listing failed"}: ${cause.message}`,
+            }),
+          ),
+          Effect.withSpan("mcp.plugin.discover_tools", {
+            attributes: { "mcp.connection.name": String(connection.name) },
+          }),
+        );
 
         if (!manifest.ok || !manifest.manifest) {
-          return { tools: [] as readonly ToolDef[], incomplete: true };
+          return incomplete(`MCP tool discovery failed: ${manifest.reason ?? "unknown cause"}`);
         }
         return { tools: manifest.manifest.tools.map(toToolDef) };
       }).pipe(
@@ -1207,7 +1225,11 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           attributes: { "mcp.connection.name": String(connection.name) },
         }),
       ) as Effect.Effect<
-        { readonly tools: readonly ToolDef[]; readonly incomplete?: boolean },
+        {
+          readonly tools: readonly ToolDef[];
+          readonly incomplete?: boolean;
+          readonly incompleteReason?: string;
+        },
         StorageFailure
       >,
 

--- a/packages/plugins/openapi/src/sdk/spec-blob.test.ts
+++ b/packages/plugins/openapi/src/sdk/spec-blob.test.ts
@@ -234,9 +234,11 @@ describe("OpenAPI plugin — spec blob storage", () => {
             beforeTools.map((tool) => String(tool.name)).sort(),
           );
           expect(afterDefinitions).toHaveLength(beforeDefinitions.length);
-          expect(connection?.lastHealth).toMatchObject({
-            status: "degraded",
-            detail: expect.stringContaining("OpenAPI spec could not be parsed"),
+          // Sync trouble is catalog metadata, not a health verdict.
+          expect(connection?.lastHealth ?? null).toBeNull();
+          expect(connection?.toolsSyncError).toMatchObject({
+            failures: 1,
+            reason: expect.stringContaining("OpenAPI spec could not be parsed"),
           });
         }),
       ),
@@ -307,9 +309,11 @@ describe("OpenAPI plugin — spec blob storage", () => {
           beforeTools.map((tool) => String(tool.name)).sort(),
         );
         expect(afterDefinitions).toHaveLength(beforeDefinitions.length);
-        expect(connection?.lastHealth).toMatchObject({
-          status: "degraded",
-          detail: expect.stringContaining("OpenAPI spec blob could not be loaded"),
+        // Sync trouble is catalog metadata, not a health verdict.
+        expect(connection?.lastHealth ?? null).toBeNull();
+        expect(connection?.toolsSyncError).toMatchObject({
+          failures: 1,
+          reason: expect.stringContaining("OpenAPI spec blob could not be loaded"),
         });
       }),
     ),

--- a/packages/react/src/api/atoms.tsx
+++ b/packages/react/src/api/atoms.tsx
@@ -367,6 +367,7 @@ export const addConnectionOptimistic = Atom.family((owner: Owner) =>
             oauthClientOwner: null,
             oauthScope: null,
             lastHealth: null,
+            toolsSyncError: null,
           };
           return [optimistic, ...rows];
         }),

--- a/packages/react/src/components/accounts-section.tsx
+++ b/packages/react/src/components/accounts-section.tsx
@@ -2,7 +2,12 @@ import { useEffect, useMemo, useState } from "react";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
-import { IntegrationSlug, type Connection, type Owner } from "@executor-js/sdk/shared";
+import {
+  IntegrationSlug,
+  isToolsSyncStale,
+  type Connection,
+  type Owner,
+} from "@executor-js/sdk/shared";
 import type { IntegrationAccountHandoff } from "@executor-js/sdk/client";
 import { toast } from "sonner";
 
@@ -148,6 +153,19 @@ function AccountRow(props: {
         {needsReconsent ? (
           <CardStackEntryDescription className="mt-1 text-xs text-muted-foreground">
             This connection wasn't granted all the access this integration now needs.
+          </CardStackEntryDescription>
+        ) : null}
+        {isToolsSyncStale(connection.toolsSyncError) ? (
+          // Catalog freshness, NOT credential health: several consecutive tool
+          // syncs failed, so the tool list may be stale. Muted on purpose — the
+          // status dot above stays a pure credential-health signal.
+          <CardStackEntryDescription
+            className="mt-1 text-xs text-muted-foreground"
+            title={connection.toolsSyncError?.reason}
+          >
+            Tool list may be out of date: the last{" "}
+            {connection.toolsSyncError ? connection.toolsSyncError.failures : 0} sync attempts
+            failed.
           </CardStackEntryDescription>
         ) : null}
       </CardStackEntryContent>

--- a/packages/react/src/components/integration-health-summary.tsx
+++ b/packages/react/src/components/integration-health-summary.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
-import type { Connection, IntegrationSlug } from "@executor-js/sdk/shared";
+import { isToolsSyncStale, type Connection, type IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { connectionsForIntegrationAtom } from "../api/atoms";
 import {
@@ -18,6 +18,11 @@ import { useConnectionsHealth } from "../lib/use-connection-health";
 // each one stale-while-revalidate (the same automatic check the detail page
 // runs), and collapses them to the worst status: one dot per row, however
 // many connections back it.
+//
+// The verdict is CREDENTIAL health only. Catalog-sync trouble (tool listing
+// failing) is a different, lesser signal: it renders as a muted "SYNC" tag,
+// never as the amber/red health treatment, and only after several consecutive
+// failures (see isToolsSyncStale) so a single transient blip shows nothing.
 //
 // Display only: the row is a Link, so this must never introduce a nested
 // interactive element. No connections, or nothing but never-probed ones,
@@ -42,23 +47,37 @@ export function IntegrationHealthSummary(props: { readonly integration: Integrat
   const status = worstHealthStatus(
     connections.map((connection) => probeFor(connection)?.status ?? "unknown"),
   );
-  // No connections, or none has ever produced a verdict: no signal, no dot.
-  if (status === null) return null;
+  const syncStale = connections.find((connection) => isToolsSyncStale(connection.toolsSyncError));
+  // No connections, or no signal of either kind: render nothing at all.
+  if (status === null && syncStale === undefined) return null;
 
-  const label = HEALTH_STATUS_LABEL[status];
+  const label = status === null ? null : HEALTH_STATUS_LABEL[status];
   return (
-    <span className="flex shrink-0 items-center gap-1.5" title={`Status: ${label}`}>
-      {status !== "healthy" ? (
+    <span
+      className="flex shrink-0 items-center gap-1.5"
+      title={label === null ? undefined : `Status: ${label}`}
+    >
+      {syncStale !== undefined ? (
+        <span
+          className="font-mono text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground"
+          title={`Tool list may be out of date: ${syncStale.toolsSyncError?.reason ?? "sync failing"}`}
+        >
+          Sync
+        </span>
+      ) : null}
+      {status !== null && status !== "healthy" ? (
         <span
           className={`font-mono text-[11px] font-medium uppercase tracking-[0.08em] ${HEALTH_TEXT_CLASS[status]}`}
         >
           {label}
         </span>
       ) : null}
-      <span
-        aria-label={`Status: ${label}`}
-        className={`size-2 rounded-full ${HEALTH_INDICATOR_COLOR[status].dot}`}
-      />
+      {status !== null ? (
+        <span
+          aria-label={`Status: ${label}`}
+          className={`size-2 rounded-full ${HEALTH_INDICATOR_COLOR[status].dot}`}
+        />
+      ) : null}
     </span>
   );
 }

--- a/packages/react/src/lib/use-connection-health.ts
+++ b/packages/react/src/lib/use-connection-health.ts
@@ -2,9 +2,9 @@
 // render a connection's health (the detail page's AccountRow and the
 // integrations-list summary), and both must revalidate the same way: render
 // the persisted `lastHealth` verdict instantly, then probe in the background
-// unless the verdict is healthy and fresh. Keeping the guard, the `ifStaleMs`
-// semantics, and the freshness window here means the two surfaces cannot
-// drift apart.
+// unless the verdict is steady (healthy/unknown) and fresh. Keeping the guard,
+// the `ifStaleMs` semantics, and the freshness window here means the two
+// surfaces cannot drift apart.
 
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { RegistryContext, useAtomSet } from "@effect/atom-react";
@@ -26,21 +26,26 @@ const connectionParams = (connection: Connection) => ({
   name: connection.name,
 });
 
-/** Whether a persisted verdict may render as-is without a background probe.
- *  Healthy-and-fresh renders untouched. Everything else revalidates: stale or
- *  never-checked for obvious reasons, and NON-healthy always; an expired dot
- *  is exactly the verdict the user is waiting to see change, so recovery must
- *  show on the next load, not after the freshness window. */
-const healthyAndFresh = (last: HealthCheckResult | null | undefined): boolean =>
-  last?.status === "healthy" && Date.now() - last.checkedAt < HEALTH_REVALIDATE_MS;
+/** Statuses that may render as-is when fresh, without a background probe.
+ *  `healthy` for the obvious reason; `unknown` because it means "no health
+ *  check configured / not supported" — re-probing it on every page load just
+ *  rewrites the same verdict (row churn, no signal). Expired/degraded always
+ *  revalidate: a bad dot is exactly the verdict the user is waiting to see
+ *  change, so recovery must show on the next load, not after the window. */
+const STEADY_STATUSES: ReadonlySet<HealthStatus> = new Set(["healthy", "unknown"]);
 
-/** The revalidation query: a healthy (but stale) verdict defers to the
+const steadyAndFresh = (last: HealthCheckResult | null | undefined): boolean =>
+  last != null &&
+  STEADY_STATUSES.has(last.status) &&
+  Date.now() - last.checkedAt < HEALTH_REVALIDATE_MS;
+
+/** The revalidation query: a steady (but stale) verdict defers to the
  *  server-enforced window so N open tabs can't stampede the upstream; a
- *  missing or non-healthy verdict forces a fresh probe. */
+ *  missing or non-steady verdict forces a fresh probe. */
 const revalidateQuery = (
   last: HealthCheckResult | null | undefined,
 ): { readonly ifStaleMs?: number } =>
-  last?.status === "healthy" ? { ifStaleMs: HEALTH_REVALIDATE_MS } : {};
+  last != null && STEADY_STATUSES.has(last.status) ? { ifStaleMs: HEALTH_REVALIDATE_MS } : {};
 
 /**
  * Imperative invalidation of the connections cache for one owner. The server
@@ -86,7 +91,7 @@ export function useConnectionHealth(connection: Connection): {
   useEffect(() => {
     if (revalidated.current) return;
     const last = connection.lastHealth;
-    if (healthyAndFresh(last)) return;
+    if (steadyAndFresh(last)) return;
     revalidated.current = true;
     void doCheck({
       params: connectionParams(connection),
@@ -148,7 +153,7 @@ export function useConnectionsHealth(
       const key = probeKey(connection);
       if (revalidated.current.has(key)) continue;
       const last = connection.lastHealth;
-      if (healthyAndFresh(last)) continue;
+      if (steadyAndFresh(last)) continue;
       revalidated.current.add(key);
       void doCheck({
         params: connectionParams(connection),


### PR DESCRIPTION
A failed tool sync used to persist a degraded health verdict on the connection, so a single transient MCP dial failure or spec-blob read hiccup showed DEGRADED across whole connection lists even though the credentials were fine.

Sync trouble now lives on its own connection column (`tools_sync_error`) with a consecutive-failure count and the plugin's reason; `last_health` is written by health probes only. The UI debounces the sync signal (3+ consecutive failures) and shows it as a muted stale-catalog hint instead of the health treatment. Existing tool-sync pseudo-verdicts are cleared by migration (cloud drizzle 0010 + a stamped sqlite data migration), and fresh `unknown` verdicts no longer re-probe on every page load.