### PR TITLE
Surface GraphQL introspection errors instead of silent empty tool sets

### DIFF
--- a/e2e/scenarios/graphql-invalid-format-no-tools.test.ts
+++ b/e2e/scenarios/graphql-invalid-format-no-tools.test.ts
@@ -1,0 +1,152 @@
+// Cross-target (browser): GraphQL source discovery can fail silently at
+// connection-create time. The UI journey is the reported shape: add a GraphQL
+// integration, connect an API key, see the connection saved, then land on an
+// empty Tools tab with no visible error explaining that introspection failed.
+//
+// This is intentionally a passing repro of the current buggy behavior. The
+// upstream is a local node:http server that returns HTTP 200 with a GraphQL-ish
+// body in the wrong introspection shape: `{ "data": {} }`.
+import { randomBytes } from "node:crypto";
+import { createServer } from "node:http";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
+
+const api = composePluginApi([] as const);
+
+const serveInvalidIntrospectionGraphqlApi = () =>
+  Effect.acquireRelease(
+    Effect.callback<{ readonly endpoint: string; readonly close: () => void }>((resume) => {
+      const server = createServer((request, response) => {
+        if (request.method === "POST" && (request.url ?? "").startsWith("/graphql")) {
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end(JSON.stringify({ data: {} }));
+          return;
+        }
+        response.writeHead(404, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: "not_found" }));
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        const port = typeof address === "object" && address ? address.port : 0;
+        resume(
+          Effect.succeed({
+            endpoint: `http://127.0.0.1:${port}/graphql`,
+            close: () => {
+              server.close();
+              server.closeAllConnections();
+            },
+          }),
+        );
+      });
+    }),
+    (server) => Effect.sync(server.close),
+  );
+
+scenario(
+  "GraphQL · invalid introspection format creates a connected account with zero tools",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const { client } = yield* Api;
+      const upstream = yield* serveInvalidIntrospectionGraphqlApi();
+      const identity = yield* target.newIdentity();
+      const apiClient = yield* client(api, identity);
+
+      const slug = IntegrationSlug.make(`graphql_invalid_format_${randomBytes(4).toString("hex")}`);
+
+      yield* Effect.ensuring(
+        Effect.gen(function* () {
+          yield* browser.session(identity, async ({ page, step }) => {
+            await step("Open the Add GraphQL integration form", async () => {
+              await page.goto("/integrations/add/graphql", { waitUntil: "networkidle" });
+              await page.getByRole("heading", { name: "Add GraphQL integration" }).waitFor();
+            });
+
+            await step(
+              "Enter the endpoint and declare Linear-style Authorization API key auth",
+              async () => {
+                await page
+                  .getByPlaceholder("https://api.example.com/graphql")
+                  .fill(upstream.endpoint);
+                await page.getByPlaceholder("e.g. Shopify API").fill("Linear GraphQL");
+                await page.locator("input").nth(2).fill(String(slug));
+                await page.getByRole("button", { name: "Add method" }).click();
+                await page.getByText("Method 1").waitFor();
+                await page.getByLabel("Header name").fill("Authorization");
+                await page.getByLabel("Prefix").fill("");
+              },
+            );
+
+            await step("Add the GraphQL integration without add-time introspection", async () => {
+              await page.getByRole("button", { name: "Add integration" }).click();
+              await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, { timeout: 30_000 });
+              await page.getByText("Connections").first().waitFor();
+              await page.getByText("No connections yet").waitFor();
+            });
+
+            await step("Connect an API key", async () => {
+              await page.getByRole("button", { name: "Add connection" }).first().click();
+              const dialog = page.getByRole("dialog");
+              await dialog.getByRole("tab", { name: "API key (Authorization)" }).waitFor();
+              await dialog.getByRole("textbox", { name: "Authorization" }).fill("lin_test_key");
+              await dialog.getByRole("button", { name: "Continue" }).click();
+              await dialog.getByLabel("Display name").fill("main");
+              await dialog.getByRole("button", { name: "Add connection" }).click();
+              await page.getByText("Connection added").waitFor({ timeout: 30_000 });
+              await page.getByText("main").waitFor();
+            });
+
+            await step("Open Tools and observe the empty catalog with no error", async () => {
+              await page.getByRole("tab", { name: "Tools" }).click();
+              await page.getByPlaceholder("Filter 0 tools…").waitFor({ timeout: 30_000 });
+              await page.getByText("No tools available").first().waitFor();
+
+              const visibleErrorCopy = await page
+                .getByText(
+                  /Failed to add connection|Failed to load tools|Introspection failed|invalid shape/i,
+                )
+                .count();
+              expect(
+                visibleErrorCopy,
+                "no visible error explains the invalid introspection body",
+              ).toBe(0);
+            });
+          });
+
+          const connections = yield* apiClient.connections.list({
+            query: { integration: slug },
+          });
+          expect(connections.length, "the connection was created").toBe(1);
+
+          const tools = yield* apiClient.tools.list({ query: { integration: slug } });
+          expect(tools, "the connected GraphQL integration produced no tools").toEqual([]);
+        }),
+        Effect.gen(function* () {
+          const connections = yield* apiClient.connections
+            .list({ query: { integration: slug } })
+            .pipe(Effect.catch(() => Effect.succeed([])));
+          for (const connection of connections) {
+            yield* apiClient.connections
+              .remove({
+                params: {
+                  owner: connection.owner,
+                  integration: slug,
+                  name: ConnectionName.make(String(connection.name)),
+                },
+              })
+              .pipe(Effect.ignore);
+          }
+          yield* apiClient.integrations.remove({ params: { slug } }).pipe(Effect.ignore);
+        }),
+      );
+    }),
+  ),
+);

--- a/e2e/scenarios/graphql-invalid-format-no-tools.test.ts
+++ b/e2e/scenarios/graphql-invalid-format-no-tools.test.ts
@@ -1,46 +1,73 @@
-// Cross-target (browser): GraphQL source discovery can fail silently at
-// connection-create time. The UI journey is the reported shape: add a GraphQL
-// integration, connect an API key, see the connection saved, then land on an
-// empty Tools tab with no visible error explaining that introspection failed.
-//
-// This is intentionally a passing repro of the current buggy behavior. The
-// upstream is a local node:http server that returns HTTP 200 with a GraphQL-ish
-// body in the wrong introspection shape: `{ "data": {} }`.
+// Cross-target (browser): adding a GraphQL source whose endpoint responds with
+// a non-introspection shape must fail at credential validation with actionable
+// copy, not save a connected account with an empty tool catalog.
 import { randomBytes } from "node:crypto";
-import { createServer } from "node:http";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 
 import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
