### PR TITLE
Restrict workspace-level settings to admins

### DIFF
--- a/.changeset/workspace-writes-admin-only.md
+++ b/.changeset/workspace-writes-admin-only.md
@@ -1,0 +1,21 @@
+---
+"@executor-js/sdk": minor
+"@executor-js/plugin-graphql": minor
+"@executor-js/plugin-mcp": minor
+"@executor-js/plugin-openapi": minor
+---
+
+**Workspace-level settings are now admin-only**
+
+The executor binding gains `orgWrites: "allowed" | "denied"`. Hosts derive it
+from the acting member's role (cloud: WorkOS membership role; self-host:
+Better Auth org membership role), and a plain member's binding refuses every
+user-intent workspace-level mutation with the new `OrgWriteDeniedError`
+(HTTP 403): org-owned tool policies, workspace-shared connections, org OAuth
+apps and org connect flows, and integration-catalog changes (add, update,
+remove, health check).
+
+Using workspace resources is unchanged for members: reads, tool execution over
+shared connections, and the operational writes those imply (token refresh,
+tool-catalog re-sync, config-rewrite healing) keep working. Hosts with no role
+model (local, the CLI, embedded SDK use) default to `"allowed"`.

--- a/apps/cloud/src/api/protected-api-key-auth.node.test.ts
+++ b/apps/cloud/src/api/protected-api-key-auth.node.test.ts
@@ -98,6 +98,9 @@ describe("protected API key auth", () => {
         name: null,
         avatarUrl: null,
         roles: [],
+        // The stub membership carries no role slug — normalization FAILS
+        // CLOSED to plain member, so the executor binds workspace writes off.
+        orgRole: "member",
       });
     }),
   );

--- a/apps/cloud/src/api/protected-jwt-auth.node.test.ts
+++ b/apps/cloud/src/api/protected-jwt-auth.node.test.ts
@@ -119,6 +119,9 @@ describe("protected JWT (device-login) auth", () => {
         name: null,
         avatarUrl: null,
         roles: [],
+        // The stub membership carries no role slug — normalization FAILS
+        // CLOSED to plain member, so the executor binds workspace writes off.
+        orgRole: "member",
       });
     }),
   );

--- a/apps/cloud/src/auth/organization.ts
+++ b/apps/cloud/src/auth/organization.ts
@@ -86,7 +86,14 @@ export const authorizeOrganization = (userId: string, organizationId: string) =>
     );
     if (!active) return null;
 
-    return yield* resolveOrganization(organizationId);
+    const org = yield* resolveOrganization(organizationId);
+    // The membership row already names the caller's role — surface it
+    // normalized so identity resolution can bind the executor's workspace
+    // write permission without a second WorkOS call. WorkOS issues
+    // `admin` / `member`; anything unrecognized stays a plain member.
+    const roleSlug = (active as { readonly role?: { readonly slug?: string } }).role?.slug;
+    const memberRole: "admin" | "member" = roleSlug === "admin" ? "admin" : "member";
+    return { ...org, memberRole };
   });
 
 // ---------------------------------------------------------------------------

--- a/apps/cloud/src/auth/workos-auth-provider.ts
+++ b/apps/cloud/src/auth/workos-auth-provider.ts
@@ -154,6 +154,7 @@ const resolveJwtPrincipal = (token: string, jwt: JwtBearerConfig) =>
       name: null,
       avatarUrl: null,
       roles: [],
+      orgRole: org.memberRole,
     } satisfies Principal;
   });
 
@@ -253,6 +254,7 @@ export const resolveBearerAuth = (
       name: null,
       avatarUrl: null,
       roles: [],
+      orgRole: org.memberRole,
     } satisfies Principal;
   });
 
@@ -326,6 +328,7 @@ export const resolveSessionPrincipal = (request: Request) =>
       name: sealedSessionDisplayName(session),
       avatarUrl: session.avatarUrl ?? null,
       roles: [],
+      orgRole: org.memberRole,
     } satisfies Principal;
   });
 

--- a/apps/cloud/src/mcp/session-durable-object.ts
+++ b/apps/cloud/src/mcp/session-durable-object.ts
@@ -58,7 +58,7 @@ import { buildExecuteDescription, type ResumeResponse } from "@executor-js/execu
 // `SessionAuthLive` instead.)
 import { CoreSharedServices } from "../auth/workos";
 import { UserStoreService } from "../auth/context";
-import { resolveOrganization } from "../auth/organization";
+import { authorizeOrganization } from "../auth/organization";
 import {
   DbService,
   combinedSchema,
@@ -214,7 +214,13 @@ export class McpSessionDOSqlite extends McpAgentSessionDOBase<Env, CloudSessionD
   protected override resolveSessionMeta(token: McpSessionInit): Effect.Effect<SessionMeta> {
     const dbHandle = makeEphemeralDb();
     return Effect.gen(function* () {
-      const org = yield* resolveOrganization(token.organizationId);
+      // Membership was already verified by the worker's per-request auth; this
+      // re-check is where the session learns the member's WORKSPACE ROLE, so
+      // the executor it builds can bind `orgWrites` (a member may use org
+      // connections but not configure workspace-level state). The role is
+      // baked into the persisted meta: a demotion applies from the next
+      // session init, not mid-session.
+      const org = yield* authorizeOrganization(token.userId, token.organizationId);
       if (!org) {
         return yield* new OrganizationNotFoundError({ organizationId: token.organizationId });
       }
@@ -223,6 +229,7 @@ export class McpSessionDOSqlite extends McpAgentSessionDOBase<Env, CloudSessionD
         organizationName: org.name,
         organizationSlug: org.slug,
         userId: token.userId,
+        orgRole: org.memberRole,
         resource: token.resource,
         elicitationMode: token.elicitationMode,
         artifactsEnabled: token.artifactsEnabled,
@@ -253,7 +260,10 @@ export class McpSessionDOSqlite extends McpAgentSessionDOBase<Env, CloudSessionD
         sessionMeta.userId,
         sessionMeta.organizationId,
         sessionMeta.organizationName,
-        { mcpResource: sessionMeta.resource },
+        {
+          mcpResource: sessionMeta.resource,
+          orgWrites: sessionMeta.orgRole === "member" ? "denied" : "allowed",
+        },
       ).pipe(
         // The metered stack tracks each execution to Autumn. It requires
         // `AutumnService | DbService`; `AutumnService.Default` is provided here

--- a/apps/host-selfhost/src/admin/require-admin.ts
+++ b/apps/host-selfhost/src/admin/require-admin.ts
@@ -74,8 +74,12 @@ export interface InstanceAdmin {
  * string is the common case rather than the contract. Membership in the
  * privileged set is therefore tested per role, not by equality on the whole
  * field — an `"owner,admin"` value must not read as neither.
+ *
+ * Exported for the identity seam: the same "who counts as an admin" answer
+ * decides the executor's workspace-write binding (`Principal.orgRole`), and
+ * there is only one place to be right about it.
  */
-const isPrivileged = (role: string): boolean =>
+export const isPrivileged = (role: string): boolean =>
   role
     .split(",")
     .map((part) => part.trim())

--- a/apps/host-selfhost/src/auth/identity.ts
+++ b/apps/host-selfhost/src/auth/identity.ts
@@ -2,6 +2,7 @@ import { Effect, Layer } from "effect";
 
 import { IdentityProvider, Unauthorized } from "@executor-js/api/server";
 
+import { isPrivileged } from "../admin/require-admin";
 import { BetterAuth } from "./better-auth";
 
 // ---------------------------------------------------------------------------
@@ -49,13 +50,18 @@ export const betterAuthIdentityLayer: Layer.Layer<IdentityProvider, never, Bette
             let resolved = yield* Effect.promise(() =>
               auth.api.getSession({ headers: request.headers }),
             );
+            // The credential shape that resolved the session — the SAME headers
+            // are what the membership-role lookup below must present.
+            let sessionHeaders: Headers | Record<string, string> = request.headers;
             if (!resolved) {
               const token = bearerToken(request.headers);
               if (token) {
+                const apiKeyHeaders = { "x-api-key": token };
                 resolved = yield* Effect.tryPromise({
-                  try: () => auth.api.getSession({ headers: { "x-api-key": token } }),
+                  try: () => auth.api.getSession({ headers: apiKeyHeaders }),
                   catch: () => "api-key session lookup failed",
                 }).pipe(Effect.orElseSucceed(() => null));
+                sessionHeaders = apiKeyHeaders;
               }
             }
             // No session resolved from any credential shape -> unauthenticated.
@@ -66,6 +72,21 @@ export const betterAuthIdentityLayer: Layer.Layer<IdentityProvider, never, Bette
             // session hook; API-key-minted sessions carry no active org, so we
             // default to the seeded org rather than rejecting with NoOrganization.
             const resolvedOrganizationId = resolved.session.activeOrganizationId ?? organizationId;
+            // The workspace role, resolved against the INSTANCE org exactly as
+            // the admin gate does (require-admin.ts): the explicit
+            // `organizationId` query keeps a caller-controlled active org from
+            // answering for an org they own elsewhere. FAIL CLOSED to "member"
+            // — an infra fault demotes rather than escalates.
+            const membership = yield* Effect.tryPromise(() =>
+              auth.api.getActiveMemberRole({
+                headers: sessionHeaders,
+                query: { organizationId: resolvedOrganizationId },
+              }),
+            ).pipe(Effect.orElseSucceed(() => null));
+            const orgRole =
+              membership && isPrivileged(membership.role)
+                ? ("admin" as const)
+                : ("member" as const);
             return {
               kind: "member" as const,
               accountId: resolved.user.id,
@@ -79,6 +100,7 @@ export const betterAuthIdentityLayer: Layer.Layer<IdentityProvider, never, Bette
                 .split(",")
                 .map((role) => role.trim())
                 .filter((role) => role.length > 0),
+              orgRole,
             };
           }),
       });

--- a/apps/host-selfhost/src/mcp/auth.ts
+++ b/apps/host-selfhost/src/mcp/auth.ts
@@ -11,6 +11,7 @@ import {
   type Principal,
 } from "@executor-js/host-mcp";
 
+import { isPrivileged } from "../admin/require-admin";
 import { BetterAuth } from "../auth/better-auth";
 import { MCP_ORIGINAL_PATH_HEADER, mcpResourcePathFromOriginalPath } from "./org-path";
 
@@ -205,6 +206,24 @@ export const selfHostMcpAuth: Layer.Layer<McpAuthProvider, never, BetterAuth | I
         Effect.gen(function* () {
           const user = yield* Effect.promise(() => context.internalAdapter.findUserById(userId));
           if (!user) return null;
+          // The workspace role, read from the INSTANCE org's membership row
+          // (an OAuth token carries no session, so the header-based
+          // `getActiveMemberRole` gate is out of reach — the adapter query
+          // answers the same question against the same table). FAIL CLOSED to
+          // "member": an infra fault demotes rather than escalates.
+          const membership = yield* Effect.promise(() =>
+            context.adapter.findOne<{ readonly role?: string | null }>({
+              model: "member",
+              where: [
+                { field: "userId", value: userId },
+                { field: "organizationId", value: organizationId },
+              ],
+            }),
+          ).pipe(Effect.orElseSucceed(() => null));
+          const orgRole =
+            membership?.role != null && isPrivileged(membership.role)
+              ? ("admin" as const)
+              : ("member" as const);
           return {
             accountId: user.id,
             // Single-org self-host: OAuth tokens carry no active org, so pin to
@@ -216,6 +235,7 @@ export const selfHostMcpAuth: Layer.Layer<McpAuthProvider, never, BetterAuth | I
             name: user.name ?? null,
             avatarUrl: user.image ?? null,
             roles: parseRoles(userRole(user)),
+            orgRole,
           } satisfies Principal;
         });
 

--- a/apps/host-selfhost/src/multi-user.test.ts
+++ b/apps/host-selfhost/src/multi-user.test.ts
@@ -42,8 +42,8 @@ const TINY_SPEC = JSON.stringify({
   },
 });
 