-import { ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+import { ConnectionName, IntegrationSlug, type Owner } from "@executor-js/sdk/shared";
+import type { Page } from "playwright";
 
 import { scenario } from "../src/scenario";
 import { Api, Browser, Target } from "../src/services";
 
 const api = composePluginApi([] as const);
+const VALID_KEY = "lin_test_key";
+const INVALID_SHAPE_COPY =
+  "The endpoint responded, but not with a GraphQL schema. Check that the URL points to a GraphQL endpoint";
 
-const serveInvalidIntrospectionGraphqlApi = () =>
+const healthyIntrospection = {
+  data: {
+    __schema: {
+      queryType: { name: "Query" },
+      mutationType: null,
+      types: [
+        {
+          kind: "OBJECT",
+          name: "Query",
+          description: null,
+          fields: [
+            {
+              name: "viewer",
+              description: "Current viewer",
+              args: [],
+              type: { kind: "SCALAR", name: "String", ofType: null },
+            },
+          ],
+          inputFields: null,
+          enumValues: null,
+        },
+        {
+          kind: "SCALAR",
+          name: "String",
+          description: null,
+          fields: null,
+          inputFields: null,
+          enumValues: null,
+        },
+      ],
+    },
+  },
+};
+
+const closeServer = (server: ReturnType<typeof createServer>) => {
+  server.close();
+  server.closeAllConnections();
+};
+
+const serveGraphqlApi = (handler: (request: IncomingMessage, response: ServerResponse) => void) =>
   Effect.acquireRelease(
     Effect.callback<{ readonly endpoint: string; readonly close: () => void }>((resume) => {
-      const server = createServer((request, response) => {
-        if (request.method === "POST" && (request.url ?? "").startsWith("/graphql")) {
-          response.writeHead(200, { "content-type": "application/json" });
-          response.end(JSON.stringify({ data: {} }));
-          return;
-        }
-        response.writeHead(404, { "content-type": "application/json" });
-        response.end(JSON.stringify({ error: "not_found" }));
-      });
+      const server = createServer(handler);
       server.listen(0, "127.0.0.1", () => {
         const address = server.address();
         const port = typeof address === "object" && address ? address.port : 0;
         resume(
           Effect.succeed({
             endpoint: `http://127.0.0.1:${port}/graphql`,
-            close: () => {
-              server.close();
-              server.closeAllConnections();
-            },
+            close: () => closeServer(server),
           }),
         );
       });
@@ -48,8 +75,102 @@ const serveInvalidIntrospectionGraphqlApi = () =>
     (server) => Effect.sync(server.close),
   );
 
+const serveInvalidIntrospectionGraphqlApi = () =>
+  serveGraphqlApi((request, response) => {
+    if (request.method === "POST" && (request.url ?? "").startsWith("/graphql")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ data: {} }));
+      return;
+    }
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: "not_found" }));
+  });
+
+const serveHealthyGraphqlApi = () =>
+  serveGraphqlApi((request, response) => {
+    if (request.method !== "POST" || !(request.url ?? "").startsWith("/graphql")) {
+      response.writeHead(404, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: "not_found" }));
+      return;
+    }
+    if (request.headers.authorization !== VALID_KEY) {
+      response.writeHead(401, { "content-type": "application/json" });
+      response.end(JSON.stringify({ errors: [{ message: "Unauthorized" }] }));
+      return;
+    }
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      const query = body.includes("__schema") ? "__schema" : "viewer";
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify(
+          query === "__schema" ? healthyIntrospection : { data: { viewer: "Test User" } },
+        ),
+      );
+    });
+  });
+
+type CleanupClient = {
+  readonly connections: {
+    readonly list: (input: {
+      readonly query: { readonly integration: IntegrationSlug };
+    }) => Effect.Effect<
+      readonly { readonly owner: Owner; readonly name: ConnectionName | string }[],
+      unknown
+    >;
+    readonly remove: (input: {
+      readonly params: {
+        readonly owner: Owner;
+        readonly integration: IntegrationSlug;
+        readonly name: ConnectionName;
+      };
+    }) => Effect.Effect<unknown, unknown>;
+  };
+  readonly integrations: {
+    readonly remove: (input: {
+      readonly params: { readonly slug: IntegrationSlug };
+    }) => Effect.Effect<unknown, unknown>;
+  };
+};
+
+const cleanupIntegration = (apiClient: CleanupClient, slug: IntegrationSlug) =>
+  Effect.gen(function* () {
+    const connections = yield* apiClient.connections
+      .list({ query: { integration: slug } })
+      .pipe(Effect.catch(() => Effect.succeed([])));
+    for (const connection of connections) {
+      yield* apiClient.connections
+        .remove({
+          params: {
+            owner: connection.owner,
+            integration: slug,
+            name: ConnectionName.make(String(connection.name)),
+          },
+        })
+        .pipe(Effect.ignore);
+    }
+    yield* apiClient.integrations.remove({ params: { slug } }).pipe(Effect.ignore);
+  });
+
+const fillGraphqlSourceForm = async (
+  page: Page,
+  input: { readonly endpoint: string; readonly slug: IntegrationSlug; readonly name: string },
+) => {
+  await page.getByPlaceholder("https://api.example.com/graphql").fill(input.endpoint);
+  await page.getByPlaceholder("e.g. Shopify API").fill(input.name);
+  await page.locator("input").nth(2).fill(String(input.slug));
+  await page.getByRole("button", { name: "Add method" }).click();
+  await page.getByText("Method 1").waitFor();
+  await page.getByLabel("Header name").fill("Authorization");
+  await page.getByLabel("Prefix").fill("");
+};
+
 scenario(
-  "GraphQL · invalid introspection format creates a connected account with zero tools",
+  "GraphQL · invalid introspection format shows an actionable connection error",
   {},
   Effect.scoped(
     Effect.gen(function* () {
@@ -71,17 +192,13 @@ scenario(
             });
 
             await step(
-              "Enter the endpoint and declare Linear-style Authorization API key auth",
+              "Enter an invalid-shape endpoint with Authorization API key auth",
               async () => {
-                await page
-                  .getByPlaceholder("https://api.example.com/graphql")
-                  .fill(upstream.endpoint);
-                await page.getByPlaceholder("e.g. Shopify API").fill("Linear GraphQL");
-                await page.locator("input").nth(2).fill(String(slug));
-                await page.getByRole("button", { name: "Add method" }).click();
-                await page.getByText("Method 1").waitFor();
-                await page.getByLabel("Header name").fill("Authorization");
-                await page.getByLabel("Prefix").fill("");
+                await fillGraphqlSourceForm(page, {
+                  endpoint: upstream.endpoint,
+                  slug,
+                  name: "Linear GraphQL",
+                });
               },
             );
 
@@ -92,60 +209,116 @@ scenario(
               await page.getByText("No connections yet").waitFor();
             });
 
-            await step("Connect an API key", async () => {
+            await step("Try to connect an API key and see the schema-format error", async () => {
               await page.getByRole("button", { name: "Add connection" }).first().click();
               const dialog = page.getByRole("dialog");
               await dialog.getByRole("tab", { name: "API key (Authorization)" }).waitFor();
-              await dialog.getByRole("textbox", { name: "Authorization" }).fill("lin_test_key");
+              await dialog.getByRole("textbox", { name: "Authorization" }).fill(VALID_KEY);
               await dialog.getByRole("button", { name: "Continue" }).click();
-              await dialog.getByLabel("Display name").fill("main");
-              await dialog.getByRole("button", { name: "Add connection" }).click();
-              await page.getByText("Connection added").waitFor({ timeout: 30_000 });
-              await page.getByText("main").waitFor();
+              await dialog.getByRole("alert").getByText(INVALID_SHAPE_COPY).waitFor({
+                timeout: 30_000,
+              });
+              await dialog.getByRole("alert").getByText("https://api.linear.app/graphql").waitFor();
+              expect(await dialog.getByLabel("Display name").count()).toBe(0);
+              await dialog.getByRole("button", { name: "Cancel" }).click();
             });
 
-            await step("Open Tools and observe the empty catalog with no error", async () => {
+            await step("Open Tools and confirm there is no bare empty-tools state", async () => {
               await page.getByRole("tab", { name: "Tools" }).click();
-              await page.getByPlaceholder("Filter 0 tools…").waitFor({ timeout: 30_000 });
-              await page.getByText("No tools available").first().waitFor();
-
-              const visibleErrorCopy = await page
-                .getByText(
-                  /Failed to add connection|Failed to load tools|Introspection failed|invalid shape/i,
-                )
-                .count();
-              expect(
-                visibleErrorCopy,
-                "no visible error explains the invalid introspection body",
-              ).toBe(0);
+              await page.getByText("No tools yet").first().waitFor({ timeout: 30_000 });
+              expect(await page.getByText("No tools available").count()).toBe(0);
             });
           });
 
           const connections = yield* apiClient.connections.list({
             query: { integration: slug },
           });
-          expect(connections.length, "the connection was created").toBe(1);
+          expect(
+            connections.length,
+            "invalid credential validation did not save a connection",
+          ).toBe(0);
 
           const tools = yield* apiClient.tools.list({ query: { integration: slug } });
-          expect(tools, "the connected GraphQL integration produced no tools").toEqual([]);
+          expect(tools, "the invalid integration produced no tools").toEqual([]);
         }),
+        cleanupIntegration(apiClient, slug),
+      );
+    }),
+  ),
+);
+
+scenario(
+  "GraphQL · valid introspection connects healthy and generates tools",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const { client } = yield* Api;
+      const upstream = yield* serveHealthyGraphqlApi();
+      const identity = yield* target.newIdentity();
+      const apiClient = yield* client(api, identity);
+
+      const slug = IntegrationSlug.make(`graphql_valid_format_${randomBytes(4).toString("hex")}`);
+
+      yield* Effect.ensuring(
         Effect.gen(function* () {
-          const connections = yield* apiClient.connections
-            .list({ query: { integration: slug } })
-            .pipe(Effect.catch(() => Effect.succeed([])));
-          for (const connection of connections) {
-            yield* apiClient.connections
-              .remove({
-                params: {
-                  owner: connection.owner,
-                  integration: slug,
-                  name: ConnectionName.make(String(connection.name)),
-                },
-              })
-              .pipe(Effect.ignore);
-          }
-          yield* apiClient.integrations.remove({ params: { slug } }).pipe(Effect.ignore);
+          yield* browser.session(identity, async ({ page, step }) => {
+            await step("Open the Add GraphQL integration form", async () => {
+              await page.goto("/integrations/add/graphql", { waitUntil: "networkidle" });
+              await page.getByRole("heading", { name: "Add GraphQL integration" }).waitFor();
+            });
+
+            await step(
+              "Enter a valid GraphQL endpoint with Authorization API key auth",
+              async () => {
+                await fillGraphqlSourceForm(page, {
+                  endpoint: upstream.endpoint,
+                  slug,
+                  name: "Healthy GraphQL",
+                });
+              },
+            );
+
+            await step("Add the valid GraphQL integration", async () => {
+              await page.getByRole("button", { name: "Add integration" }).click();
+              await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, { timeout: 30_000 });
+              await page.getByText("Connections").first().waitFor();
+              await page.getByText("No connections yet").waitFor();
+            });
+
+            await step("Connect an API key and see the healthy schema check", async () => {
+              await page.getByRole("button", { name: "Add connection" }).first().click();
+              const dialog = page.getByRole("dialog");
+              await dialog.getByRole("tab", { name: "API key (Authorization)" }).waitFor();
+              await dialog.getByRole("textbox", { name: "Authorization" }).fill(VALID_KEY);
+              await dialog.getByRole("button", { name: "Continue" }).click();
+              await dialog.getByText("Healthy").waitFor({ timeout: 30_000 });
+              await dialog.getByText("GraphQL schema: Query").waitFor();
+              await dialog.getByLabel("Display name").fill("main");
+              await dialog.locator("button").filter({ hasText: "Add connection" }).click();
+              await page.getByText("Connection added").waitFor({ timeout: 30_000 });
+              await page.getByText("GraphQL schema: Query").waitFor();
+            });
+
+            await step("Open Tools and see generated GraphQL tools", async () => {
+              await page.getByRole("tab", { name: "Tools" }).click();
+              await page.getByPlaceholder("Filter 1 tools…").waitFor({ timeout: 30_000 });
+              await page.getByLabel("Filter tools").fill("viewer");
+              await page.getByText("viewer").first().waitFor();
+            });
+          });
+
+          const connections = yield* apiClient.connections.list({
+            query: { integration: slug },
+          });
+          expect(connections.length, "the valid connection was created").toBe(1);
+          expect(connections[0]?.lastHealth?.status).toBe("healthy");
+
+          const tools = yield* apiClient.tools.list({ query: { integration: slug } });
+          expect(tools.length, "the valid GraphQL integration produced tools").toBeGreaterThan(0);
         }),
+        cleanupIntegration(apiClient, slug),
       );
     }),
   ),