-const signUp = async (email: string): Promise<string> => {
-  const inviteCode = await mintInviteCode(handler);
+const signUp = async (email: string, role: "admin" | "member" = "member"): Promise<string> => {
+  const inviteCode = await mintInviteCode(handler, role);
   const res = await handler(
     new Request(`${BASE}/api/auth/sign-up/email`, {
       method: "POST",
@@ -136,7 +136,9 @@ const runCode = async (token: string, code: string) => {
 };
 
 test("multiple accounts share one org but isolate per-user connections", async () => {
-  const alice = await signUp("alice@multi.test");
+  // Workspace-level setup (the catalog, org-shared connections) is admin-only,
+  // so Alice joins as an admin; Bob stays a plain member.
+  const alice = await signUp("alice@multi.test", "admin");
   const bob = await signUp("bob@multi.test");
 
   // Same single org for both members.
@@ -146,6 +148,21 @@ test("multiple accounts share one org but isolate per-user connections", async (
 
   // The integration is tenant-scoped; register it once.
   expect((await addIntegration(alice, "tiny")).status).toBe(200);
+
+  // A plain member cannot register integrations or mint workspace-shared
+  // connections — 403 from the executor's workspace-write gate.
+  expect((await addIntegration(bob, "tiny2")).status).toBe(403);
+  expect(
+    (
+      await createConnection(bob, {
+        owner: "org",
+        name: "bob-shared",
+        integration: "tiny",
+        template: "bearer",
+        value: "bob-token",
+      })
+    ).status,
+  ).toBe(403);
 
   // Alice attaches a USER-owned connection (private to her) and an ORG-owned
   // connection (shared across the tenant).

--- a/packages/core/api/src/connections/api.ts
+++ b/packages/core/api/src/connections/api.ts
@@ -22,6 +22,7 @@ import {
   IntegrationSlug,
   InternalError,
   InvalidConnectionInputError,
+  OrgWriteDeniedError,
   OAuthClientSlug,
   Owner,
   ProviderItemId,
@@ -195,6 +196,7 @@ export const ConnectionsApi = HttpApiGroup.make("connections")
         IntegrationNotFound,
         CredentialProviderNotRegistered,
         InvalidConnectionInput,
+        OrgWriteDeniedError,
       ],
     }),
   )
@@ -210,14 +212,14 @@ export const ConnectionsApi = HttpApiGroup.make("connections")
       params: ConnectionParams,
       payload: UpdateConnectionPayload,
       success: ConnectionResponse,
-      error: [InternalError, ConnectionNotFound],
+      error: [InternalError, ConnectionNotFound, OrgWriteDeniedError],
     }),
   )
   .add(
     HttpApiEndpoint.delete("remove", "/connections/:owner/:integration/:name", {
       params: ConnectionParams,
       success: Schema.Struct({ removed: Schema.Boolean }),
-      error: [InternalError, ConnectionNotFound],
+      error: [InternalError, ConnectionNotFound, OrgWriteDeniedError],
     }),
   )
   .add(

--- a/packages/core/api/src/integrations/api.ts
+++ b/packages/core/api/src/integrations/api.ts
@@ -18,6 +18,7 @@ import {
   IntegrationRemovalNotAllowedError,
   IntegrationSlug,
   InternalError,
+  OrgWriteDeniedError,
 } from "@executor-js/sdk/shared";
 
 // ---------------------------------------------------------------------------
@@ -132,14 +133,14 @@ export const IntegrationsApi = HttpApiGroup.make("integrations")
       params: IntegrationParams,
       payload: UpdateIntegrationPayload,
       success: IntegrationResponse,
-      error: [InternalError, IntegrationNotFound],
+      error: [InternalError, IntegrationNotFound, OrgWriteDeniedError],
     }),
   )
   .add(
     HttpApiEndpoint.delete("remove", "/integrations/:slug", {
       params: IntegrationParams,
       success: Schema.Struct({ removed: Schema.Boolean }),
-      error: [InternalError, IntegrationRemovalNotAllowed],
+      error: [InternalError, IntegrationRemovalNotAllowed, OrgWriteDeniedError],
     }),
   )
   .add(
@@ -172,6 +173,6 @@ export const IntegrationsApi = HttpApiGroup.make("integrations")
       params: IntegrationParams,
       payload: SetHealthCheckPayload,
       success: Schema.Struct({ ok: Schema.Boolean }),
-      error: [InternalError, IntegrationNotFound],
+      error: [InternalError, IntegrationNotFound, OrgWriteDeniedError],
     }),
   );

--- a/packages/core/api/src/oauth/api.ts
+++ b/packages/core/api/src/oauth/api.ts
@@ -27,6 +27,7 @@ import {
   OAuthSessionNotFoundError,
   OAuthStartError,
   OAuthState,
+  OrgWriteDeniedError,
   Owner,
   ProviderKey,
 } from "@executor-js/sdk/shared";