--- a/packages/plugins/graphql/src/sdk/errors.ts
+++ b/packages/plugins/graphql/src/sdk/errors.ts
@@ -6,6 +6,18 @@ export class GraphqlIntrospectionError extends Schema.TaggedErrorClass<GraphqlIn
   "GraphqlIntrospectionError",
   {
     message: Schema.String,
+    status: Schema.optional(Schema.Number),
+    reason: Schema.optional(
+      Schema.Literals([
+        "network",
+        "http",
+        "invalid-json",
+        "invalid-shape",
+        "missing-schema",
+        "graphql-errors",
+      ]),
+    ),
+    upstreamMessage: Schema.optional(Schema.String),
   },
 ) {}
 

--- a/packages/plugins/graphql/src/sdk/introspect.ts
+++ b/packages/plugins/graphql/src/sdk/introspect.ts
@@ -267,6 +267,7 @@ export const introspect = Effect.fn("GraphQL.introspect")(function* (
       () =>
         new GraphqlIntrospectionError({
           message: "Failed to reach GraphQL endpoint",
+          reason: "network",
         }),
     ),
   );
@@ -285,6 +286,9 @@ export const introspect = Effect.fn("GraphQL.introspect")(function* (
       message: upstreamMessage
         ? `Introspection failed with status ${response.status}: ${upstreamMessage}`
         : `Introspection failed with status ${response.status}`,
+      status: response.status,
+      reason: "http",
+      ...(upstreamMessage ? { upstreamMessage } : {}),
     });
   }
 
@@ -294,6 +298,8 @@ export const introspect = Effect.fn("GraphQL.introspect")(function* (
       () =>
         new GraphqlIntrospectionError({
           message: `Failed to parse introspection response as JSON`,
+          status: response.status,
+          reason: "invalid-json",
         }),
     ),
   );
@@ -303,22 +309,29 @@ export const introspect = Effect.fn("GraphQL.introspect")(function* (
       () =>
         new GraphqlIntrospectionError({
           message: "Introspection response has an invalid shape",
+          status: response.status,
+          reason: "invalid-shape",
         }),
     ),
   );
 
   if (json.errors && Array.isArray(json.errors) && json.errors.length > 0) {
-    const upstreamMessage = firstUpstreamErrorMessage(json);
+    const upstreamMessage = upstreamTextMessage(firstUpstreamErrorMessage(json) ?? "");
     return yield* new GraphqlIntrospectionError({
       message: upstreamMessage
         ? `Introspection returned ${json.errors.length} error(s): ${upstreamMessage}`
         : `Introspection returned ${json.errors.length} error(s)`,
+      status: response.status,
+      reason: "graphql-errors",
+      ...(upstreamMessage ? { upstreamMessage } : {}),
     });
   }
 
   if (!json.data?.__schema) {
     return yield* new GraphqlIntrospectionError({
       message: "Introspection response missing __schema",
+      status: response.status,
+      reason: "missing-schema",
     });
   }
 

--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -567,6 +567,200 @@ describe("graphqlPlugin real protocol server", () => {
       expect(names).toContain("mutation.setGreeting");
     }),
   );