@@ -259,14 +260,14 @@ export const OAuthApi = HttpApiGroup.make("oauth")
     HttpApiEndpoint.post("createClient", "/oauth/clients", {
       payload: CreateClientPayload,
       success: CreateClientResponse,
-      error: InternalError,
+      error: [InternalError, OrgWriteDeniedError],
     }),
   )
   .add(
     HttpApiEndpoint.post("registerDynamic", "/oauth/clients/register-dynamic", {
       payload: RegisterDynamicPayload,
       success: RegisterDynamicResponse,
-      error: [InternalError, OAuthRegisterDynamic],
+      error: [InternalError, OAuthRegisterDynamic, OrgWriteDeniedError],
     }),
   )
   .add(
@@ -280,14 +281,14 @@ export const OAuthApi = HttpApiGroup.make("oauth")
       params: RemoveClientParams,
       payload: RemoveClientPayload,
       success: RemoveClientResponse,
-      error: InternalError,
+      error: [InternalError, OrgWriteDeniedError],
     }),
   )
   .add(
     HttpApiEndpoint.post("start", "/oauth/start", {
       payload: StartPayload,
       success: StartResponse,
-      error: [InternalError, OAuthStart],
+      error: [InternalError, OAuthStart, OrgWriteDeniedError],
     }),
   )
   .add(

--- a/packages/core/api/src/policies/api.ts
+++ b/packages/core/api/src/policies/api.ts
@@ -8,7 +8,13 @@
 
 import { HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi";
 import { Schema } from "effect";
-import { InternalError, Owner, PolicyId, ToolPolicyActionSchema } from "@executor-js/sdk/shared";
+import {
+  InternalError,
+  OrgWriteDeniedError,
+  Owner,
+  PolicyId,
+  ToolPolicyActionSchema,
+} from "@executor-js/sdk/shared";
 
 // ---------------------------------------------------------------------------
 // Params
@@ -63,7 +69,7 @@ export const PoliciesApi = HttpApiGroup.make("policies")
     HttpApiEndpoint.post("create", "/policies", {
       payload: CreateToolPolicyPayload,
       success: ToolPolicyResponse,
-      error: InternalError,
+      error: [InternalError, OrgWriteDeniedError],
     }),
   )
   .add(
@@ -71,7 +77,7 @@ export const PoliciesApi = HttpApiGroup.make("policies")
       params: PolicyParams,
       payload: UpdateToolPolicyPayload,
       success: ToolPolicyResponse,
-      error: InternalError,
+      error: [InternalError, OrgWriteDeniedError],
     }),
   )
   .add(
@@ -79,6 +85,6 @@ export const PoliciesApi = HttpApiGroup.make("policies")
       params: PolicyParams,
       payload: RemoveToolPolicyPayload,
       success: Schema.Struct({ removed: Schema.Boolean }),
-      error: InternalError,
+      error: [InternalError, OrgWriteDeniedError],
     }),
   );

--- a/packages/core/api/src/server/execution-stack-middleware.ts
+++ b/packages/core/api/src/server/execution-stack-middleware.ts
@@ -239,6 +239,9 @@ export const makeExecutionStackMiddleware = <
             resolved.accountId,
             resolved.organizationId,
             resolved.organizationName,
+            // A plain member binds with workspace writes denied; an admin —
+            // or a host with no role model (`orgRole` absent) — binds allowed.
+            { orgWrites: resolved.orgRole === "member" ? "denied" : "allowed" },
           ).pipe(
             Effect.provide(options.stackLayer),
             Effect.provideService(RequestWebOrigin, {

--- a/packages/core/api/src/server/execution-stack.ts
+++ b/packages/core/api/src/server/execution-stack.ts
@@ -112,7 +112,12 @@ export const makeExecutionStack = <
   accountId: string,
   organizationId: string,
   organizationName: string,
-  options?: { readonly mcpResource?: McpResource },
+  options?: {
+    readonly mcpResource?: McpResource;
+    /** Workspace-settings permission for this binding (see
+     *  `ExecutorConfig.orgWrites`), derived from the acting member's role. */
+    readonly orgWrites?: "allowed" | "denied";
+  },
 ): Effect.Effect<
   { readonly executor: Executor<TPlugins>; readonly engine: ExecutionEngine<Cause.YieldableError> },
   StorageFailure,
@@ -123,7 +128,10 @@ export const makeExecutionStack = <
       accountId,
       organizationId,
       organizationName,
-      { plugins: { mcpResource: options?.mcpResource } },
+      {
+        plugins: { mcpResource: options?.mcpResource },
+        ...(options?.orgWrites === undefined ? {} : { orgWrites: options.orgWrites }),
+      },
     ).pipe(Effect.withSpan("executor.stack.scoped_executor"));
     const codeExecutor = yield* CodeExecutorProvider.asEffect().pipe(
       Effect.withSpan("executor.stack.code_executor"),

--- a/packages/core/api/src/server/identity.ts
+++ b/packages/core/api/src/server/identity.ts
@@ -48,6 +48,17 @@ export interface Principal {
   readonly name: string | null;
   readonly avatarUrl: string | null;
   readonly roles: readonly string[];
+  /**
+   * The member's NORMALIZED workspace role, when the host resolves one:
+   * `"admin"` may configure workspace-level state (org-owned rows, the
+   * integration catalog), `"member"` may only use it. Cloud maps its WorkOS
+   * membership role (`admin` / `member`); self-host maps Better Auth's org
+   * membership role (`owner` and `admin` → `"admin"`). ABSENT means the host
+   * has no role model (local's single user, test fakes) and the middleware
+   * binds the executor with workspace writes allowed — hosts that DO
+   * distinguish roles must always set it.
+   */
+  readonly orgRole?: "admin" | "member";
 }
 
 /**

--- a/packages/core/api/src/server/mcp-build.ts
+++ b/packages/core/api/src/server/mcp-build.ts
@@ -48,7 +48,12 @@ export const makeMcpBuildServer =
         principal.accountId,
         principal.organizationId,
         principal.organizationName,
-        { mcpResource: options?.resource },
+        {
+          mcpResource: options?.resource,
+          // A plain member binds with workspace writes denied; an admin — or
+          // a host with no role model (`orgRole` absent) — binds allowed.
+          orgWrites: principal.orgRole === "member" ? "denied" : "allowed",
+        },
       ).pipe(Effect.withSpan("mcp.execution_stack.build"));
       // Read inside the provided boundary: `webBaseUrl` is a host seam, and
       // hosts that can't know their public URL at boot leave it unset — in

--- a/packages/core/api/src/server/scoped-executor.ts
+++ b/packages/core/api/src/server/scoped-executor.ts
@@ -218,7 +218,13 @@ export const makeScopedExecutor = <
   // `EngineStackIdentity` (the engine decorator still wants it); not part of the
   // v2 executor binding, which is `{ tenant, subject }` only.
   _organizationName: string,
-  options?: { readonly plugins?: PluginsProviderContext },
+  options?: {
+    readonly plugins?: PluginsProviderContext;
+    /** Workspace-settings permission for this binding (see
+     *  `ExecutorConfig.orgWrites`). Hosts derive it from the acting member's
+     *  role; omitted -> allowed (hosts with no role model). */
+    readonly orgWrites?: "allowed" | "denied";
+  },
 ): Effect.Effect<Executor<TPlugins>, StorageFailure, DbProvider | PluginsProvider | HostConfig> =>
   Effect.gen(function* () {
     const { db, blobs } = yield* DbProvider.asEffect().pipe(
@@ -285,6 +291,7 @@ export const makeScopedExecutor = <
       fetch: hostedFetch,
       onIntegrationChange: config.onIntegrationChange,
       onElicitation: "accept-all",
+      ...(options?.orgWrites === undefined ? {} : { orgWrites: options.orgWrites }),
       redirectUri,
       oauthCallbackStateOrgSlug: orgSlug,
       coreTools: {

--- a/packages/core/sdk/src/errors.ts
+++ b/packages/core/sdk/src/errors.ts
@@ -142,6 +142,32 @@ export class IntegrationRemovalNotAllowedError extends Schema.TaggedErrorClass<I
   }
 }
 
+/** A workspace-level mutation (an `owner: "org"` row, or the tenant-shared
+ *  integration catalog) was attempted on an executor bound with
+ *  `orgWrites: "denied"` — a member who may USE workspace resources but not
+ *  configure them. Reads, tool execution, and operational writes (token
+ *  refresh, catalog re-sync) are unaffected; only the user-intent settings
+ *  surfaces raise this. */
+export class OrgWriteDeniedError
+  extends Schema.TaggedErrorClass<OrgWriteDeniedError>()(
+    "OrgWriteDeniedError",
+    {},
+    { httpApiStatus: 403 },
+  )
+  implements UserActionableError
+{
+  readonly __executorUserActionable = true;
+  readonly code = "org_write_denied";
+
+  override get message(): string {
+    return "Workspace-level changes require a workspace admin.";
+  }
+
+  get userMessage(): string {
+    return this.message;
+  }
+}
+
 export class ConnectionNotFoundError extends Schema.TaggedErrorClass<ConnectionNotFoundError>()(
   "ConnectionNotFoundError",
   {

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -72,6 +72,7 @@ import {
   InvalidConnectionInputError,
   IntegrationRemovalNotAllowedError,
   NoHandlerError,
+  OrgWriteDeniedError,
   PluginNotLoadedError,
   ToolBlockedError,
   ToolInvocationError,
@@ -277,10 +278,13 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
     readonly update: (
       slug: IntegrationSlug,
       patch: { readonly name?: string; readonly description?: string },
-    ) => Effect.Effect<void, IntegrationNotFoundError | StorageFailure>;
+    ) => Effect.Effect<void, IntegrationNotFoundError | OrgWriteDeniedError | StorageFailure>;
     readonly remove: (
       slug: IntegrationSlug,
-    ) => Effect.Effect<void, IntegrationRemovalNotAllowedError | StorageFailure>;
+    ) => Effect.Effect<
+      void,
+      IntegrationRemovalNotAllowedError | OrgWriteDeniedError | StorageFailure
+    >;
     readonly detect: (
       url: string,
     ) => Effect.Effect<readonly IntegrationDetectionResult[], StorageFailure>;
@@ -305,7 +309,7 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
       readonly set: (
         slug: IntegrationSlug,
         spec: HealthCheckSpec | null,
-      ) => Effect.Effect<void, IntegrationNotFoundError | StorageFailure>;
+      ) => Effect.Effect<void, IntegrationNotFoundError | OrgWriteDeniedError | StorageFailure>;
     };
   };
 
@@ -317,6 +321,7 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
       | IntegrationNotFoundError
       | CredentialProviderNotRegisteredError
       | InvalidConnectionInputError
+      | OrgWriteDeniedError
       | StorageFailure
     >;
     readonly list: (filter?: {
@@ -329,10 +334,10 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
     readonly update: (
       ref: ConnectionRef,
       input: UpdateConnectionInput,
-    ) => Effect.Effect<Connection, ConnectionNotFoundError | StorageFailure>;
+    ) => Effect.Effect<Connection, ConnectionNotFoundError | OrgWriteDeniedError | StorageFailure>;
     readonly remove: (
       ref: ConnectionRef,
-    ) => Effect.Effect<void, ConnectionNotFoundError | StorageFailure>;
+    ) => Effect.Effect<void, ConnectionNotFoundError | OrgWriteDeniedError | StorageFailure>;
     readonly refresh: (
       ref: ConnectionRef,
     ) => Effect.Effect<
@@ -379,9 +384,15 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
 
   readonly policies: {
     readonly list: () => Effect.Effect<readonly ToolPolicy[], StorageFailure>;
-    readonly create: (input: CreateToolPolicyInput) => Effect.Effect<ToolPolicy, StorageFailure>;
-    readonly update: (input: UpdateToolPolicyInput) => Effect.Effect<ToolPolicy, StorageFailure>;
-    readonly remove: (input: RemoveToolPolicyInput) => Effect.Effect<void, StorageFailure>;
+    readonly create: (
+      input: CreateToolPolicyInput,
+    ) => Effect.Effect<ToolPolicy, OrgWriteDeniedError | StorageFailure>;
+    readonly update: (
+      input: UpdateToolPolicyInput,
+    ) => Effect.Effect<ToolPolicy, OrgWriteDeniedError | StorageFailure>;
+    readonly remove: (
+      input: RemoveToolPolicyInput,
+    ) => Effect.Effect<void, OrgWriteDeniedError | StorageFailure>;
     readonly resolve: (address: ToolAddress) => Effect.Effect<EffectivePolicy, StorageFailure>;
   };
 
@@ -671,6 +682,24 @@ export interface ExecutorConfig<TPlugins extends readonly AnyPlugin[] = readonly
    * every subject's connection rows, credential item ids included.
    */
   readonly platformView?: boolean;
+  /**
+   * Whether this binding may CONFIGURE workspace-level state: `owner: "org"`
+   * rows (shared connections, org tool policies, org OAuth clients) and the
+   * tenant-shared integration catalog. Hosts derive it from the acting
+   * member's role — admins bind `"allowed"`, plain members `"denied"`.
+   * Defaults to `"allowed"` for hosts with no role model (local's single
+   * user, the CLI, tests).
+   *
+   * `"denied"` gates only the USER-INTENT settings surfaces (`policies`,
+   * `connections` create/update/remove, `integrations` update/remove/
+   * healthCheck, OAuth client CRUD and org connect flows, new-integration
+   * registration). Members still USE workspace resources: reads, tool
+   * execution over org connections, and the operational writes those imply
+   * (token refresh, tool-catalog re-sync) are deliberately untouched — which
+   * is why this is a surface gate, not a storage-policy axis like
+   * `platformView`'s blanket `writes: "denied"`.
+   */
+  readonly orgWrites?: "allowed" | "denied";
 }
 
 /** Default freshness window for remote-catalog connections (see
@@ -1575,6 +1604,17 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           )
         : Effect.void;
 
+    // Workspace-settings gate (`ExecutorConfig.orgWrites`). Called at the top
+    // of every user-intent workspace-level mutation: with an explicit owner it
+    // refuses only `"org"` targets; with no owner it guards a tenant-shared
+    // surface (the integration catalog) outright. Deliberately NOT wired into
+    // the storage owner policy — operational org-row writes (token refresh,
+    // tool-catalog re-sync) must keep working for a denied member.
+    const guardOrgWrite = (owner?: Owner): Effect.Effect<void, OrgWriteDeniedError> =>
+      config.orgWrites === "denied" && (owner === undefined || owner === "org")
+        ? Effect.fail(new OrgWriteDeniedError())
+        : Effect.void;
+
     // Built-in core-tools plugin: agent-facing static tools over the v2 surface.
     const plugins: readonly AnyPlugin[] = config.coreTools
       ? ([
@@ -2308,7 +2348,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     const integrationsRegister = (
       pluginId: string,
       input: RegisterIntegrationInput,
-    ): Effect.Effect<void, StorageFailure> =>
+    ): Effect.Effect<void, OrgWriteDeniedError | StorageFailure> =>
       transaction(
         Effect.gen(function* () {
           const now = new Date();
@@ -2329,6 +2369,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             });
             return false;
           }
+          // A NEW catalog row is always user intent (the add-integration
+          // flows); the replace arm above stays open so config rewrites and
+          // legacy healing keep converging under any member's binding.
+          yield* guardOrgWrite();
           yield* core.create("integration", {
             tenant,
             slug: String(input.slug),
@@ -2359,8 +2403,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         readonly description?: string;
         readonly config?: IntegrationConfig;
       },
-    ): Effect.Effect<void, StorageFailure> =>
+    ): Effect.Effect<void, OrgWriteDeniedError | StorageFailure> =>
       Effect.gen(function* () {
+        yield* guardOrgWrite();
         const now = new Date();
         const set: Record<string, unknown> = { updated_at: now };
         if (patch.name !== undefined) set.name = patch.name;
@@ -2382,7 +2427,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     const integrationsUpdatePublic = (
       slug: IntegrationSlug,
       patch: { readonly name?: string; readonly description?: string },
-    ): Effect.Effect<void, IntegrationNotFoundError | StorageFailure> =>
+    ): Effect.Effect<void, IntegrationNotFoundError | OrgWriteDeniedError | StorageFailure> =>
       Effect.gen(function* () {
         const existing = yield* findIntegrationRow(slug);
         if (!existing) return yield* new IntegrationNotFoundError({ slug });
@@ -2391,9 +2436,13 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
 
     const integrationsRemove = (
       slug: IntegrationSlug,
-    ): Effect.Effect<void, IntegrationRemovalNotAllowedError | StorageFailure> =>
+    ): Effect.Effect<
+      void,
+      IntegrationRemovalNotAllowedError | OrgWriteDeniedError | StorageFailure
+    > =>
       transaction(
         Effect.gen(function* () {
+          yield* guardOrgWrite();
           const existing = yield* findIntegrationRow(slug);
           if (!existing) return null;
           if (!existing.can_remove) {
@@ -2481,8 +2530,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     const integrationSetHealthCheck = (
       slug: IntegrationSlug,
       spec: HealthCheckSpec | null,
-    ): Effect.Effect<void, IntegrationNotFoundError | StorageFailure> =>
+    ): Effect.Effect<void, IntegrationNotFoundError | OrgWriteDeniedError | StorageFailure> =>
       Effect.gen(function* () {
+        yield* guardOrgWrite();
         const row = yield* findIntegrationRow(slug);
         if (!row) return yield* new IntegrationNotFoundError({ slug });
         yield* core.updateMany("integration", {
@@ -2722,9 +2772,11 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       | IntegrationNotFoundError
       | CredentialProviderNotRegisteredError
       | InvalidConnectionInputError
+      | OrgWriteDeniedError
       | StorageFailure
     > =>
       Effect.gen(function* () {
+        yield* guardOrgWrite(input.owner);
         const name = connectionIdentifier(String(input.name));
         // Typed (not StorageError) so the HTTP edge can answer 400 with the
         // reason instead of an opaque 500 — callers can act on it.
@@ -3081,8 +3133,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     const connectionsUpdate = (
       ref: ConnectionRef,
       input: UpdateConnectionInput,
-    ): Effect.Effect<Connection, ConnectionNotFoundError | StorageFailure> =>
+    ): Effect.Effect<Connection, ConnectionNotFoundError | OrgWriteDeniedError | StorageFailure> =>
       Effect.gen(function* () {
+        yield* guardOrgWrite(ref.owner);
         const row = yield* findConnectionRow(ref);
         if (!row) {
           return yield* new ConnectionNotFoundError({
@@ -3109,9 +3162,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
 
     const connectionsRemove = (
       ref: ConnectionRef,
-    ): Effect.Effect<void, ConnectionNotFoundError | StorageFailure> =>
+    ): Effect.Effect<void, ConnectionNotFoundError | OrgWriteDeniedError | StorageFailure> =>
       transaction(
         Effect.gen(function* () {
+          yield* guardOrgWrite(ref.owner);
           const row = yield* findConnectionRow(ref);
           if (!row) {
             return yield* new ConnectionNotFoundError({
@@ -3939,8 +3993,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
 
     const policiesCreate = (
       input: CreateToolPolicyInput,
-    ): Effect.Effect<ToolPolicy, StorageFailure> =>
+    ): Effect.Effect<ToolPolicy, OrgWriteDeniedError | StorageFailure> =>
       Effect.gen(function* () {
+        yield* guardOrgWrite(input.owner);
         if (!isValidPattern(input.pattern)) {
           return yield* new StorageError({
             message: `Invalid tool policy pattern: ${input.pattern}`,
@@ -3986,8 +4041,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
 
     const policiesUpdate = (
       input: UpdateToolPolicyInput,
-    ): Effect.Effect<ToolPolicy, StorageFailure> =>
+    ): Effect.Effect<ToolPolicy, OrgWriteDeniedError | StorageFailure> =>
       Effect.gen(function* () {
+        yield* guardOrgWrite(input.owner);
         if (input.pattern !== undefined && !isValidPattern(input.pattern)) {
           return yield* new StorageError({
             message: `Invalid tool policy pattern: ${input.pattern}`,
@@ -4011,10 +4067,16 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         return rowToToolPolicy(updated ?? ({ ...existing, ...set } as ToolPolicyRow));
       });
 
-    const policiesRemove = (input: RemoveToolPolicyInput): Effect.Effect<void, StorageFailure> =>
-      core.deleteMany("tool_policy", {
-        where: (b: AnyCb) => b.and(byOwner(input.owner)(b), b("id", "=", input.id)),
-      });
+    const policiesRemove = (
+      input: RemoveToolPolicyInput,
+    ): Effect.Effect<void, OrgWriteDeniedError | StorageFailure> =>
+      guardOrgWrite(input.owner).pipe(
+        Effect.andThen(
+          core.deleteMany("tool_policy", {
+            where: (b: AnyCb) => b.and(byOwner(input.owner)(b), b("id", "=", input.id)),
+          }),
+        ),
+      );
 
     const policiesResolve = (
       address: ToolAddress,
@@ -4532,6 +4594,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       tenant,
       subject,
       ownedKeys: (owner: Owner) => ownedKeys(owner),
+      guardOrgWrite: (owner: Owner) => guardOrgWrite(owner),
       defaultWritableProvider,
       mintOAuthConnection: (input: MintOAuthConnectionInput) => mintOAuthConnection(input),
       connectionNameTaken: (ref) => findConnectionRow(ref).pipe(Effect.map((row) => row !== null)),

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -69,6 +69,7 @@ export {
   IntegrationNotFoundError,
   IntegrationAlreadyExistsError,
   IntegrationRemovalNotAllowedError,
+  OrgWriteDeniedError,
   ConnectionNotFoundError,
   CredentialProviderNotRegisteredError,
   CredentialResolutionError,

--- a/packages/core/sdk/src/oauth-client.ts
+++ b/packages/core/sdk/src/oauth-client.ts
@@ -2,7 +2,7 @@ import type { Effect } from "effect";
 import { Schema } from "effect";
 
 import type { Connection } from "./connection";
-import type { UserActionableError } from "./errors";
+import type { OrgWriteDeniedError, UserActionableError } from "./errors";
 import type { StorageFailure } from "./fuma-runtime";
 import {
   type AuthTemplateSlug,
@@ -271,12 +271,15 @@ export class OAuthSessionNotFoundError extends Schema.TaggedErrorClass<OAuthSess
 export interface OAuthService {
   readonly createClient: (
     input: CreateOAuthClientInput,
-  ) => Effect.Effect<OAuthClientSlug, StorageFailure>;
+  ) => Effect.Effect<OAuthClientSlug, OrgWriteDeniedError | StorageFailure>;
   /** Mint a client via RFC 7591 Dynamic Client Registration (no pre-shared
    *  client id/secret) and persist it as an owner-scoped `oauth_client`. */
   readonly registerDynamicClient: (
     input: RegisterDynamicClientInput,
-  ) => Effect.Effect<OAuthClientSlug, OAuthRegisterDynamicError | StorageFailure>;
+  ) => Effect.Effect<
+    OAuthClientSlug,
+    OAuthRegisterDynamicError | OrgWriteDeniedError | StorageFailure
+  >;
   /** All registered clients visible to the caller (their org's shared clients +
    *  their own user clients), as metadata-only summaries — never the secret. */
   readonly listClients: () => Effect.Effect<readonly OAuthClientSummary[], StorageFailure>;