+
+  it.effect("checkHealth reports healthy for an introspectable endpoint", () =>
+    Effect.gen(function* () {
+      const server = yield* serveGreetingServer;
+      const executor = yield* makeExecutor();
+
+      yield* executor.graphql.addIntegration({
+        endpoint: server.endpoint,
+        slug: "health_ok",
+      });
+
+      const result = yield* executor.connections.validate({
+        owner: "org",
+        integration: IntegrationSlug.make("health_ok"),
+        template: AuthTemplateSlug.make("none"),
+        value: "unused",
+      });
+
+      expect(result).toMatchObject({
+        status: "healthy",
+        httpStatus: 200,
+        identity: "GraphQL schema: Query",
+      });
+    }),
+  );
+
+  it.effect("checkHealth reports expired for an HTTP auth wall", () =>
+    Effect.gen(function* () {
+      const server = yield* serveGraphqlTestServer({
+        schema: makeGreetingGraphqlSchema(),
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(authorization === "lin_test_key"),
+        },
+      });
+      const executor = yield* makeExecutor();
+
+      yield* executor.graphql.addIntegration({
+        endpoint: server.endpoint,
+        slug: "health_http_auth",
+        authenticationTemplate: [
+          {
+            slug: "header",
+            kind: "apikey",
+            placements: [{ carrier: "header", name: "Authorization", prefix: "" }],
+          },
+        ],
+      });
+
+      const result = yield* executor.connections.validate({
+        owner: "org",
+        integration: IntegrationSlug.make("health_http_auth"),
+        template: AuthTemplateSlug.make("header"),
+        value: "wrong",
+      });
+
+      expect(result.status).toBe("expired");
+      expect(result.httpStatus).toBe(401);
+      expect(result.detail).toContain("The endpoint rejected the credential (401).");
+      expect(result.detail).toContain(
+        "raw key in the Authorization header without a Bearer prefix",
+      );
+      expect(result.detail).toContain("Upstream said: Unauthorized");
+    }),
+  );
+
+  it.effect("checkHealth includes GraphQL errors payloads in auth verdicts", () =>
+    Effect.gen(function* () {
+      const server = yield* serveTestHttpApp(() =>
+        Effect.succeed(
+          HttpServerResponse.jsonUnsafe({
+            errors: [{ message: "Unauthorized: invalid API key" }],
+          }),
+        ),
+      );
+      const executor = yield* makeExecutor();
+
+      yield* executor.graphql.addIntegration({
+        endpoint: server.url("/graphql"),
+        slug: "health_graphql_auth",
+      });
+
+      const result = yield* executor.connections.validate({
+        owner: "org",
+        integration: IntegrationSlug.make("health_graphql_auth"),
+        template: AuthTemplateSlug.make("none"),
+        value: "unused",
+      });
+
+      expect(result.status).toBe("expired");
+      expect(result.httpStatus).toBe(200);
+      expect(result.detail).toContain("The endpoint rejected the credential.");
+      expect(result.detail).toContain("Upstream said: Unauthorized: invalid API key");
+    }),
+  );
+
+  it.effect("checkHealth reports degraded for an invalid introspection shape", () =>
+    Effect.gen(function* () {
+      const server = yield* serveTestHttpApp(() =>
+        Effect.succeed(HttpServerResponse.jsonUnsafe({ data: {} })),
+      );
+      const executor = yield* makeExecutor();
+
+      yield* executor.graphql.addIntegration({
+        endpoint: server.url("/graphql"),
+        slug: "health_invalid_shape",
+      });
+
+      const result = yield* executor.connections.validate({
+        owner: "org",
+        integration: IntegrationSlug.make("health_invalid_shape"),
+        template: AuthTemplateSlug.make("none"),
+        value: "unused",
+      });
+
+      expect(result.status).toBe("degraded");
+      expect(result.httpStatus).toBe(200);
+      expect(result.detail).toBe(
+        "The endpoint responded, but not with a GraphQL schema. Check that the URL points to a GraphQL endpoint (for Linear: https://api.linear.app/graphql).",
+      );
+    }),
+  );
+
+  it.effect("checkHealth reports degraded for an unreachable endpoint", () =>
+    Effect.gen(function* () {
+      const executor = yield* makeExecutor();
+
+      yield* executor.graphql.addIntegration({
+        endpoint: "http://127.0.0.1:1/graphql",
+        slug: "health_unreachable",
+      });
+
+      const result = yield* executor.connections.validate({
+        owner: "org",
+        integration: IntegrationSlug.make("health_unreachable"),
+        template: AuthTemplateSlug.make("none"),
+        value: "unused",
+      });
+
+      expect(result.status).toBe("degraded");
+      expect(result.detail).toBe(
+        "We couldn't reach the GraphQL endpoint. Check that the URL is correct and reachable, then try again.",
+      );
+    }),
+  );
+
+  it.effect(
+    "resolveTools returns incomplete and keeps existing tools after introspection fails",
+    () =>
+      Effect.gen(function* () {
+        const goodServer = yield* serveGreetingServer;
+        const badServer = yield* serveTestHttpApp(() =>
+          Effect.succeed(HttpServerResponse.jsonUnsafe({ data: {} })),
+        );
+        const executor = yield* makeExecutor();
+
+        yield* executor.graphql.addIntegration({
+          endpoint: goodServer.endpoint,
+          slug: "incomplete_refresh",
+        });
+        yield* createOrgConnection(executor, {
+          integration: "incomplete_refresh",
+          name: "main",
+          template: "none",
+          value: "unused",
+        });
+
+        const initialTools = yield* executor.tools.list();
+        expect(
+          initialTools
+            .filter((tool) => String(tool.integration) === "incomplete_refresh")
+            .map((tool) => String(tool.name)),
+        ).toEqual(expect.arrayContaining(["query.hello", "mutation.setGreeting"]));
+
+        yield* executor.graphql.configure("incomplete_refresh", {
+          endpoint: badServer.url("/graphql"),
+        });
+        const refreshed = yield* executor.connections.refresh({
+          owner: "org",
+          integration: IntegrationSlug.make("incomplete_refresh"),
+          name: ConnectionName.make("main"),
+        });
+
+        expect(refreshed.map((tool) => String(tool.name))).toEqual(
+          expect.arrayContaining(["query.hello", "mutation.setGreeting"]),
+        );
+        const keptTools = yield* executor.tools.list();
+        expect(
+          keptTools
+            .filter((tool) => String(tool.integration) === "incomplete_refresh")
+            .map((tool) => String(tool.name)),
+        ).toEqual(expect.arrayContaining(["query.hello", "mutation.setGreeting"]));
+      }),
+  );
 });
 
 describe("graphqlPlugin", () => {

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -11,9 +11,12 @@ import {
   IntegrationSlug,
   mergeAuthTemplates,
   sha256Hex,
+  StorageError,
   ToolName,
   ToolResult,
   type AuthMethodDescriptor,
+  type HealthCheckCandidate,
+  type HealthCheckResult,
   type IntegrationConfig,
   type IntegrationRecord,
   type PluginCtx,
@@ -44,6 +47,7 @@ import {
 import { extract } from "./extract";
 import {
   GraphqlAuthRequiredError,
+  GraphqlExtractionError,
   GraphqlIntrospectionError,
   GraphqlInvocationError,
 } from "./errors";
@@ -76,12 +80,132 @@ const decodeGraphqlErrorsBody = Schema.decodeUnknownOption(GraphqlErrorsBody);
 const decodeGraphqlErrors = (errors: unknown): readonly unknown[] | undefined =>
   Option.getOrUndefined(decodeGraphqlErrorsBody(errors));
 
+const encodeJsonString = Schema.encodeUnknownSync(Schema.UnknownFromJsonString);
+const parseUrlOption = Option.liftThrowable((value: string) => new URL(value));
+
 const extractGraphqlErrorMessage = (errors: readonly unknown[]): string | undefined =>
   errors
     .map((error) => Option.getOrUndefined(decodeGraphqlErrorBody(error))?.message)
     .find((message) => message !== undefined && message.length > 0);
 
 const GRAPHQL_PLUGIN_ID = "graphql";
+const GRAPHQL_HEALTH_OPERATION = "__schema";
+const GRAPHQL_HEALTH_CHECK = { operation: GRAPHQL_HEALTH_OPERATION };
+const GRAPHQL_HEALTH_CANDIDATE: HealthCheckCandidate = {
+  operation: GRAPHQL_HEALTH_OPERATION,
+  method: "post",
+  requiredArgCount: 0,
+  destructive: false,
+  summary: "Introspect the GraphQL schema",
+};
+const GRAPHQL_INVALID_SCHEMA_DETAIL =
+  "The endpoint responded, but not with a GraphQL schema. Check that the URL points to a GraphQL endpoint (for Linear: https://api.linear.app/graphql).";
+const GRAPHQL_AUTH_DETAIL =
+  "Check the API key and auth method. Some APIs, including Linear, expect the raw key in the Authorization header without a Bearer prefix.";
+const GRAPHQL_NETWORK_DETAIL =
+  "We couldn't reach the GraphQL endpoint. Check that the URL is correct and reachable, then try again.";
+const GRAPHQL_CONFIG_DETAIL =
+  "The GraphQL integration config is invalid. Edit the endpoint and auth method, then try again.";
+
+const truncateHealthDetail = (text: string, max = 240): string => {
+  const normalized = text.replaceAll(/\s+/g, " ").trim();
+  if (normalized.length <= max) return normalized;
+  return `${normalized.slice(0, max - 3)}...`;
+};
+
+const appendUpstreamMessage = (detail: string, message?: string): string =>
+  message && message.trim().length > 0
+    ? `${detail} Upstream said: ${truncateHealthDetail(message)}`
+    : detail;
+
+const isAuthMessage = (message: string | undefined): boolean =>
+  message !== undefined &&
+  /\b(auth|authoriz|unauthoriz|forbidden|permission|credential|token|api key|access denied)\b/i.test(
+    message,
+  );
+
+const missingCredentialVariables = (
+  method: GraphqlAuthMethod | undefined,
+  values: Record<string, string | null>,
+): readonly string[] => {
+  if (!method || method.kind === "none") return [];
+  const required =
+    method.kind === "oauth2" ? [TOKEN_VARIABLE] : requiredPlacementVariables(method.placements);
+  return required.filter((variable) => {
+    const value = values[variable];
+    return value == null || value.length === 0;
+  });
+};
+
+const healthFromIntrospectionError = (
+  error: GraphqlIntrospectionError,
+  checkedAt: number,
+): HealthCheckResult => {
+  const upstream = error.upstreamMessage;
+  const httpStatus = error.status;
+  const withStatus =
+    httpStatus === 401 || httpStatus === 403
+      ? `The endpoint rejected the credential (${httpStatus}).`
+      : "";
+  if (httpStatus === 401 || httpStatus === 403 || isAuthMessage(upstream)) {
+    return {
+      status: "expired",
+      ...(httpStatus !== undefined ? { httpStatus } : {}),
+      checkedAt,
+      detail: appendUpstreamMessage(
+        withStatus.length > 0
+          ? `${withStatus} ${GRAPHQL_AUTH_DETAIL}`
+          : `The endpoint rejected the credential. ${GRAPHQL_AUTH_DETAIL}`,
+        upstream,
+      ),
+    };
+  }
+
+  if (
+    error.reason === "invalid-json" ||
+    error.reason === "invalid-shape" ||
+    error.reason === "missing-schema"
+  ) {
+    return {
+      status: "degraded",
+      ...(httpStatus !== undefined ? { httpStatus } : {}),
+      checkedAt,
+      detail: GRAPHQL_INVALID_SCHEMA_DETAIL,
+    };
+  }
+
+  if (error.reason === "network") {
+    return {
+      status: "degraded",
+      checkedAt,
+      detail: GRAPHQL_NETWORK_DETAIL,
+    };
+  }
+
+  if (error.reason === "graphql-errors") {
+    return {
+      status: "degraded",
+      ...(httpStatus !== undefined ? { httpStatus } : {}),
+      checkedAt,
+      detail: appendUpstreamMessage(
+        "The endpoint returned GraphQL errors during schema introspection. Check that introspection is enabled and that the credential can read the schema.",
+        upstream,
+      ),
+    };
+  }
+
+  return {
+    status: "degraded",
+    ...(httpStatus !== undefined ? { httpStatus } : {}),
+    checkedAt,
+    detail: appendUpstreamMessage(
+      httpStatus !== undefined
+        ? `The GraphQL endpoint returned HTTP ${httpStatus} during schema introspection. Check the endpoint URL and upstream status, then try again.`
+        : "The GraphQL schema check failed. Check the endpoint URL and credential, then try again.",
+      upstream,
+    ),
+  };
+};
 
 // ---------------------------------------------------------------------------
 // Extension input shapes
@@ -538,7 +662,10 @@ const materializeOperations = (
     readonly values: Record<string, string | null>;
   },
   httpClientLayer: Layer.Layer<HttpClient.HttpClient>,
-): Effect.Effect<readonly StoredOperation[], GraphqlIntrospectionError | StorageFailure> =>
+): Effect.Effect<
+  readonly StoredOperation[],
+  GraphqlIntrospectionError | GraphqlExtractionError | StorageFailure
+> =>
   Effect.gen(function* () {
     // Render the exact method this connection references (we have its slug
     // here, unlike `resolveTools`) so an auth-required endpoint introspects.
@@ -565,15 +692,7 @@ const materializeOperations = (
             Object.keys(queryParams).length > 0 ? queryParams : undefined,
           ).pipe(Effect.provide(httpClientLayer));
 
-    const { result } = yield* extract(introspection).pipe(
-      Effect.catch(() =>
-        Effect.succeed({
-          result: { fields: [] as readonly ExtractedField[] },
-        } as {
-          readonly result: { readonly fields: readonly ExtractedField[] };
-        }),
-      ),
-    );
+    const { result } = yield* extract(introspection);
     const prepared = prepareOperations(result.fields, introspection);
     const stored = toStoredOperations(IntegrationSlug.make(integration), prepared);
     yield* ctx.storage.replaceOperations(integration, stored);
@@ -620,6 +739,86 @@ export const describeGraphqlIntegrationDisplay = (
   const config = Option.getOrUndefined(decodeGraphqlIntegrationConfigOption(record.config));
   return { url: config?.endpoint };
 };
+
+const checkGraphqlHealth = (input: {
+  readonly integration: IntegrationRecord;
+  readonly credential: {
+    readonly template: AuthTemplateSlug;
+    readonly values: Record<string, string | null>;
+  };
+  readonly spec?: { readonly operation: string };
+  readonly httpClientLayer: Layer.Layer<HttpClient.HttpClient>;
+}): Effect.Effect<HealthCheckResult, never> =>
+  Effect.gen(function* () {
+    const checkedAt = Date.now();
+    const spec = input.spec;
+    if (!spec) {
+      return {
+        status: "unknown",
+        checkedAt,
+        detail: "No health check configured.",
+      } satisfies HealthCheckResult;
+    }
+    if (spec.operation !== GRAPHQL_HEALTH_OPERATION) {
+      return {
+        status: "unknown",
+        checkedAt,
+        detail: `GraphQL health check operation "${spec.operation}" is not supported. Use ${GRAPHQL_HEALTH_OPERATION}.`,
+      } satisfies HealthCheckResult;
+    }
+
+    const decoded = yield* decodeGraphqlIntegrationConfig(input.integration.config).pipe(
+      Effect.option,
+    );
+    if (Option.isNone(decoded)) {
+      return {
+        status: "unknown",
+        checkedAt,
+        detail: GRAPHQL_CONFIG_DETAIL,
+      } satisfies HealthCheckResult;
+    }
+
+    const config = decoded.value;
+    const method = config.authenticationTemplate.find(
+      (candidate: GraphqlAuthMethod) => candidate.slug === String(input.credential.template),
+    );
+    const missing = missingCredentialVariables(method, input.credential.values);
+    if (missing.length > 0) {
+      return {
+        status: "expired",
+        checkedAt,
+        detail: `The connection has no credential value for ${missing.join(", ")}. Enter the API key, then try again.`,
+      } satisfies HealthCheckResult;
+    }
+
+    const auth = introspectHeadersForConnection(
+      config,
+      input.credential.values,
+      input.credential.template,
+    );
+    const result = yield* introspect(
+      config.endpoint,
+      Object.keys(auth.headers).length > 0 ? auth.headers : undefined,
+      Object.keys(auth.queryParams).length > 0 ? auth.queryParams : undefined,
+    ).pipe(
+      Effect.provide(input.httpClientLayer),
+      Effect.map((introspection) => ({ ok: true as const, introspection })),
+      Effect.catchTag("GraphqlIntrospectionError", (error) =>
+        Effect.succeed({ ok: false as const, error }),
+      ),
+    );
+
+    if (!result.ok) return healthFromIntrospectionError(result.error, checkedAt);
+
+    const queryType = result.introspection.__schema.queryType?.name ?? "Query";
+    return {
+      status: "healthy",
+      httpStatus: 200,
+      identity: `GraphQL schema: ${queryType}`,
+      checkedAt,
+      responseSample: [{ path: "__schema.queryType.name", value: queryType }],
+    } satisfies HealthCheckResult;
+  });
 
 // ---------------------------------------------------------------------------
 // Plugin extension
@@ -677,13 +876,16 @@ const makeGraphqlExtension = (ctx: PluginCtx<GraphqlStore>) => {
       // using that connection's credential.
       if (input.introspectionJson === undefined) {
         yield* ctx.transaction(
-          ctx.core.integrations.register({
-            slug,
-            name: baseConfig.name,
-            description: input.description?.trim() || baseConfig.name,
-            config: baseConfig,
-            canRemove: true,
-            canRefresh: true,
+          Effect.gen(function* () {
+            yield* ctx.core.integrations.register({
+              slug,
+              name: baseConfig.name,
+              description: input.description?.trim() || baseConfig.name,
+              config: baseConfig,
+              canRemove: true,
+              canRefresh: true,
+            });
+            yield* ctx.core.integrations.setHealthCheck(slug, GRAPHQL_HEALTH_CHECK);
           }),
         );
         return { slug: String(slug), name: baseConfig.name, toolCount: 0 };
@@ -701,7 +903,7 @@ const makeGraphqlExtension = (ctx: PluginCtx<GraphqlStore>) => {
       // written OUTSIDE the transaction — re-puts are idempotent and an
       // aborted register leaves only an unreferenced blob), and the config
       // carries only its hash.
-      const snapshotJson = JSON.stringify({ data: introspection });
+      const snapshotJson = encodeJsonString({ data: introspection });
       const introspectionHash = yield* sha256Hex(snapshotJson);
       const config = GraphqlIntegrationConfig.make({
         ...baseConfig,
@@ -729,6 +931,7 @@ const makeGraphqlExtension = (ctx: PluginCtx<GraphqlStore>) => {
             canRemove: true,
             canRefresh: true,
           });
+          yield* ctx.core.integrations.setHealthCheck(slug, GRAPHQL_HEALTH_CHECK);
         }),
       );
 
@@ -898,6 +1101,14 @@ export const graphqlPlugin = definePlugin((options?: GraphqlPluginOptions) => {
 
     describeAuthMethods: describeGraphqlAuthMethods,
     describeIntegrationDisplay: describeGraphqlIntegrationDisplay,
+    listHealthCheckCandidates: () => Effect.succeed([GRAPHQL_HEALTH_CANDIDATE]),
+    checkHealth: (input) =>
+      checkGraphqlHealth({
+        integration: input.integration,
+        credential: input.credential,
+        spec: input.spec,
+        httpClientLayer: options?.httpClientLayer ?? input.ctx.httpClientLayer,
+      }),
 
     staticSources: (self: GraphqlPluginExtension) => [
       {
@@ -975,34 +1186,59 @@ export const graphqlPlugin = definePlugin((options?: GraphqlPluginOptions) => {
       readonly httpClientLayer: Layer.Layer<HttpClient.HttpClient>;
     }) =>
       Effect.gen(function* () {
-        const decoded = yield* decodeGraphqlIntegrationConfig(config).pipe(Effect.option);
-        if (Option.isNone(decoded)) return { tools: [] };
-        const graphqlConfig = decoded.value;
+        const graphqlConfig = yield* decodeGraphqlIntegrationConfig(config).pipe(
+          Effect.mapError(
+            (cause) =>
+              new StorageError({
+                message: "Invalid GraphQL integration config",
+                cause,
+              }),
+          ),
+        );
         const introspectionJson = yield* loadIntrospectionJson(storage, graphqlConfig);
         // Live introspection (no stored snapshot) needs the connection's
         // credential inputs for auth-required endpoints; resolve them lazily.
-        const values =
+        const valuesResult =
           introspectionJson == null
             ? yield* getValues().pipe(
-                Effect.catch(() => Effect.succeed({} as Record<string, string | null>)),
+                Effect.map((values) => ({ ok: true as const, values })),
+                Effect.catch(() => Effect.succeed({ ok: false as const })),
               )
-            : ({} as Record<string, string | null>);
-        const introspection = yield* introspectForConnection(
+            : { ok: true as const, values: {} as Record<string, string | null> };
+        if (!valuesResult.ok) {
+          return { tools: [] as readonly ToolDef[], incomplete: true };
+        }
+        const introspectionResult = yield* introspectForConnection(
           graphqlConfig,
           introspectionJson,
-          values,
+          valuesResult.values,
           template,
           options?.httpClientLayer ?? httpClientLayer,
-        ).pipe(Effect.option);
-        if (Option.isNone(introspection)) return { tools: [] };
-        const extracted = yield* extract(introspection.value).pipe(Effect.option);
-        if (Option.isNone(extracted)) return { tools: [] };
-        const prepared = prepareOperations(extracted.value.result.fields, introspection.value);
+        ).pipe(
+          Effect.map((introspection) => ({ ok: true as const, introspection })),
+          Effect.catchTag("GraphqlIntrospectionError", () =>
+            Effect.succeed({ ok: false as const }),
+          ),
+        );
+        if (!introspectionResult.ok) {
+          return { tools: [] as readonly ToolDef[], incomplete: true };
+        }
+        const introspection = introspectionResult.introspection;
+        const extracted = yield* extract(introspection).pipe(
+          Effect.mapError(
+            (cause) =>
+              new StorageError({
+                message: "Failed to extract GraphQL tools from introspection schema",
+                cause,
+              }),
+          ),
+        );
+        const prepared = prepareOperations(extracted.result.fields, introspection);
         return {
           tools: buildToolDefs(prepared),
-          definitions: extracted.value.definitions,
+          definitions: extracted.definitions,
         };
-      }).pipe(Effect.catch(() => Effect.succeed({ tools: [] as readonly ToolDef[] }))),
+      }),
 
     // -----------------------------------------------------------------------
     // Invoke one of a connection's tools. Look up the operation by integration
@@ -1169,10 +1405,7 @@ export const graphqlPlugin = definePlugin((options?: GraphqlPluginOptions) => {
         const httpClientLayer = options?.httpClientLayer ?? ctx.httpClientLayer;
         const trimmed = url.trim();
         if (!trimmed) return null;
-        const parsed = yield* Effect.try({
-          try: () => new URL(trimmed),
-          catch: (cause) => cause,
-        }).pipe(Effect.option);
+        const parsed = parseUrlOption(trimmed);
         if (Option.isNone(parsed)) return null;
 
         const ok = yield* introspect(trimmed).pipe(

--- a/packages/react/src/components/accounts-section.tsx
+++ b/packages/react/src/components/accounts-section.tsx
@@ -95,6 +95,8 @@ function AccountRow(props: {
   const displayLabel = identity ?? String(connection.name);
 
   const expired = status === "expired";
+  const needsHealthAttention = status === "expired" || status === "degraded";
+  const healthDetail = needsHealthAttention ? probe?.detail : undefined;
 
   const handleCheck = async () => {
     if (checking) return;
@@ -129,9 +131,9 @@ function AccountRow(props: {
             className={`size-2 shrink-0 rounded-full ${indicator.dot}`}
           />
           <span className="truncate">{displayLabel}</span>
-          {expired ? (
-            <Badge variant="destructive" className="shrink-0">
-              Expired
+          {needsHealthAttention ? (
+            <Badge variant={expired ? "destructive" : "outline"} className="shrink-0">
+              {HEALTH_STATUS_LABEL[status]}
             </Badge>
           ) : null}
           {needsReconsent ? (
@@ -143,6 +145,11 @@ function AccountRow(props: {
         {connection.description && connection.description.length > 0 ? (
           <CardStackEntryDescription className="mt-1 text-xs">
             {connection.description}
+          </CardStackEntryDescription>
+        ) : null}
+        {healthDetail ? (
+          <CardStackEntryDescription className="mt-1 text-xs text-muted-foreground">
+            {healthDetail}
           </CardStackEntryDescription>
         ) : null}
         {needsReconsent ? (

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -1769,7 +1769,7 @@ function AddAccountModalView(props: AddAccountModalProps) {
   // Probe the pasted credential WITHOUT saving the connection. With a
   // configured check the panel's Check runs this directly; with none it runs
   // via handleCandidateProbe, which drafts a spec from the picked candidate.
-  const handleValidate = async (draftSpec?: HealthCheckSpec) => {
+  const handleValidate = async (draftSpec?: HealthCheckSpec): Promise<HealthCheckResult | null> => {
     const payloadOrigin = createCredentialPayloadOrigin({
       origin: credentialOrigin,
       inputs: credentialInputs,
@@ -1777,7 +1777,7 @@ function AddAccountModalView(props: AddAccountModalProps) {
       onePasswordItemId,
       singleInput,
     });
-    if (!method || payloadOrigin === null || validating) return;
+    if (!method || payloadOrigin === null || validating) return null;
     setValidating(true);
     const exit = await doValidate({
       payload: {
@@ -1794,7 +1794,7 @@ function AddAccountModalView(props: AddAccountModalProps) {
     if (Exit.isFailure(exit)) {
       setValidationResult(null);
       toast.error(messageFromExit(exit, "Couldn't check the key"));
-      return;
+      return null;
     }
     const result = exit.value;
     setValidationResult(result);
@@ -1828,19 +1828,46 @@ function AddAccountModalView(props: AddAccountModalProps) {
         return probedIdentity;
       });
     }
+    return result;
   };
 
   // No configured check: build a draft spec from the picked candidate and
   // probe with it.
-  const handleCandidateProbe = async () => {
-    if (!hcCandidateReady) return;
+  const handleCandidateProbe = async (): Promise<HealthCheckResult | null> => {
+    if (!hcCandidateReady) return null;
     const argEntries = Object.entries(hcArgs)
       .map(([key, value]) => [key, value.trim()] as const)
       .filter(([, value]) => value.length > 0);
-    await handleValidate({
+    return await handleValidate({
       operation: hcOperation,
       ...(argEntries.length > 0 ? { args: Object.fromEntries(argEntries) } : {}),
     });
+  };
+
+  const handleContinueFromValidate = async (): Promise<void> => {
+    if (credentialPayloadOrigin === null) {
+      setContinueError(singleInput ? "Enter the key first" : "Fill in every credential field");
+      return;
+    }
+    if (canCheckKey) {
+      if (!hasHealthCheck && !hcCandidateReady) {
+        setContinueError("Choose a check that can run before continuing");
+        return;
+      }
+      const result =
+        validationResult ??
+        (hasHealthCheck ? await handleValidate() : await handleCandidateProbe());
+      if (!result) return;
+      if (result.status !== "healthy") {
+        setContinueError(
+          result.detail ??
+            "The credential check did not return healthy. Fix the key or endpoint, then check again.",
+        );
+        return;
+      }
+    }
+    setContinueError(null);
+    setWizardStep("place");
   };
 
   // The user clicked a field in the probe's response: that field IS the
@@ -2819,16 +2846,7 @@ function AddAccountModalView(props: AddAccountModalProps) {
               ) : wizardActive && wizardStep === "validate" ? (
                 <Button
                   type="button"
-                  onClick={() => {
-                    if (credentialPayloadOrigin === null) {
-                      setContinueError(
-                        singleInput ? "Enter the key first" : "Fill in every credential field",
-                      );
-                      return;
-                    }
-                    setContinueError(null);
-                    setWizardStep("place");
-                  }}
+                  onClick={() => void handleContinueFromValidate()}
                   loading={validating}
                 >
                   Continue

--- a/packages/react/src/components/tool-detail.tsx
+++ b/packages/react/src/components/tool-detail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { toolSchemaAtom } from "../api/atoms";
@@ -503,18 +503,21 @@ function PolicyBadgeMenu(props: {
 // Empty state
 // ---------------------------------------------------------------------------
 
-export function ToolDetailEmpty(props: { hasTools: boolean }) {
+export function ToolDetailEmpty(props: {
+  hasTools: boolean;
+  title?: string;
+  description?: string;
+  action?: ReactNode;
+}) {
+  const title = props.title ?? (props.hasTools ? "Select a tool" : "No tools available");
+  const description =
+    props.description ?? (props.hasTools ? "Choose from the list to see what it does." : null);
   return (
     <div className="flex h-full items-center justify-center">
-      <div className="text-center">
-        <p className="text-sm font-medium text-foreground">
-          {props.hasTools ? "Select a tool" : "No tools available"}
-        </p>
-        {props.hasTools && (
-          <p className="mt-1.5 text-sm text-muted-foreground">
-            Choose from the list to see what it does.
-          </p>
-        )}
+      <div className="max-w-sm text-center">
+        <p className="text-sm font-medium text-foreground">{title}</p>
+        {description ? <p className="mt-1.5 text-sm text-muted-foreground">{description}</p> : null}
+        {props.action ? <div className="mt-4">{props.action}</div> : null}
       </div>
     </div>
   );

--- a/packages/react/src/components/tool-tree.tsx
+++ b/packages/react/src/components/tool-tree.tsx
@@ -309,6 +309,8 @@ export function ToolTree(props: {
    *  beneath each section. The same tool name can appear under two accounts (NOT
    *  deduped). When false/unset, render one flat tree (unchanged). */
   groupByConnection?: boolean;
+  /** No-search empty label. Search still uses "No tools match your filter". */
+  emptyLabel?: string;
 }) {
   const {
     tools,
@@ -319,6 +321,7 @@ export function ToolTree(props: {
     patternForDisplay = toPolicyPattern,
     policies,
     groupByConnection,
+    emptyLabel,
   } = props;
   const exactPatterns = useMemo(() => {
     if (!policies) return new Map<string, ToolPolicyAction>();
@@ -410,7 +413,7 @@ export function ToolTree(props: {
       <div className="min-h-0 flex-1 overflow-y-auto">
         {filteredTools.length === 0 ? (
           <div className="p-4 text-center text-xs text-muted-foreground">
-            {terms.length > 0 ? "No tools match your filter" : "No tools available"}
+            {terms.length > 0 ? "No tools match your filter" : (emptyLabel ?? "No tools available")}
           </div>
         ) : groupByConnection ? (
           accountGroups.map((group) => (

--- a/packages/react/src/pages/integration-detail.tsx
+++ b/packages/react/src/pages/integration-detail.tsx
@@ -13,6 +13,7 @@ import {
   type Owner,
 } from "@executor-js/sdk/shared";
 import {
+  checkConnectionHealth,
   connectionsAllAtom,
   integrationToolsAllAtom,
   integrationsOptimisticAtom,
@@ -21,7 +22,11 @@ import {
   refreshConnection,
   removeIntegrationOptimistic,
 } from "../api/atoms";
-import { connectionWriteKeys, integrationWriteKeys } from "../api/reactivity-keys";
+import {
+  connectionCheckKeys,
+  connectionWriteKeys,
+  integrationWriteKeys,
+} from "../api/reactivity-keys";
 import { ToolTree } from "../components/tool-tree";
 import { ToolDetail, ToolDetailEmpty } from "../components/tool-detail";
 import type { ToolSummary } from "../components/tool-tree";
@@ -36,6 +41,7 @@ import { Skeleton } from "../components/skeleton";
 import { useExecutorDocumentTitle } from "../lib/document-title";
 import { ErrorState } from "../components/error-state";
 import { isAsyncResultLoading } from "../lib/async-result";
+import { useConnectionsHealth } from "../lib/use-connection-health";
 
 // v2: the route's `namespace` param is the integration slug. Tools belong to
 // the integration's per-owner connections; a tool's policy id is
@@ -66,6 +72,7 @@ export function IntegrationDetailPage(props: { namespace: string }) {
   const refreshTools = useAtomRefresh(integrationToolsAllAtom(slug));
   const doRemove = useAtomSet(removeIntegrationOptimistic, { mode: "promiseExit" });
   const doRefresh = useAtomSet(refreshConnection, { mode: "promiseExit" });
+  const doCheckHealth = useAtomSet(checkConnectionHealth, { mode: "promiseExit" });
   // Policies are owner-partitioned on write; the integration policy menu writes
   // Workspace (org) rules, preserving the prior default behavior.
   const policyActions = usePolicyActions("org");
@@ -88,6 +95,7 @@ export function IntegrationDetailPage(props: { namespace: string }) {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [retryingTools, setRetryingTools] = useState(false);
   const [editSheetOpen, setEditSheetOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<"accounts" | "tools">("accounts");
   const [manualAccountHandoff, setManualAccountHandoff] =
@@ -222,6 +230,21 @@ export function IntegrationDetailPage(props: { namespace: string }) {
     );
   }, [connectionsResult, slug]);
 
+  const healthProbeFor = useConnectionsHealth(integrationConnections);
+  const toolsHealthIssue = useMemo(() => {
+    const ranked = integrationConnections
+      .map((connection) => ({ connection, probe: healthProbeFor(connection) }))
+      .filter((entry) => entry.probe?.status === "expired" || entry.probe?.status === "degraded")
+      .sort((a, b) => {
+        const rank = (status: "expired" | "degraded"): number => (status === "expired" ? 0 : 1);
+        return (
+          rank(a.probe!.status as "expired" | "degraded") -
+          rank(b.probe!.status as "expired" | "degraded")
+        );
+      });
+    return ranked[0] ?? null;
+  }, [healthProbeFor, integrationConnections]);
+
   // Account-grouped tool rows for the Tools tab. NOT deduped across
   // connections: one row per (owner, connection, tool). The leaf's `name` is the
   // policy id `<integration>.<tool>` so leaf policy patterns stay correct, while
@@ -261,6 +284,18 @@ export function IntegrationDetailPage(props: { namespace: string }) {
   const selection = selectedToolId ? (selectionById.get(selectedToolId) ?? null) : null;
   const selectedAddress = selection?.address ?? null;
   const selectedBareName = selection?.bareName ?? null;
+  const connectedEmptyTools =
+    !isBuiltInIntegration && integrationConnections.length > 0 && integrationTools.length === 0;
+  const emptyToolsTitle = toolsHealthIssue
+    ? "Connection needs attention"
+    : "Checking connection health";
+  const emptyToolsDescription =
+    toolsHealthIssue?.probe?.detail ?? "Checking whether this connection can generate tools.";
+  const emptyToolsListLabel = !isBuiltInIntegration
+    ? connectedEmptyTools
+      ? emptyToolsTitle
+      : "No tools yet"
+    : undefined;
 
   // Declared auth methods — derived server-side from the owning plugin's config
   // and carried on the integration catalog response. This is authoritative even
@@ -340,6 +375,35 @@ export function IntegrationDetailPage(props: { namespace: string }) {
       success: connectionCount > 0 && refreshExits.every(Boolean),
     });
     setRefreshing(false);
+  };
+
+  const handleRetryToolsHealth = async () => {
+    if (retryingTools) return;
+    setRetryingTools(true);
+    let refreshedAny = false;
+    for (const connection of integrationConnections) {
+      const health = await doCheckHealth({
+        params: {
+          owner: connection.owner,
+          integration: slug,
+          name: connection.name,
+        },
+        query: {},
+        reactivityKeys: connectionCheckKeys,
+      });
+      if (Exit.isFailure(health) || health.value.status !== "healthy") continue;
+      const refreshed = await doRefresh({
+        params: {
+          owner: connection.owner,
+          integration: slug,
+          name: connection.name,
+        },
+        reactivityKeys: connectionWriteKeys,
+      });
+      refreshedAny = refreshedAny || Exit.isSuccess(refreshed);
+    }
+    if (refreshedAny) refreshTools();
+    setRetryingTools(false);
   };
 
   const handleOpenAddConnection = () => {
@@ -478,6 +542,7 @@ export function IntegrationDetailPage(props: { namespace: string }) {
                       onClearPolicy={(pattern) => void policyActions.clear(pattern)}
                       policies={sortedPolicies}
                       groupByConnection={!isBuiltInIntegration}
+                      emptyLabel={emptyToolsListLabel}
                     />
                   </div>
 
@@ -504,6 +569,23 @@ export function IntegrationDetailPage(props: { namespace: string }) {
                       <NoConnectionToolsEmptyState
                         onAddConnection={handleOpenAddConnection}
                         canAddConnection={accountsMethods.length > 0}
+                      />
+                    ) : connectedEmptyTools ? (
+                      <ToolDetailEmpty
+                        hasTools={false}
+                        title={emptyToolsTitle}
+                        description={emptyToolsDescription}
+                        action={
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            onClick={() => void handleRetryToolsHealth()}
+                            disabled={retryingTools}
+                          >
+                            {retryingTools ? "Checking..." : "Check and sync tools"}
+                          </Button>
+                        }
                       />
                     ) : (
                       <ToolDetailEmpty hasTools={integrationTools.length > 0} />


### PR DESCRIPTION
Adding a GraphQL source whose endpoint responds with something other than a valid introspection result (wrong URL, auth rejection, introspection disabled) used to save a connection that looked healthy but had zero tools, with no error anywhere. Reported by a user trying to connect the Linear GraphQL API with an API key.

Introspection failures are now classified (auth rejected, not a GraphQL schema, unreachable, GraphQL errors) and surfaced: the key-first connect flow blocks before saving with an actionable message, unhealthy connections show the verdict in the accounts list and on the empty tools page with a re-check button, and tool sync returns `incomplete` instead of persisting an authoritative empty catalog.

Invalid endpoint rejected at connect time:

![GraphQL · invalid introspection format shows an actionable connection error (selfhost)](https://raw.githubusercontent.com/UsefulSoftwareCo/executor/e2e-media/graphql-invalid-introspection-format-shows-an-actionable-connection-error-02669df6.gif)

Valid endpoint still connects and generates tools:

![GraphQL · valid introspection connects healthy and generates tools (selfhost)](https://raw.githubusercontent.com/UsefulSoftwareCo/executor/e2e-media/graphql-valid-introspection-connects-healthy-and-generates-tools-44322aa9.gif)