@@ -288,10 +291,10 @@ export interface OAuthService {
   readonly removeClient: (
     owner: Owner,
     slug: OAuthClientSlug,
-  ) => Effect.Effect<void, StorageFailure>;
+  ) => Effect.Effect<void, OrgWriteDeniedError | StorageFailure>;
   readonly start: (
     input: OAuthStartInput,
-  ) => Effect.Effect<ConnectResult, OAuthStartError | StorageFailure>;
+  ) => Effect.Effect<ConnectResult, OAuthStartError | OrgWriteDeniedError | StorageFailure>;
   readonly complete: (
     input: OAuthCompleteInput,
   ) => Effect.Effect<Connection, OAuthCompleteError | OAuthSessionNotFoundError | StorageFailure>;

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -19,6 +19,7 @@ import { FetchHttpClient, type HttpClient } from "effect/unstable/http";
 
 import { connectionIdentifier } from "./connection-name-identifier";
 import type { Connection } from "./connection";
+import type { OrgWriteDeniedError } from "./errors";
 import type { IFumaClient, StorageFailure } from "./fuma-runtime";
 import { StorageError } from "./fuma-runtime";
 import {
@@ -127,6 +128,10 @@ export interface OAuthServiceDeps {
     readonly owner: Owner;
     readonly subject: string;
   };
+  /** Workspace-settings gate from the executor binding
+   *  (`ExecutorConfig.orgWrites`): refuses `owner: "org"` targets on the
+   *  user-intent client/connect surfaces. */
+  readonly guardOrgWrite: (owner: Owner) => Effect.Effect<void, OrgWriteDeniedError>;
   readonly defaultWritableProvider: () => CredentialProvider | null;
   /** Write the connection row with OAuth lifecycle fields + produce its tools. */
   readonly mintOAuthConnection: (
@@ -595,8 +600,9 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
   // -----------------------------------------------------------------------
   const createClient = (
     input: CreateOAuthClientInput,
-  ): Effect.Effect<OAuthClientSlug, StorageFailure> =>
+  ): Effect.Effect<OAuthClientSlug, OrgWriteDeniedError | StorageFailure> =>
     Effect.gen(function* () {
+      yield* deps.guardOrgWrite(input.owner);
       yield* validateClientEndpoints(input, deps.endpointUrlPolicy);
       const keys = yield* Effect.try({
         try: () => deps.ownedKeys(input.owner),
@@ -680,8 +686,12 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
   // the next token refresh, prompting a reconnect (graceful degradation; this
   // op never cascades into connections).
   // -----------------------------------------------------------------------
-  const removeClient = (owner: Owner, slug: OAuthClientSlug): Effect.Effect<void, StorageFailure> =>
+  const removeClient = (
+    owner: Owner,
+    slug: OAuthClientSlug,
+  ): Effect.Effect<void, OrgWriteDeniedError | StorageFailure> =>
     Effect.gen(function* () {
+      yield* deps.guardOrgWrite(owner);
       yield* deps.fuma
         .use("oauth_client.delete", (db) =>
           looseDb(db).deleteMany("oauth_client", {
@@ -869,7 +879,10 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
 
   const registerDynamicClient = (
     input: RegisterDynamicClientInput,
-  ): Effect.Effect<OAuthClientSlug, OAuthRegisterDynamicError | StorageFailure> =>
+  ): Effect.Effect<
+    OAuthClientSlug,
+    OAuthRegisterDynamicError | OrgWriteDeniedError | StorageFailure
+  > =>
     Effect.gen(function* () {
       const issuer = canonicalDcrIssuer(input.issuer, input.registrationEndpoint);
       // Resolved before the reuse decision: a persisted client registered with
@@ -1044,8 +1057,12 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
   // -----------------------------------------------------------------------
   const start = (
     input: OAuthStartInput,
-  ): Effect.Effect<ConnectResult, OAuthStartError | StorageFailure> =>
+  ): Effect.Effect<ConnectResult, OAuthStartError | OrgWriteDeniedError | StorageFailure> =>
     Effect.gen(function* () {
+      // Gate BEFORE any session row or upstream exchange: minting a Workspace
+      // connection (including a reconnect that would replace its credential)
+      // is a workspace-level change.
+      yield* deps.guardOrgWrite(input.owner);
       const keys = yield* Effect.try({
         try: () => deps.ownedKeys(input.owner),
         catch: (cause) =>

--- a/packages/core/sdk/src/org-writes.test.ts
+++ b/packages/core/sdk/src/org-writes.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  OAuthClientSlug,
+  ProviderItemId,
+  ProviderKey,
+  ToolAddress,
+  ToolName,
+} from "./ids";
+import { createExecutor } from "./executor";
+import { definePlugin } from "./plugin";
+import type { CredentialProvider } from "./provider";
+import { makeTestConfig } from "./testing";
+
+// ---------------------------------------------------------------------------
+// `ExecutorConfig.orgWrites` — the workspace-settings gate.
+//
+// A `"denied"` binding (a plain member) may USE workspace resources — read
+// them, execute tools over org connections — but every user-intent
+// workspace-level mutation refuses with `OrgWriteDeniedError`: org-owned
+// policies / connections / OAuth clients, and the tenant-shared integration
+// catalog. `"allowed"` (admins, and hosts with no role model) behaves exactly
+// as before.
+//
+// The fixtures build TWO executors over ONE test database: an admin
+// (default `orgWrites`) that seeds the workspace, and a member
+// (`orgWrites: "denied"`) that the assertions run against.
+// ---------------------------------------------------------------------------
+
+const memoryProvider = (): CredentialProvider => {
+  const store = new Map<string, string>();
+  return {
+    key: ProviderKey.make("memory"),
+    writable: true,
+    get: (id) => Effect.sync(() => store.get(String(id)) ?? null),
+    set: (id, value) => Effect.sync(() => void store.set(String(id), value)),
+    has: (id) => Effect.sync(() => store.has(String(id))),
+    list: () =>
+      Effect.sync(() =>
+        Array.from(store.keys()).map((key) => ({
+          id: ProviderItemId.make(key),
+          name: key,
+        })),
+      ),
+  };
+};
+
+const INTEG = IntegrationSlug.make("vercel");
+const TEMPLATE = AuthTemplateSlug.make("apiKey");
+
+const demoPlugin = definePlugin(() => ({
+  id: "demo" as const,
+  credentialProviders: [memoryProvider()],
+  storage: () => ({}),
+  resolveTools: () =>
+    Effect.succeed({
+      tools: [{ name: ToolName.make("deploy"), description: "deploy" }],
+    }),
+  invokeTool: ({ toolRow, credential }) =>
+    Effect.succeed({ ran: toolRow.name, value: credential.value }),
+  extension: (ctx) => ({
+    seed: () =>
+      ctx.core.integrations.register({
+        slug: INTEG,
+        description: "Vercel",
+        config: {},
+      }),
+    seedFresh: () =>
+      ctx.core.integrations.register({
+        slug: IntegrationSlug.make("fresh"),
+        description: "Fresh",
+        config: {},
+      }),
+  }),
+}))();
+
+const setup = () =>
+  Effect.gen(function* () {
+    const config = makeTestConfig({ plugins: [demoPlugin] as const });
+    const admin = yield* createExecutor(config);
+    const member = yield* createExecutor({ ...config, orgWrites: "denied" });
+    yield* Effect.addFinalizer(() =>
+      admin.close().pipe(Effect.andThen(member.close()), Effect.ignore),
+    );
+    yield* admin.demo.seed();
+    return { admin, member };
+  });
+
+const expectOrgWriteDenied = <A, R>(effect: Effect.Effect<A, unknown, R>) =>
+  effect.pipe(
+    Effect.flip,
+    Effect.map((error) => {
+      expect(error).toMatchObject({ _tag: "OrgWriteDeniedError" });
+    }),
+  );
+
+describe("orgWrites: denied", () => {
+  it.effect("refuses org tool policies but accepts user ones", () =>
+    Effect.gen(function* () {
+      const { member } = yield* setup();
+      yield* expectOrgWriteDenied(
+        member.policies.create({ owner: "org", pattern: "*", action: "block" }),
+      );
+      const mine = yield* member.policies.create({
+        owner: "user",
+        pattern: "*",
+        action: "require_approval",
+      });
+      yield* expectOrgWriteDenied(
+        member.policies.update({ id: mine.id, owner: "org", action: "block" }),
+      );
+      yield* expectOrgWriteDenied(member.policies.remove({ id: mine.id, owner: "org" }));
+      yield* member.policies.update({ id: mine.id, owner: "user", action: "approve" });
+      yield* member.policies.remove({ id: mine.id, owner: "user" });
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("refuses org connections but accepts personal ones", () =>
+    Effect.gen(function* () {
+      const { admin, member } = yield* setup();
+      yield* expectOrgWriteDenied(
+        member.connections.create({
+          owner: "org",
+          name: ConnectionName.make("shared"),
+          integration: INTEG,
+          template: TEMPLATE,
+          value: "org-token",
+        }),
+      );
+      const personal = yield* member.connections.create({
+        owner: "user",
+        name: ConnectionName.make("mine"),
+        integration: INTEG,
+        template: TEMPLATE,
+        value: "user-token",
+      });
+      expect(personal.owner).toBe("user");
+
+      const shared = yield* admin.connections.create({
+        owner: "org",
+        name: ConnectionName.make("shared"),
+        integration: INTEG,
+        template: TEMPLATE,
+        value: "org-token",
+      });
+      const ref = { owner: shared.owner, integration: shared.integration, name: shared.name };
+      yield* expectOrgWriteDenied(member.connections.update(ref, { description: "renamed" }));
+      yield* expectOrgWriteDenied(member.connections.remove(ref));
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("still USES the workspace: reads org rows and executes org-connection tools", () =>
+    Effect.gen(function* () {
+      const { admin, member } = yield* setup();
+      yield* admin.connections.create({
+        owner: "org",
+        name: ConnectionName.make("shared"),
+        integration: INTEG,
+        template: TEMPLATE,
+        value: "org-token",
+      });
+      const visible = yield* member.connections.list({ owner: "org" });
+      expect(visible.map((c) => String(c.name))).toContain("shared");
+      const out = yield* member.execute(ToolAddress.make("tools.vercel.org.shared.deploy"), {});
+      expect(out).toMatchObject({ ran: "deploy", value: "org-token" });
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("refuses catalog mutations: new registration, update, health check, removal", () =>
+    Effect.gen(function* () {
+      const { member } = yield* setup();
+      // A NEW slug is refused through the plugin ctx register path (the seam
+      // every add-integration flow funnels through)…
+      yield* expectOrgWriteDenied(member.demo.seedFresh());
+      const fresh = yield* member.integrations.get(IntegrationSlug.make("fresh"));
+      expect(fresh).toBeNull();
+      // …and so are the public catalog mutations.
+      yield* expectOrgWriteDenied(member.integrations.update(INTEG, { name: "Renamed" }));
+      yield* expectOrgWriteDenied(member.integrations.healthCheck.set(INTEG, null));
+      yield* expectOrgWriteDenied(member.integrations.remove(INTEG));
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("keeps the register REPLACE arm open (config rewrites converge for members)", () =>
+    Effect.gen(function* () {
+      const { member } = yield* setup();
+      // The admin already registered `vercel`; re-registering the same slug on
+      // the denied binding is the replace arm and must succeed — this is the
+      // path catalog rebuilds and legacy healing converge through.
+      yield* member.demo.seed();
+      const row = yield* member.integrations.get(INTEG);
+      expect(row?.slug).toBe(INTEG);
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("refuses org OAuth clients and org connect flows", () =>
+    Effect.gen(function* () {
+      const { member } = yield* setup();
+      yield* expectOrgWriteDenied(
+        member.oauth.createClient({
+          owner: "org",
+          slug: OAuthClientSlug.make("shared-app"),
+          authorizationUrl: "https://example.com/authorize",
+          tokenUrl: "https://example.com/token",
+          grant: "authorization_code",
+          clientId: "client-id",
+          clientSecret: "",
+        }),
+      );
+      yield* expectOrgWriteDenied(
+        member.oauth.removeClient("org", OAuthClientSlug.make("shared-app")),
+      );
+      yield* expectOrgWriteDenied(
+        member.oauth.start({
+          owner: "org",
+          clientOwner: "org",
+          client: OAuthClientSlug.make("shared-app"),
+          integration: INTEG,
+          template: TEMPLATE,
+          name: ConnectionName.make("shared"),
+        }),
+      );
+      // Personal clients stay open.
+      const slug = yield* member.oauth.createClient({
+        owner: "user",
+        slug: OAuthClientSlug.make("my-app"),
+        authorizationUrl: "https://example.com/authorize",
+        tokenUrl: "https://example.com/token",
+        grant: "authorization_code",
+        clientId: "client-id",
+        clientSecret: "",
+      });
+      expect(String(slug)).toBe("my-app");
+    }).pipe(Effect.scoped),
+  );
+});
+
+describe("orgWrites: default (allowed)", () => {
+  it.effect("admin bindings mutate workspace-level state as before", () =>
+    Effect.gen(function* () {
+      const { admin } = yield* setup();
+      const policy = yield* admin.policies.create({
+        owner: "org",
+        pattern: "*",
+        action: "require_approval",
+      });
+      expect(policy.owner).toBe("org");
+      yield* admin.policies.remove({ id: policy.id, owner: "org" });
+      yield* admin.integrations.update(INTEG, { name: "Vercel (renamed)" });
+      const row = yield* admin.integrations.get(INTEG);
+      expect(row?.name).toBe("Vercel (renamed)");
+    }).pipe(Effect.scoped),
+  );
+});

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -47,6 +47,7 @@ import type {
   IntegrationNotFoundError,
   IntegrationRemovalNotAllowedError,
   InvalidConnectionInputError,
+  OrgWriteDeniedError,
 } from "./errors";
 import type { OAuthService } from "./oauth-client";
 import type { CredentialProvider, ProviderEntry } from "./provider";
@@ -162,8 +163,12 @@ export interface PluginCtx<TStore = unknown> {
 
   readonly core: {
     readonly integrations: {
-      /** Register / replace this plugin's integration in the catalog. */
-      readonly register: (input: RegisterIntegrationInput) => Effect.Effect<void, StorageFailure>;
+      /** Register / replace this plugin's integration in the catalog. A NEW
+       *  row is a workspace-level change gated by the executor's `orgWrites`
+       *  binding; replacing an existing row stays open at every role. */
+      readonly register: (
+        input: RegisterIntegrationInput,
+      ) => Effect.Effect<void, OrgWriteDeniedError | StorageFailure>;
       readonly update: (
         slug: IntegrationSlug,
         patch: {
@@ -171,21 +176,24 @@ export interface PluginCtx<TStore = unknown> {
           readonly description?: string;
           readonly config?: IntegrationConfig;
         },
-      ) => Effect.Effect<void, StorageFailure>;
+      ) => Effect.Effect<void, OrgWriteDeniedError | StorageFailure>;
       readonly list: () => Effect.Effect<readonly Integration[], StorageFailure>;
       readonly get: (
         slug: IntegrationSlug,
       ) => Effect.Effect<IntegrationRecord | null, StorageFailure>;
       readonly remove: (
         slug: IntegrationSlug,
-      ) => Effect.Effect<void, IntegrationRemovalNotAllowedError | StorageFailure>;
+      ) => Effect.Effect<
+        void,
+        IntegrationRemovalNotAllowedError | OrgWriteDeniedError | StorageFailure
+      >;
       /** Declare (or clear, with null) the integration's health check. Core
        *  owns this storage; plugins call it e.g. to install a zero-config
        *  default probe at registration time. */
       readonly setHealthCheck: (
         slug: IntegrationSlug,
         spec: HealthCheckSpec | null,
-      ) => Effect.Effect<void, StorageFailure>;
+      ) => Effect.Effect<void, OrgWriteDeniedError | StorageFailure>;
       readonly detect: (
         url: string,
       ) => Effect.Effect<readonly IntegrationDetectionResult[], StorageFailure>;
@@ -194,9 +202,15 @@ export interface PluginCtx<TStore = unknown> {
     };
     readonly policies: {
       readonly list: () => Effect.Effect<readonly ToolPolicy[], StorageFailure>;
-      readonly create: (input: CreateToolPolicyInput) => Effect.Effect<ToolPolicy, StorageFailure>;
-      readonly update: (input: UpdateToolPolicyInput) => Effect.Effect<ToolPolicy, StorageFailure>;
-      readonly remove: (input: RemoveToolPolicyInput) => Effect.Effect<void, StorageFailure>;
+      readonly create: (
+        input: CreateToolPolicyInput,
+      ) => Effect.Effect<ToolPolicy, OrgWriteDeniedError | StorageFailure>;
+      readonly update: (
+        input: UpdateToolPolicyInput,
+      ) => Effect.Effect<ToolPolicy, OrgWriteDeniedError | StorageFailure>;
+      readonly remove: (
+        input: RemoveToolPolicyInput,
+      ) => Effect.Effect<void, OrgWriteDeniedError | StorageFailure>;
     };
   };
 
@@ -210,6 +224,7 @@ export interface PluginCtx<TStore = unknown> {
       | IntegrationNotFoundError
       | CredentialProviderNotRegisteredError
       | InvalidConnectionInputError
+      | OrgWriteDeniedError
       | StorageFailure
     >;
     readonly list: (filter?: {
@@ -221,10 +236,10 @@ export interface PluginCtx<TStore = unknown> {
     readonly update: (
       ref: ConnectionRef,
       input: UpdateConnectionInput,
-    ) => Effect.Effect<Connection, ConnectionNotFoundError | StorageFailure>;
+    ) => Effect.Effect<Connection, ConnectionNotFoundError | OrgWriteDeniedError | StorageFailure>;
     readonly remove: (
       ref: ConnectionRef,
-    ) => Effect.Effect<void, ConnectionNotFoundError | StorageFailure>;
+    ) => Effect.Effect<void, ConnectionNotFoundError | OrgWriteDeniedError | StorageFailure>;
     readonly refresh: (
       ref: ConnectionRef,
     ) => Effect.Effect<

--- a/packages/core/sdk/src/shared.ts
+++ b/packages/core/sdk/src/shared.ts
@@ -59,6 +59,7 @@ export {
   IntegrationNotFoundError,
   IntegrationAlreadyExistsError,
   IntegrationRemovalNotAllowedError,
+  OrgWriteDeniedError,
   ConnectionNotFoundError,
   InvalidConnectionInputError,
   CredentialProviderNotRegisteredError,

--- a/packages/core/sdk/src/test-config.ts
+++ b/packages/core/sdk/src/test-config.ts
@@ -123,6 +123,10 @@ export type TestConfigOptions<TPlugins extends readonly AnyPlugin[] = readonly [
   readonly redirectUri?: string | null;
   readonly oauthCallbackStateOrgSlug?: string;
   readonly onIntegrationChange?: ExecutorConfig<TPlugins>["onIntegrationChange"];
+  /** Workspace-settings permission for the test binding (see
+   *  `ExecutorConfig.orgWrites`). Defaults to allowed, like production hosts
+   *  with no role model. */
+  readonly orgWrites?: ExecutorConfig<TPlugins>["orgWrites"];
 };
 
 export const makeTestConfig = <const TPlugins extends readonly AnyPlugin[] = readonly []>(
@@ -162,6 +166,7 @@ export const makeTestConfig = <const TPlugins extends readonly AnyPlugin[] = rea
     onElicitation: "accept-all",
     onIntegrationChange: options?.onIntegrationChange,
     ...(redirectUri != null ? { redirectUri } : {}),
+    ...(options?.orgWrites === undefined ? {} : { orgWrites: options.orgWrites }),
     oauthCallbackStateOrgSlug: options?.oauthCallbackStateOrgSlug,
   };
 };

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -100,6 +100,14 @@ export interface SessionMeta {
    * Pins browser-handoff URLs to the right org's console. */
   readonly organizationSlug?: string;
   readonly userId: string;
+  /**
+   * The member's normalized workspace role at session-meta resolution time.
+   * `"member"` binds the session executor with workspace writes denied
+   * (`orgWrites: "denied"`); `"admin"` binds allowed. Absent means the host
+   * has no role model (host-cf's single-tenant Access principal) — or the
+   * session was persisted before the field existed — and behaves as allowed.
+   */
+  readonly orgRole?: "admin" | "member";
   readonly elicitationMode?: McpElicitationMode;
   /** Whether the session serves artifacts (carried from {@link McpSessionInit}).
    *  Absent — including for sessions persisted before the flag existed — means

--- a/packages/hosts/mcp/src/seams.ts
+++ b/packages/hosts/mcp/src/seams.ts
@@ -48,6 +48,11 @@ export const Principal = Schema.Struct({
   name: Schema.NullOr(Schema.String),
   avatarUrl: Schema.NullOr(Schema.String),
   roles: Schema.Array(Schema.String),
+  /** The member's normalized workspace role, when the auth provider resolves
+   *  one (mirrors `Principal.orgRole` in `@executor-js/api/server`). `"member"`
+   *  binds the session executor with workspace writes denied; `"admin"` — or
+   *  absent, for hosts with no role model — binds allowed. */
+  orgRole: Schema.optional(Schema.Literals(["admin", "member"])),
 });
 
 export type Principal = Schema.Schema.Type<typeof Principal>;

--- a/packages/plugins/graphql/src/api/group.ts
+++ b/packages/plugins/graphql/src/api/group.ts
@@ -1,6 +1,10 @@
 import { HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi";
 import { Schema } from "effect";
-import { InternalError, IntegrationAlreadyExistsError } from "@executor-js/sdk/shared";
+import {
+  InternalError,
+  IntegrationAlreadyExistsError,
+  OrgWriteDeniedError,
+} from "@executor-js/sdk/shared";
 
 import { GraphqlIntrospectionError, GraphqlExtractionError } from "../sdk/errors";
 import { GraphqlAuthMethod, GraphqlAuthMethodInput } from "../sdk/types";
@@ -87,6 +91,7 @@ const GraphqlErrors = [
   IntrospectionError,
   ExtractionError,
   IntegrationAlreadyExistsError,
+  OrgWriteDeniedError,
 ] as const;
 
 export const GraphqlGroup = HttpApiGroup.make("graphql")

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -19,6 +19,7 @@ import {
   type HealthCheckResult,
   type IntegrationConfig,
   type IntegrationRecord,
+  type OrgWriteDeniedError,
   type PluginCtx,
   type StorageFailure,
   type ToolAnnotations,
@@ -1020,7 +1021,7 @@ const makeGraphqlExtension = (ctx: PluginCtx<GraphqlStore>) => {
   const configureAuthMethods = (
     slug: string,
     input: GraphqlConfigureAuthInput,
-  ): Effect.Effect<readonly GraphqlAuthMethod[], StorageFailure> =>
+  ): Effect.Effect<readonly GraphqlAuthMethod[], OrgWriteDeniedError | StorageFailure> =>
     ctx.transaction(
       Effect.gen(function* () {
         const record = yield* ctx.core.integrations.get(IntegrationSlug.make(slug));

--- a/packages/plugins/mcp/src/api/group.ts
+++ b/packages/plugins/mcp/src/api/group.ts
@@ -4,6 +4,7 @@ import {
   IntegrationSlug,
   InternalError,
   IntegrationAlreadyExistsError,
+  OrgWriteDeniedError,
 } from "@executor-js/sdk/shared";
 
 import { McpConnectionError, McpToolDiscoveryError } from "../sdk/errors";
@@ -149,6 +150,7 @@ export const McpGroup = HttpApiGroup.make("mcp")
         McpConnectionError,
         McpToolDiscoveryError,
         IntegrationAlreadyExistsError,
+        OrgWriteDeniedError,
       ],
     }),
   )
@@ -156,7 +158,7 @@ export const McpGroup = HttpApiGroup.make("mcp")
     HttpApiEndpoint.delete("removeServer", "/mcp/servers/:slug", {
       params: SlugParams,
       success: RemoveServerResponse,
-      error: [InternalError, McpConnectionError, McpToolDiscoveryError],
+      error: [InternalError, McpConnectionError, McpToolDiscoveryError, OrgWriteDeniedError],
     }),
   )
   .add(
@@ -171,7 +173,7 @@ export const McpGroup = HttpApiGroup.make("mcp")
       params: SlugParams,
       payload: ConfigureServerPayload,
       success: ConfigureServerResponse,
-      error: [InternalError, McpConnectionError, McpToolDiscoveryError],
+      error: [InternalError, McpConnectionError, McpToolDiscoveryError, OrgWriteDeniedError],
     }),
   )
   .add(
@@ -179,6 +181,6 @@ export const McpGroup = HttpApiGroup.make("mcp")
       params: SlugParams,
       payload: ConfigureAuthPayload,
       success: ConfigureAuthResponse,
-      error: [InternalError, McpConnectionError, McpToolDiscoveryError],
+      error: [InternalError, McpConnectionError, McpToolDiscoveryError, OrgWriteDeniedError],
     }),
   );

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -23,6 +23,7 @@ import {
   type IntegrationConfig,
   type IntegrationRecord,
   type OAuthClientSummary,
+  type OrgWriteDeniedError,
   type Owner,
   type PluginCtx,
   type StaticToolSchema,
@@ -1667,12 +1668,17 @@ export interface McpPluginExtension {
     input: McpServerInput,
   ) => Effect.Effect<
     { readonly slug: string },
-    McpExtensionFailure | IntegrationAlreadyExistsError
+    McpExtensionFailure | IntegrationAlreadyExistsError | OrgWriteDeniedError
   >;
-  readonly removeServer: (slug: string) => Effect.Effect<void, McpExtensionFailure>;
+  readonly removeServer: (
+    slug: string,
+  ) => Effect.Effect<void, McpExtensionFailure | OrgWriteDeniedError>;
   /** Ensure every stdio integration has its default connection (migrating any
    *  legacy inline env into the secret store). Idempotent; safe to run at boot. */
-  readonly reconcileStdioConnections: () => Effect.Effect<void, McpExtensionFailure>;
+  readonly reconcileStdioConnections: () => Effect.Effect<
+    void,
+    McpExtensionFailure | OrgWriteDeniedError
+  >;
   readonly getServer: (
     slug: string,
   ) => Effect.Effect<
@@ -1682,9 +1688,9 @@ export interface McpPluginExtension {
   readonly configureServer: (
     slug: string,
     config: McpIntegrationConfigType,
-  ) => Effect.Effect<void, McpExtensionFailure>;
+  ) => Effect.Effect<void, McpExtensionFailure | OrgWriteDeniedError>;
   readonly configureAuth: (
     slug: string,
     input: McpConfigureAuthInput,
-  ) => Effect.Effect<readonly McpAuthMethod[], McpExtensionFailure>;
+  ) => Effect.Effect<readonly McpAuthMethod[], McpExtensionFailure | OrgWriteDeniedError>;
 }

--- a/packages/plugins/openapi/src/api/group.ts
+++ b/packages/plugins/openapi/src/api/group.ts
@@ -7,6 +7,7 @@ import {
   IntegrationAlreadyExistsError,
   IntegrationNotFoundError,
   IntegrationSlug,
+  OrgWriteDeniedError,
 } from "@executor-js/sdk/shared";
 
 import {
@@ -33,6 +34,7 @@ const DomainErrors = [
   OpenApiOAuthError,
   OpenApiSpecOverrideError,
   IntegrationAlreadyExistsError,
+  OrgWriteDeniedError,
 ] as const;
 
 const IntegrationNotFound = IntegrationNotFoundError.annotate({ httpApiStatus: 404 });
@@ -44,6 +46,7 @@ const UpdateSpecErrors = [
   OpenApiOAuthError,
   OpenApiSpecOverrideError,
   IntegrationNotFound,
+  OrgWriteDeniedError,
 ] as const;
 
 const SlugParams = {

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -18,6 +18,7 @@ import {
   type IntegrationConfig,
   type IntegrationPreset,
   type IntegrationRecord,
+  type OrgWriteDeniedError,
   type PluginCtx,
   type StorageFailure,
 } from "@executor-js/sdk/core";
@@ -165,6 +166,7 @@ export interface OpenApiPluginExtension {
     | OpenApiOAuthError
     | OpenApiSpecOverrideError
     | IntegrationAlreadyExistsError
+    | OrgWriteDeniedError
     | StorageFailure
   >;
   /** Re-resolve the integration's spec (from its stored source URL, or the
@@ -180,9 +182,10 @@ export interface OpenApiPluginExtension {
     | OpenApiOAuthError
     | OpenApiSpecOverrideError
     | IntegrationNotFoundError
+    | OrgWriteDeniedError
     | StorageFailure
   >;
-  readonly removeSpec: (slug: string) => Effect.Effect<void, StorageFailure>;
+  readonly removeSpec: (slug: string) => Effect.Effect<void, OrgWriteDeniedError | StorageFailure>;
   readonly getIntegration: (slug: string) => Effect.Effect<Integration | null, StorageFailure>;
   /** Read the integration's full opaque config, including its
    *  `authenticationTemplate`. Returns null when the integration is absent. */
@@ -194,7 +197,7 @@ export interface OpenApiPluginExtension {
   readonly configure: (
     slug: string,
     input: OpenApiConfigureInput,
-  ) => Effect.Effect<readonly Authentication[], StorageFailure>;
+  ) => Effect.Effect<readonly Authentication[], OrgWriteDeniedError | StorageFailure>;
 }
 
 // ---------------------------------------------------------------------------
@@ -1140,7 +1143,7 @@ export const openApiPlugin = definePlugin<
         configure: (
           slug: string,
           input: OpenApiConfigureInput,
-        ): Effect.Effect<readonly Authentication[], StorageFailure> =>
+        ): Effect.Effect<readonly Authentication[], OrgWriteDeniedError | StorageFailure> =>
           ctx.transaction(
             Effect.gen(function* () {
               const record = yield* ctx.core.integrations.get(IntegrationSlug.make(slug));


### PR DESCRIPTION
Members can still USE workspace resources — read them, execute tools over shared connections, and the operational writes those imply (token refresh, tool-catalog re-sync, config-rewrite healing) — but CONFIGURING them is now admin-only.

## What's gated

The executor binding gains `orgWrites: "allowed" | "denied"`, enforced at the top of every user-intent workspace-level mutation with a new `OrgWriteDeniedError` (403):

- org-owned tool policies (create/update/remove)
- workspace-shared connections (create/update/remove, org OAuth connect/reconnect)
- org OAuth apps (create/remove, incl. DCR persisting an org client)
- the integration catalog (new registration, update, remove, health check) — including the plugin extension surfaces (openapi addSpec/updateSpec/configure, mcp add/remove/configure server, graphql add/configure)

Deliberately a surface gate rather than a storage-policy axis: catalog rebuilds, legacy stdio healing, and OAuth token refresh on shared connections must keep converging under any member's binding.

## Role plumbing

- cloud: `authorizeOrganization` now surfaces the WorkOS membership role (no extra API call); HTTP requests and MCP sessions bind from it. MCP sessions bake the role at session init, so a demotion applies from the next session, and sessions persisted before this field existed keep their old behavior until re-init.
- self-host: the identity seam resolves the Better Auth org membership role (same explicit-org query as the admin gate); the MCP OAuth-bearer path reads the membership row directly. Fails closed to member.
- local / CLI / host-cf (single-tenant Access): no role model, binding stays allowed.

## Tests

- `packages/core/sdk/src/org-writes.test.ts`: denied vs allowed bindings across policies, connections, catalog, OAuth — including that members still execute tools over org connections and that the register replace-arm stays open.
- `apps/host-selfhost/src/multi-user.test.ts`: member 403s end-to-end through real Better Auth; admin setup unchanged.
- Full repo gates green (`format:check`, `lint`, `typecheck`, `test`). `apps/cloud/src/account/org-api-key-revoke.node.test.ts` fails on main already (pre-existing, untouched).

## Not in this PR

Console UI affordance (hiding the Workspace owner option and catalog mutations for non-admins) — the server now answers 403 and the console renders the error; the nav-level admin gate (`packages/react/src/lib/admin-access.ts`) already exists to build on.