### PR TITLE
Reland outbound MCP client on SDK v2 (spec 2026-07-28)

### DIFF
--- a/.changeset/reland-outbound-mcp-v2.md
+++ b/.changeset/reland-outbound-mcp-v2.md
@@ -1,0 +1,5 @@
+---
+"@executor-js/plugin-mcp": minor
+---
+
+Restore MCP spec 2026-07-28 negotiation for outbound MCP connections. Remote Streamable HTTP connections auto-negotiate the modern protocol era again, stdio servers can opt in per integration, and the negotiated era is recorded on connection handshake traces.

--- a/bun.lock
+++ b/bun.lock
@@ -721,7 +721,7 @@
         "@executor-js/react": "workspace:*",
         "@executor-js/runtime-quickjs": "workspace:*",
         "@modelcontextprotocol/ext-apps": "^1.7.4",
-        "@modelcontextprotocol/sdk": "^1.12.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@tanstack/react-query": "^5.99.0",
         "effect": "catalog:",
         "esbuild": "^0.27.7",
@@ -994,6 +994,8 @@
         "@effect/platform-node": "catalog:",
         "@executor-js/config": "workspace:*",
         "@executor-js/sdk": "workspace:*",
+        "@modelcontextprotocol/client": "2.0.0",
+        "@modelcontextprotocol/core": "2.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "4.3.6",
       },
@@ -1002,6 +1004,7 @@
         "@effect/vitest": "catalog:",
         "@executor-js/api": "workspace:*",
         "@executor-js/react": "workspace:*",
+        "@modelcontextprotocol/server": "2.0.0",
         "@types/node": "catalog:",
         "@types/react": "catalog:",
         "bun-types": "catalog:",
@@ -2120,9 +2123,15 @@
 
     "@mishieck/ink-titled-box": ["@mishieck/ink-titled-box@0.3.0", "", { "peerDependencies": { "ink": "^6.0.0", "react": "^19.1.0", "typescript": "^5" } }, "sha512-ugzVH9hixp3hwKfQ8On/qnsrdAxS3y9rTu/aGOFed4zVUvtZyGZNIR4rxAwXult8HKI4vJEh0OM8wib9NPrwUg=="],
 
+    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.2.0" } }, "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw=="],
+
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA=="],
+
     "@modelcontextprotocol/ext-apps": ["@modelcontextprotocol/ext-apps@1.7.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-TjPH2S2y5UEGKhmI6+XGFuqfqOV4ppe1x6DA3txnUaEWkgtA4G5vo14jGKFZmegdkZ1H4QMLyujLvoU1BEdnAg=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "zod": "^4.2.0" } }, "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
 
@@ -6106,7 +6115,15 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
+    "@modelcontextprotocol/client/jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "@modelcontextprotocol/client/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "@modelcontextprotocol/core/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
     "@modelcontextprotocol/sdk/jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "@modelcontextprotocol/server/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/e2e/local/stdio-mcp.test.ts
+++ b/e2e/local/stdio-mcp.test.ts
@@ -146,6 +146,36 @@ scenario(
           declTools.map((t) => t.name),
           "connecting with the secret discovers the env-gated tool",
         ).toContain("whoami");
+
+        // --- versionNegotiation "auto" survives the API → config → connector
+        // path and still reaches a legacy server: the probe gets the fixture's
+        // method-not-found for `server/discover` (a definitive legacy verdict)
+        // and falls back to `initialize`. Modern-era acceptance against a real
+        // legacy-disabled SDK v2 server lives in the plugin's
+        // stdio-negotiation.test.ts. ---
+        const autoSlug = "e2e-stdio-auto";
+        yield* client.mcp.addServer({
+          payload: {
+            transport: "stdio",
+            name: "E2E Stdio Auto",
+            command: "node",
+            args: [FIXTURE],
+            versionNegotiation: "auto",
+            slug: autoSlug,
+          },
+        });
+
+        const autoStored = yield* client.mcp.getServer({ params: { slug: autoSlug } });
+        expect(
+          JSON.stringify(autoStored?.config ?? {}),
+          "the negotiation mode is persisted on the integration config",
+        ).toContain('"versionNegotiation":"auto"');
+
+        const autoTools = yield* client.tools.list({ query: { integration: autoSlug } });
+        expect(
+          autoTools.map((t) => t.name),
+          "auto negotiation falls back to legacy and still discovers tools",
+        ).toContain("echo_tool");
       }),
     );
   }),

--- a/packages/hosts/mcp-apps-shell/package.json
+++ b/packages/hosts/mcp-apps-shell/package.json
@@ -69,7 +69,7 @@
     "@executor-js/react": "workspace:*",
     "@executor-js/runtime-quickjs": "workspace:*",
     "@modelcontextprotocol/ext-apps": "^1.7.4",
-    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@tanstack/react-query": "^5.99.0",
     "effect": "catalog:",
     "esbuild": "^0.27.7",

--- a/packages/plugins/mcp/package.json
+++ b/packages/plugins/mcp/package.json
@@ -65,6 +65,8 @@
     "@effect/platform-node": "catalog:",
     "@executor-js/config": "workspace:*",
     "@executor-js/sdk": "workspace:*",
+    "@modelcontextprotocol/client": "2.0.0",
+    "@modelcontextprotocol/core": "2.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "4.3.6"
   },
@@ -73,6 +75,7 @@
     "@effect/vitest": "catalog:",
     "@executor-js/api": "workspace:*",
     "@executor-js/react": "workspace:*",
+    "@modelcontextprotocol/server": "2.0.0",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "bun-types": "catalog:",

--- a/packages/plugins/mcp/src/api/group.ts
+++ b/packages/plugins/mcp/src/api/group.ts
@@ -57,6 +57,10 @@ const AddStdioServerPayload = Schema.Struct({
   /** One-shot secret env values (programmatic). The UI sends `envVars`. */
   env: Schema.optional(StringMap),
   cwd: Schema.optional(Schema.String),
+  /** Protocol negotiation at connect: `auto` probes `server/discover` (spec
+   *  2026-07-28) for modern-only servers; default is the legacy `initialize`
+   *  handshake. */
+  versionNegotiation: Schema.optional(Schema.Literals(["legacy", "auto"])),
   slug: Schema.optional(Schema.String),
 });
 

--- a/packages/plugins/mcp/src/api/handlers.ts
+++ b/packages/plugins/mcp/src/api/handlers.ts
@@ -39,6 +39,7 @@ const toServerInput = (
       envVars?: readonly string[];
       env?: Record<string, string>;
       cwd?: string;
+      versionNegotiation?: "legacy" | "auto";
       slug?: string;
     };
     return {
@@ -50,6 +51,7 @@ const toServerInput = (
       envVars: p.envVars ? [...p.envVars] : undefined,
       env: p.env,
       cwd: p.cwd,
+      versionNegotiation: p.versionNegotiation,
       slug: p.slug,
     };
   }

--- a/packages/plugins/mcp/src/sdk/connection-pool.ts
+++ b/packages/plugins/mcp/src/sdk/connection-pool.ts
@@ -3,6 +3,10 @@ import { Cause, Effect, Exit, Predicate } from "effect";
 import type { McpConnection, McpConnector } from "./connection";
 import type { McpInvocationError } from "./errors";
 
+// The pool preserves sessions for sessionful legacy servers. Stateless
+// 2026-07-28 servers do not need it, but retaining a cheap idle client is
+// harmless and keeps one lifecycle for both protocol eras.
+
 const IDLE_TTL_MS = 5 * 60 * 1_000;
 
 type IdleConnection = {

--- a/packages/plugins/mcp/src/sdk/connection.ts
+++ b/packages/plugins/mcp/src/sdk/connection.ts
@@ -1,16 +1,18 @@
-import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
-import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker";
+import {
+  Client,
+  SSEClientTransport,
+  StreamableHTTPClientTransport,
+  type FetchLike,
+  type OAuthClientProvider,
+} from "@modelcontextprotocol/client";
+import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/client/validators/cf-worker";
 import { Effect, Layer, Predicate, Stream } from "effect";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 
 // NOTE: `StdioClientTransport` is NOT imported eagerly. The upstream module
-// (`@modelcontextprotocol/sdk/client/stdio.js`) touches `node:child_process`
-// at evaluation time, which crashes workerd (incl. vitest-pool-workers) at
-// SIGSEGV on module instantiation. Cloud callers set
+// (`@modelcontextprotocol/client/stdio`) still imports Node process/stream and
+// `cross-spawn` eagerly at evaluation time, which crashes workerd (including
+// vitest-pool-workers) with SIGSEGV on module instantiation. Cloud callers set
 // `dangerouslyAllowStdioMCP: false` and never reach the stdio branch below;
 // prod bundles that DO use stdio load it via a dynamic import inside the
 // stdio branch of `createMcpConnector`.
@@ -201,12 +203,13 @@ const fetchFromHttpClientLayer = (
 // MCP plugin runs inside a Cloudflare Worker (executor.sh). The
 // cfworker validator does not use code generation and works in every
 // runtime we ship to.
-const createClient = (): Client =>
+const createClient = (versionNegotiation?: { readonly mode: "auto" }): Client =>
   new Client(
     { name: "executor-mcp", version: "0.1.0" },
     {
       capabilities: { elicitation: { form: {}, url: {} } },
       jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
+      ...(versionNegotiation === undefined ? {} : { versionNegotiation }),
     },
   );
 
@@ -247,9 +250,10 @@ const connectionFailure = (
 const connectClient = (input: {
   transport: string;
   createTransport: () => Parameters<Client["connect"]>[0];
+  versionNegotiation?: { readonly mode: "auto" };
 }): Effect.Effect<McpConnection, McpConnectionError | McpOAuthReauthorizationRequired> =>
   Effect.gen(function* () {
-    const client = createClient();
+    const client = createClient(input.versionNegotiation);
     const transportInstance = input.createTransport();
 
     yield* Effect.tryPromise({
@@ -262,6 +266,15 @@ const connectClient = (input: {
       catch: (cause) =>
         connectionFailure(input.transport, `Failed connecting via ${input.transport}`, cause),
     }).pipe(
+      // The negotiated era ("modern" = 2026-07-28 server/discover, "legacy" =
+      // 2025 initialize) is otherwise invisible: both eras list and call tools
+      // identically, so traces are the one place an integration author can
+      // verify which handshake a connection actually used.
+      Effect.tap(() =>
+        Effect.annotateCurrentSpan({
+          "plugin.mcp.protocol_era": client.getProtocolEra() ?? "unknown",
+        }),
+      ),
       Effect.withSpan("plugin.mcp.connection.handshake", {
         attributes: { "plugin.mcp.transport": input.transport },
       }),
@@ -300,6 +313,12 @@ export const createMcpConnector = (input: ConnectorInput): McpConnector => {
 
       return yield* connectClient({
         transport: "stdio",
+        // Opt-in per integration (default legacy) — see
+        // `McpStdioVersionNegotiation` for why stdio does not follow the
+        // remote transport's unconditional auto.
+        ...(input.versionNegotiation === "auto"
+          ? { versionNegotiation: { mode: "auto" as const } }
+          : {}),
         createTransport: () =>
           createStdioTransport({
             command,
@@ -319,8 +338,13 @@ export const createMcpConnector = (input: ConnectorInput): McpConnector => {
 
   const endpoint = buildEndpointUrl(input.endpoint, input.queryParams ?? {});
 
+  // Auto-negotiate the 2026-07-28 era unconditionally only on Streamable
+  // HTTP. SSE is a legacy-only transport; stdio negotiates per the
+  // integration's `versionNegotiation` (default legacy — see the stdio
+  // branch above).
   const connectStreamableHttp = connectClient({
     transport: "streamable-http",
+    versionNegotiation: { mode: "auto" },
     createTransport: () =>
       new StreamableHTTPClientTransport(endpoint, {
         requestInit,

--- a/packages/plugins/mcp/src/sdk/elicitation.test.ts
+++ b/packages/plugins/mcp/src/sdk/elicitation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Predicate, Schema, Semaphore } from "effect";
-import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker";
-import type { JsonSchemaType } from "@modelcontextprotocol/sdk/validation/types";
+import type { JsonSchemaType } from "@modelcontextprotocol/client";
+import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/client/validators/cf-worker";
 
 import {
   AuthTemplateSlug,
@@ -226,7 +226,7 @@ describe("MCP elicitation (end-to-end)", () => {
         ]),
       );
       expect(schema?.outputTypeScript).toContain('type: "text"');
-      expect(schema?.outputTypeScript).toContain("structuredContent?: { [k: string]: unknown; }");
+      expect(schema?.outputTypeScript).toContain("structuredContent?: unknown;");
 
       const result = yield* executor.execute(
         simpleEcho.address,

--- a/packages/plugins/mcp/src/sdk/http-status.test.ts
+++ b/packages/plugins/mcp/src/sdk/http-status.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
+import { InsufficientScopeError, SdkErrorCode, SdkHttpError } from "@modelcontextprotocol/client";
 
 // oxlint-disable executor/no-error-constructor -- boundary: these tests reproduce the MCP SDK's own transport rejections, which are built-in Errors
 import { insufficientScopeFromCause } from "./http-status";
@@ -9,7 +10,8 @@ import { insufficientScopeFromCause } from "./http-status";
 //   - with an authProvider (the production OAuth path): the StreamableHTTP
 //     transport consumes the insufficient_scope challenge itself, retries
 //     with the broader scope, and only when THAT fails throws the fixed
-//     "Server returned 403 after trying upscoping" message.
+//     typed `InsufficientScopeError`, or after retry exhaustion the fixed
+//     `SdkHttpError` step-up message.
 describe("insufficientScopeFromCause", () => {
   it("detects the OAuth error body embedded in a transport message", () => {
     expect(
@@ -31,9 +33,21 @@ describe("insufficientScopeFromCause", () => {
     ).toBe(true);
   });
 
-  it("detects the SDK's exhausted-upscoping failure (the authProvider path)", () => {
+  it("detects the SDK's typed insufficient-scope failure", () => {
     expect(
-      insufficientScopeFromCause(new Error("Server returned 403 after trying upscoping")),
+      insufficientScopeFromCause(new InsufficientScopeError({ requiredScope: "files.read" })),
+    ).toBe(true);
+  });
+
+  it("detects the SDK's exhausted step-up failure (the authProvider path)", () => {
+    expect(
+      insufficientScopeFromCause(
+        new SdkHttpError(
+          SdkErrorCode.ClientHttpForbidden,
+          "Server returned 403 insufficient_scope after step-up re-authorization (retry limit 2 reached)",
+          { status: 403 },
+        ),
+      ),
     ).toBe(true);
   });
 

--- a/packages/plugins/mcp/src/sdk/http-status.ts
+++ b/packages/plugins/mcp/src/sdk/http-status.ts
@@ -1,7 +1,8 @@
 // ---------------------------------------------------------------------------
 // Extract the HTTP status from an MCP SDK transport error. The SDK surfaces
-// transport failures two ways: a `StreamableHTTPError` subclass carrying a
-// numeric `code`, and an SSE POST failure whose message embeds `(HTTP nnn)`.
+// transport failures two ways: an `SdkHttpError` carrying a numeric `status`,
+// and an `SseError` carrying a numeric `code`. The SSE transport also retains
+// its historic POST-failure message for errors created below EventSource.
 // Shared by the invoke path (classifies tool-call failures) and the connect
 // path (so a 401/403 during the handshake reaches the liveness health check).
 // ---------------------------------------------------------------------------
@@ -9,13 +10,13 @@
 import { Option, Schema } from "effect";
 
 import { insufficientScopeFromEmbeddedJson } from "@executor-js/sdk/core";
-import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { InsufficientScopeError, SdkHttpError, SseError } from "@modelcontextprotocol/client";
 
 const SsePostErrorCause = Schema.Struct({ message: Schema.String });
 const decodeSsePostErrorCause = Schema.decodeUnknownOption(SsePostErrorCause);
 
-// Matches the SDK's SSEClientTransport POST-failure message (sse.js); re-verify
-// on SDK bumps. A format drift just yields undefined (generic error, no crash).
+// V2 still constructs this exact message in SSEClientTransport._send. A format
+// drift just yields undefined (generic error, no crash).
 const statusFromSsePostError = (cause: unknown): number | undefined =>
   Option.match(decodeSsePostErrorCause(cause), {
     onNone: () => undefined,
@@ -26,32 +27,36 @@ const statusFromSsePostError = (cause: unknown): number | undefined =>
     },
   });
 
-const statusFromStreamableHttpError = (cause: unknown): number | undefined => {
-  // oxlint-disable-next-line executor/no-instanceof-tagged-error -- boundary: MCP SDK exposes transport HTTP failures as this Error subclass; protocol errors can carry the same numeric code
-  if (!(cause instanceof StreamableHTTPError)) return undefined;
-  const code = cause.code;
-  return code !== undefined && code >= 100 && code <= 599 ? code : undefined;
+const statusFromTypedTransportError = (cause: unknown): number | undefined => {
+  if (SdkHttpError.isInstance(cause)) return cause.status;
+  if (SseError.isInstance(cause)) {
+    const code = cause.code;
+    return code !== undefined && code >= 100 && code <= 599 ? code : undefined;
+  }
+  return undefined;
 };
 
 export const httpStatusFromCause = (cause: unknown): number | undefined =>
-  statusFromStreamableHttpError(cause) ?? statusFromSsePostError(cause);
+  statusFromTypedTransportError(cause) ?? statusFromSsePostError(cause);
 
 // The SDK embeds the upstream response text in the transport error message
 // ("Error POSTing to endpoint: <body>"), which is the only place a 403's body
 // survives for connections without an authProvider. For OAuth connections the
-// StreamableHTTP transport consumes the insufficient_scope challenge ITSELF:
-// it re-runs auth requesting the broader scope, and only when that upscoped
-// retry still 403s does it throw — with the fixed message matched below
-// (verified against @modelcontextprotocol/sdk streamableHttp.js; re-verify on
-// SDK bumps). Both paths mean the same thing: the grant does not cover the
-// operation, and re-running the identical flow cannot help. Strict matching
+// StreamableHTTP transport consumes the insufficient_scope challenge itself.
+// V2 throws `InsufficientScopeError` when configured not to reauthorize; after
+// exhausting its step-up retries it throws `SdkHttpError` with the exact fixed
+// message matched below (verified against the installed v2 transport source).
+// Both paths mean the same thing: the grant does not cover the operation, and
+// re-running the identical flow cannot help. Strict matching
 // (exact serialized field forms via the shared core detector, or the SDK's
-// exact upscoping message) — a miss stays on the generic auth path.
-const SDK_UPSCOPING_EXHAUSTED_RE = /Server returned 403 after trying upscoping/;
+// exact step-up message) — a miss stays on the generic auth path.
+const SDK_STEP_UP_EXHAUSTED_RE =
+  /^Server returned 403 insufficient_scope after step-up re-authorization \(retry limit \d+ reached\)$/;
 
 export const insufficientScopeFromCause = (cause: unknown): boolean =>
+  InsufficientScopeError.isInstance(cause) ||
   Option.match(decodeSsePostErrorCause(cause), {
     onNone: () => false,
     onSome: ({ message }) =>
-      insufficientScopeFromEmbeddedJson(message) || SDK_UPSCOPING_EXHAUSTED_RE.test(message),
+      insufficientScopeFromEmbeddedJson(message) || SDK_STEP_UP_EXHAUSTED_RE.test(message),
   });

--- a/packages/plugins/mcp/src/sdk/invoke.test.ts
+++ b/packages/plugins/mcp/src/sdk/invoke.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect, Predicate } from "effect";
 import { HttpServerResponse } from "effect/unstable/http";
 
-import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
-import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import {
+  ProtocolError,
+  SdkErrorCode,
+  SdkHttpError,
+  type OAuthClientProvider,
+} from "@modelcontextprotocol/client";
 import { ElicitationResponse } from "@executor-js/sdk";
 import { serveTestHttpApp } from "@executor-js/sdk/testing";
 
@@ -108,14 +111,16 @@ const invocationRejectionCases = [
     name: "wraps callTool rejection with a stable message and status",
     toolId: "blocked",
     transport: "streamable-http",
-    cause: new StreamableHTTPError(401, "token=do-not-leak"),
+    cause: new SdkHttpError(SdkErrorCode.ClientHttpAuthentication, "token=do-not-leak", {
+      status: 401,
+    }),
     expectedStatus: 401 as number | undefined,
   },
   {
     name: "does not treat MCP protocol error codes as HTTP statuses",
     toolId: "protocol_error",
     transport: "streamable-http",
-    cause: new McpError(401, "application-level do-not-leak"),
+    cause: new ProtocolError(401, "application-level do-not-leak"),
     expectedStatus: undefined,
   },
   {

--- a/packages/plugins/mcp/src/sdk/invoke.ts
+++ b/packages/plugins/mcp/src/sdk/invoke.ts
@@ -8,7 +8,7 @@
 //      legitimately retain state in that session. The pool keeps one idle
 //      connection per resolved identity and leases it exclusively per invoke;
 //      stdio and callers without a pool remain strictly per-call.
-//   2. Installing a per-invocation `ElicitRequestSchema` handler that bridges
+//   2. Installing a per-invocation `elicitation/create` handler that bridges
 //      MCP's elicit capability into the host's elicit function threaded via
 //      `InvokeToolInput.elicit`.
 //   3. Calling `client.callTool({ name, arguments })`.
@@ -16,12 +16,7 @@
 
 import { Cause, Effect, Exit, Option, Predicate, Schema } from "effect";
 
-import {
-  ElicitRequestSchema,
-  ErrorCode,
-  McpError,
-  ToolListChangedNotificationSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { ProtocolError, ProtocolErrorCode } from "@modelcontextprotocol/client";
 
 import {
   ElicitationId,
@@ -66,9 +61,10 @@ export const isUnknownToolMessage = (message: string, toolName: string): boolean
 
 const isUnknownToolCause = (cause: unknown, toolName: string): boolean =>
   // oxlint-disable-next-line executor/no-instanceof-tagged-error -- boundary: MCP SDK surfaces JSON-RPC protocol errors as this Error subclass
-  cause instanceof McpError &&
-  (cause.code === ErrorCode.InvalidParams || cause.code === ErrorCode.MethodNotFound) &&
-  // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: instanceof narrows to the SDK's McpError, whose message carries the only unknown-tool discriminator the protocol provides
+  cause instanceof ProtocolError &&
+  (cause.code === ProtocolErrorCode.InvalidParams ||
+    cause.code === ProtocolErrorCode.MethodNotFound) &&
+  // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: instanceof narrows to the SDK's ProtocolError, whose message carries the only unknown-tool discriminator the protocol provides
   isUnknownToolMessage(cause.message, toolName);
 
 // ---------------------------------------------------------------------------
@@ -93,6 +89,17 @@ const McpElicitParams = Schema.Union([
 type McpElicitParams = typeof McpElicitParams.Type;
 
 const decodeElicitParams = Schema.decodeUnknownSync(McpElicitParams);
+const decodeElicitContent = Schema.decodeUnknownSync(
+  Schema.Record(
+    Schema.String,
+    Schema.Union([
+      Schema.String,
+      Schema.Number,
+      Schema.Boolean,
+      Schema.mutable(Schema.Array(Schema.String)),
+    ]),
+  ),
+);
 
 const toElicitationRequest = (params: McpElicitParams): ElicitationRequest =>
   params.mode === "url"
@@ -107,7 +114,7 @@ const toElicitationRequest = (params: McpElicitParams): ElicitationRequest =>
       });
 
 const installElicitationHandler = (client: McpConnection["client"], elicit: Elicit): void => {
-  client.setRequestHandler(ElicitRequestSchema, async (request: { params: unknown }) => {
+  client.setRequestHandler("elicitation/create", async (request: { params: unknown }) => {
     const params = decodeElicitParams(request.params);
     const req = toElicitationRequest(params);
     // Use runPromiseExit so we can inspect typed failures — `elicit`
@@ -119,7 +126,9 @@ const installElicitationHandler = (client: McpConnection["client"], elicit: Elic
       const response = exit.value;
       return {
         action: response.action,
-        ...(response.action === "accept" && response.content ? { content: response.content } : {}),
+        ...(response.action === "accept" && response.content
+          ? { content: decodeElicitContent(response.content) }
+          : {}),
       };
     }
     const failure = exit.cause.reasons.find(Cause.isFailReason);
@@ -149,7 +158,7 @@ const installToolListChangedHandler = (
   onToolListChanged: (() => void) | undefined,
 ): void => {
   if (!onToolListChanged) return;
-  client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+  client.setNotificationHandler("notifications/tools/list_changed", () => {
     onToolListChanged();
   });
 };
@@ -189,8 +198,8 @@ const useConnection = (
           });
         }
         const status = httpStatusFromCause(cause);
-        // oxlint-disable-next-line executor/no-instanceof-tagged-error -- boundary: MCP SDK protocol failures are its McpError subclass; transport failures use other error shapes
-        const protocolFailure = cause instanceof McpError;
+        // oxlint-disable-next-line executor/no-instanceof-tagged-error -- boundary: MCP SDK protocol failures are its ProtocolError subclass; transport failures use other error shapes
+        const protocolFailure = cause instanceof ProtocolError;
         return new McpInvocationError({
           toolName,
           message: `MCP tool call failed for ${toolName}`,

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -1,9 +1,8 @@
 import { Effect, Layer, Option, Result, Schema } from "effect";
 import type { HttpClient } from "effect/unstable/http";
 
-import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
-import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
-import * as z from "zod/v4";
+import type { OAuthClientProvider } from "@modelcontextprotocol/client";
+import { CallToolResultSchema } from "@modelcontextprotocol/core";
 
 import {
   authToolFailure,
@@ -62,6 +61,7 @@ import {
   expandMcpAuthMethodInputs,
   mcpAuthMethodFromShorthand,
   normalizeMcpAuthMethods,
+  McpStdioVersionNegotiation,
   parseMcpIntegrationConfig,
   type McpIntegrationConfig as McpIntegrationConfigType,
   type McpStdioEnvMethod,
@@ -208,6 +208,11 @@ const McpStdioServerInputSchema = Schema.Struct({
    *  instead and leaves the values to the connect step. */
   env: Schema.optional(Schema.Record(Schema.String, Schema.String)),
   cwd: Schema.optional(Schema.String),
+  /** Protocol negotiation at connect: `auto` probes `server/discover` (spec
+   *  2026-07-28) for modern-only servers. Defaults to the legacy `initialize`
+   *  handshake — the right call for spawn-per-call servers, where the auto
+   *  probe costs an extra child process per connect. */
+  versionNegotiation: Schema.optional(McpStdioVersionNegotiation),
   slug: Schema.optional(Schema.String),
 });
 
@@ -371,6 +376,7 @@ const toIntegrationConfig = (input: McpServerInput): McpIntegrationConfigType =>
       command: input.command,
       args: input.args ? [...input.args] : undefined,
       cwd: input.cwd,
+      versionNegotiation: input.versionNegotiation,
       authenticationTemplate:
         vars.length > 0
           ? [{ slug: STDIO_ENV_TEMPLATE, kind: "stdio_env", vars }]
@@ -393,7 +399,7 @@ type JsonSchemaObject = Record<string, unknown> & {
   readonly properties?: Record<string, unknown>;
 };
 
-const McpCallToolResultJsonSchema = z.toJSONSchema(CallToolResultSchema) as JsonSchemaObject;
+const McpCallToolResultJsonSchema: JsonSchemaObject = CallToolResultSchema.toJSONSchema();
 
 const mcpCallToolResultOutputSchema = (structuredContentSchema?: unknown): JsonSchemaObject => {
   const defaultStructuredContentSchema =
@@ -494,7 +500,9 @@ export const userFacingProbeMessage = (
 // MCP-SDK OAuth provider adapter — wraps a pre-resolved access token so the
 // transport sends it as a Bearer header. Refresh is core's responsibility
 // (the connection row carries the OAuth grant); this adapter never initiates
-// a new flow and fails loudly if the SDK tries to.
+// a new flow and fails loudly if the SDK tries to. V2 stamps stored credentials
+// with the authorization-server issuer and offers scoped invalidation; this
+// single-token boundary intentionally persists neither.
 // ---------------------------------------------------------------------------
 
 const makeOAuthProvider = (accessToken: string): OAuthClientProvider => ({
@@ -587,6 +595,7 @@ const buildConnectorInput = (
       args: config.args,
       env: Object.keys(env).length > 0 ? env : undefined,
       cwd: config.cwd,
+      versionNegotiation: config.versionNegotiation,
     } satisfies McpStdioIntegrationConfig);
   }
 
@@ -1045,6 +1054,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
                 command: config.command,
                 args: config.args,
                 cwd: config.cwd,
+                versionNegotiation: config.versionNegotiation,
                 authenticationTemplate: hasEnv
                   ? [{ slug: STDIO_ENV_TEMPLATE, kind: "stdio_env", vars: envVars }]
                   : [{ slug: "none", kind: "none" }],

--- a/packages/plugins/mcp/src/sdk/probe-shape.test.ts
+++ b/packages/plugins/mcp/src/sdk/probe-shape.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Ref } from "effect";
-import { HttpServerResponse } from "effect/unstable/http";
+import { Effect, Layer, Ref } from "effect";
+import {
+  HttpClient,
+  HttpClientError,
+  HttpClientRequest,
+  HttpClientResponse,
+  HttpServerResponse,
+} from "effect/unstable/http";
 import { serveTestHttpApp } from "@executor-js/sdk/testing";
 
 import { probeMcpEndpointShape } from "./probe-shape";
@@ -318,6 +324,88 @@ describe("probeMcpEndpointShape", () => {
           expect(result).toMatchObject({ kind: "not-mcp", category: "wrong-shape" });
         }),
     ),
+  );
+
+  it.effect("falls through a wrong-shape legacy GET retry to modern server discovery", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveProbeEndpoint((request) => {
+          if (request.body.includes('"method":"server/discover"')) {
+            return HttpServerResponse.jsonUnsafe({
+              jsonrpc: "2.0",
+              id: 2,
+              error: { code: -32601, message: "Method not found" },
+            });
+          }
+          if (request.method === "GET") {
+            return HttpServerResponse.jsonUnsafe({ error: "legacy SSE is unsupported" });
+          }
+          return HttpServerResponse.empty({ status: 405 });
+        });
+
+        const result = yield* probeMcpEndpointShape(server.endpoint);
+        expect(result).toEqual({ kind: "mcp", requiresAuth: false });
+
+        const requests = yield* server.requests;
+        expect(requests).toHaveLength(3);
+        expect(requests[0]?.body).toContain('"protocolVersion":"2025-11-25"');
+        expect(requests[1]?.method).toBe("GET");
+        expect(requests[2]?.body).toBe(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 2,
+            method: "server/discover",
+            params: {
+              _meta: { "io.modelcontextprotocol/protocolVersion": "2026-07-28" },
+            },
+          }),
+        );
+        expect(requests[2]?.headers["mcp-protocol-version"]).toBe("2026-07-28");
+      }),
+    ),
+  );
+
+  // First request (initialize) answers 200 HTML; second (the discover
+  // fallback) dies at the transport. The endpoint already proved reachable,
+  // so the verdict must stay the initialize classification, not "unreachable".
+  it.effect("keeps the initialize verdict when the discover fallback fails at the transport", () =>
+    Effect.gen(function* () {
+      let requestCount = 0;
+      const httpClientLayer = Layer.succeed(HttpClient.HttpClient)(
+        HttpClient.make((request: HttpClientRequest.HttpClientRequest) => {
+          requestCount += 1;
+          if (requestCount > 1) {
+            return Effect.fail(
+              new HttpClientError.HttpClientError({
+                reason: new HttpClientError.TransportError({
+                  request,
+                  description: "connection reset by peer",
+                }),
+              }),
+            );
+          }
+          return Effect.succeed(
+            HttpClientResponse.fromWeb(
+              request,
+              new Response("<html>not mcp</html>", {
+                status: 200,
+                headers: { "content-type": "text/html" },
+              }),
+            ),
+          );
+        }),
+      );
+
+      const result = yield* probeMcpEndpointShape("https://internal.example/mcp", {
+        httpClientLayer,
+      });
+      expect(result).toEqual({
+        kind: "not-mcp",
+        category: "wrong-shape",
+        reason: "2xx POST body is not a JSON-RPC envelope",
+      });
+      expect(requestCount).toBe(2);
+    }),
   );
 
   it.effect("rejects 2xx with HTML body as wrong-shape", () =>

--- a/packages/plugins/mcp/src/sdk/probe-shape.ts
+++ b/packages/plugins/mcp/src/sdk/probe-shape.ts
@@ -13,7 +13,7 @@
 //   and (b) plenty of real MCP servers authenticate with static API
 //   keys and publish no OAuth metadata at all (e.g. cubic.dev).
 //
-// The probe issues an unauth JSON-RPC `initialize` POST and accepts
+// The primary probe issues an unauth JSON-RPC `initialize` POST and accepts
 // only the wire shapes a real MCP server can return:
 //
 //   - 2xx with `Content-Type: text/event-stream` — streamable HTTP
@@ -30,8 +30,14 @@
 // only accepts 2xx with `text/event-stream` or the same 401+Bearer
 // shape.
 //
-// One `fetch` (occasionally two), no MCP-SDK session state, no OAuth
-// round-trip, no DCR — every non-MCP endpoint exits here.
+// If initialize ultimately has the wrong shape, a second JSON-RPC POST probes
+// `server/discover` using the 2026-07-28 envelope and protocol header. This
+// catches modern-only servers that reject initialize with a non-JSON-RPC
+// response. Authentication outcomes remain terminal because they do not vary
+// by transport era.
+//
+// One primary request (occasionally plus legacy GET and modern discover), no
+// MCP-SDK session state, no OAuth round-trip, no DCR.
 // ---------------------------------------------------------------------------
 
 import { Data, Duration, Effect, Layer, Option, Schema } from "effect";
@@ -48,9 +54,18 @@ const INITIALIZE_BODY = JSON.stringify({
   id: 1,
   method: "initialize",
   params: {
-    protocolVersion: "2025-06-18",
+    protocolVersion: "2025-11-25",
     capabilities: {},
     clientInfo: { name: "executor-probe", version: "0" },
+  },
+});
+
+const DISCOVER_BODY = JSON.stringify({
+  jsonrpc: "2.0",
+  id: 2,
+  method: "server/discover",
+  params: {
+    _meta: { "io.modelcontextprotocol/protocolVersion": "2026-07-28" },
   },
 });
 
@@ -385,10 +400,9 @@ export const probeMcpEndpointShape = (
         .execute(postRequest)
         .pipe(Effect.timeout(Duration.millis(timeoutMs)));
 
-      const postResult = yield* classify(postResponse, "POST");
-      if (postResult) return postResult;
+      let initializeResult = yield* classify(postResponse, "POST");
 
-      if ([404, 405, 406, 415].includes(postResponse.status)) {
+      if (initializeResult === null && [404, 405, 406, 415].includes(postResponse.status)) {
         let getRequest = HttpClientRequest.get(url.toString()).pipe(
           HttpClientRequest.setHeader("accept", "text/event-stream"),
         );
@@ -398,15 +412,42 @@ export const probeMcpEndpointShape = (
         const getResponse = yield* client
           .execute(getRequest)
           .pipe(Effect.timeout(Duration.millis(timeoutMs)));
-        const getResult = yield* classify(getResponse, "GET");
-        if (getResult) return getResult;
+        initializeResult = yield* classify(getResponse, "GET");
       }
 
-      return {
+      initializeResult ??= {
         kind: "not-mcp",
         category: "wrong-shape",
         reason: `unexpected status ${postResponse.status} for initialize`,
       } as const;
+
+      if (initializeResult.kind !== "not-mcp" || initializeResult.category !== "wrong-shape") {
+        return initializeResult;
+      }
+
+      let discoverRequest = HttpClientRequest.post(url.toString()).pipe(
+        HttpClientRequest.setHeader("content-type", "application/json"),
+        HttpClientRequest.setHeader("accept", "application/json, text/event-stream"),
+        HttpClientRequest.bodyText(DISCOVER_BODY, "application/json"),
+      );
+      for (const [name, value] of Object.entries(options.headers ?? {})) {
+        discoverRequest = HttpClientRequest.setHeader(discoverRequest, name, value);
+      }
+      discoverRequest = HttpClientRequest.setHeader(
+        discoverRequest,
+        "MCP-Protocol-Version",
+        "2026-07-28",
+      );
+
+      // The endpoint already answered the primary probe, so a transport
+      // failure on this secondary request must not overwrite that verdict
+      // with "unreachable" — keep the initialize classification instead.
+      const discoverResult = yield* client.execute(discoverRequest).pipe(
+        Effect.timeout(Duration.millis(timeoutMs)),
+        Effect.flatMap((discoverResponse) => classify(discoverResponse, "POST")),
+        Effect.catch(() => Effect.succeed(null)),
+      );
+      return discoverResult ?? initializeResult;
     }).pipe(
       Effect.provide(options.httpClientLayer ?? FetchHttpClient.layer),
       Effect.mapError(

--- a/packages/plugins/mcp/src/sdk/stdio-connector.ts
+++ b/packages/plugins/mcp/src/sdk/stdio-connector.ts
@@ -3,8 +3,9 @@
 // ---------------------------------------------------------------------------
 //
 // Kept in its own module so `connection.ts` never imports it eagerly at
-// module load. `@modelcontextprotocol/sdk/client/stdio.js` pulls in
-// `node:child_process` at evaluation time; under `@cloudflare/vitest-pool-workers`
+// module load. The v2 `@modelcontextprotocol/client/stdio` entry still eagerly
+// evaluates Node-only process/stream imports and `cross-spawn` (which loads
+// `node:child_process`); under `@cloudflare/vitest-pool-workers`
 // that crashes workerd at module instantiation with SIGSEGV (prod bundles
 // tree-shake it away when `dangerouslyAllowStdioMCP: false`, tests do not).
 //
@@ -13,7 +14,7 @@
 // the import and therefore never touch `node:child_process`.
 // ---------------------------------------------------------------------------
 
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 
 export type StdioTransportConfig = {
   readonly command: string;

--- a/packages/plugins/mcp/src/sdk/stdio-negotiation-test-server.ts
+++ b/packages/plugins/mcp/src/sdk/stdio-negotiation-test-server.ts
@@ -1,0 +1,24 @@
+// Stdio MCP fixture for stdio-negotiation.test.ts, spawned as a child process
+// with `bun run <this file>`. Serves both protocol eras by default;
+// `--legacy-reject` refuses the 2025 `initialize` opening so only a client
+// probing `server/discover` (spec 2026-07-28) can connect — the shape of an
+// SDK v2 server running with its legacy compatibility lane disabled.
+import { McpServer } from "@modelcontextprotocol/server";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
+import * as z from "zod/v4";
+
+serveStdio(
+  () => {
+    const server = new McpServer(
+      { name: "stdio-negotiation-fixture", version: "1.0.0" },
+      { capabilities: { tools: {} } },
+    );
+    server.registerTool(
+      "add",
+      { description: "Add two numbers", inputSchema: z.object({ a: z.number(), b: z.number() }) },
+      async ({ a, b }) => ({ content: [{ type: "text", text: String(a + b) }] }),
+    );
+    return server;
+  },
+  { legacy: process.argv.includes("--legacy-reject") ? "reject" : "serve" },
+);

--- a/packages/plugins/mcp/src/sdk/stdio-negotiation.test.ts
+++ b/packages/plugins/mcp/src/sdk/stdio-negotiation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Predicate } from "effect";
+import { fileURLToPath } from "node:url";
+
+import { createMcpConnector, type StdioConnectorInput } from "./connection";
+
+const fixture = fileURLToPath(new URL("./stdio-negotiation-test-server.ts", import.meta.url));
+
+const stdioInput = (
+  overrides: Partial<Omit<StdioConnectorInput, "transport" | "command">> & {
+    readonly args: readonly string[];
+  },
+): StdioConnectorInput => ({
+  transport: "stdio",
+  command: "bun",
+  ...overrides,
+});
+
+const withConnection = (input: StdioConnectorInput) =>
+  Effect.acquireRelease(createMcpConnector(input).pipe(Effect.orDie), (connection) =>
+    Effect.promise(connection.close),
+  );
+
+describe("stdio version negotiation", () => {
+  it.effect("auto negotiation connects modern to a server with legacy support disabled", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const connection = yield* withConnection(
+          stdioInput({ args: ["run", fixture, "--legacy-reject"], versionNegotiation: "auto" }),
+        );
+
+        expect(connection.client.getProtocolEra()).toBe("modern");
+        const tools = yield* Effect.promise(() => connection.client.listTools());
+        expect(tools.tools.map(({ name }) => name)).toContain("add");
+        const result = yield* Effect.promise(() =>
+          connection.client.callTool({ name: "add", arguments: { a: 2, b: 2 } }),
+        );
+        expect(result.content).toEqual([{ type: "text", text: "4" }]);
+      }),
+    ),
+  );
+
+  it.effect("the default handshake surfaces a connection error on that same server", () =>
+    Effect.gen(function* () {
+      const error = yield* createMcpConnector(
+        stdioInput({ args: ["run", fixture, "--legacy-reject"] }),
+      ).pipe(Effect.flip);
+
+      expect(Predicate.isTagged(error, "McpConnectionError")).toBe(true);
+    }),
+  );
+
+  it.effect("absent config keeps the legacy handshake against a both-era server", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const connection = yield* withConnection(stdioInput({ args: ["run", fixture] }));
+
+        expect(connection.client.getProtocolEra()).toBe("legacy");
+        const tools = yield* Effect.promise(() => connection.client.listTools());
+        expect(tools.tools.map(({ name }) => name)).toContain("add");
+      }),
+    ),
+  );
+});

--- a/packages/plugins/mcp/src/sdk/testing-fixtures.test.ts
+++ b/packages/plugins/mcp/src/sdk/testing-fixtures.test.ts
@@ -1,7 +1,6 @@
 import { expect, layer } from "@effect/vitest";
 import { Effect } from "effect";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
 import { OAuthTestServer } from "@executor-js/sdk/testing";
 
 import { makeEchoMcpServer, serveMcpServerWithOAuth } from "../testing";
@@ -16,7 +15,10 @@ const createGreetingMcpServer = () =>
   });
 
 const makeClient = (endpoint: string, accessToken: string) => {
-  const client = new Client({ name: "executor-test-client", version: "1.0.0" });
+  const client = new Client(
+    { name: "executor-test-client", version: "1.0.0" },
+    { versionNegotiation: { mode: "auto" } },
+  );
   const transport = new StreamableHTTPClientTransport(new URL(endpoint), {
     requestInit: {
       headers: { authorization: `Bearer ${accessToken}` },

--- a/packages/plugins/mcp/src/sdk/types.ts
+++ b/packages/plugins/mcp/src/sdk/types.ts
@@ -31,6 +31,20 @@ export type McpRemoteTransport = typeof McpRemoteTransport.Type;
 export const McpTransport = Schema.Literals(["streamable-http", "sse", "stdio", "auto"]);
 export type McpTransport = typeof McpTransport.Type;
 
+/** Protocol-version negotiation for a stdio server, mirroring the client
+ *  SDK's `versionNegotiation` modes. `legacy` (the default when absent) opens
+ *  with the 2025 `initialize` handshake; `auto` probes `server/discover`
+ *  (spec 2026-07-28) and falls back to `initialize` on legacy servers.
+ *
+ *  Deliberately opt-in, unlike remote streamable HTTP where `auto` is
+ *  unconditional: the SDK's stdio probe runs on a short-lived sibling
+ *  process, and a legacy server that never answers the probe stalls connect
+ *  for the full probe timeout — the wrong default for spawn-per-call CLI
+ *  servers, and exactly the case the SDK's own guidance says to keep on the
+ *  legacy handshake unless the server is known-modern. */
+export const McpStdioVersionNegotiation = Schema.Literals(["legacy", "auto"]);
+export type McpStdioVersionNegotiation = typeof McpStdioVersionNegotiation.Type;
+
 // ---------------------------------------------------------------------------
 // Auth methods — the shared placements vocabulary (`@executor-js/sdk/http-auth`)
 // plus MCP's own oauth variant. An integration declares zero or more methods,
@@ -208,6 +222,9 @@ export const McpStdioIntegrationConfig = Schema.Struct({
   env: Schema.optional(StringMap),
   /** Working directory */
   cwd: Schema.optional(Schema.String),
+  /** Protocol negotiation at connect. Absent means `legacy` (see
+   *  `McpStdioVersionNegotiation` for why that stays the default). */
+  versionNegotiation: Schema.optional(McpStdioVersionNegotiation),
   /** Declared auth methods — a single `stdio_env` method naming the secret env
    *  vars, or `none`. A connection's `template` picks one by slug, exactly as
    *  for remote servers. Optional so pre-revamp stdio configs (which had no

--- a/packages/plugins/mcp/src/testing/server.ts
+++ b/packages/plugins/mcp/src/testing/server.ts
@@ -1,7 +1,8 @@
-import { Context, Data, Effect, Layer, Ref, Scope } from "effect";
+import { Context, Data, Effect, Layer, Option, Ref, Schema, Scope } from "effect";
 import * as http from "node:http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { OAuthTestServer } from "@executor-js/sdk/testing";
 import z from "zod";
 
@@ -56,6 +57,22 @@ const writeText = (response: http.ServerResponse, status: number, body: string) 
   response.writeHead(status, { "content-type": "text/plain; charset=utf-8" });
   response.end(body);
 };
+
+const readRequestBody = (
+  request: http.IncomingMessage,
+): Effect.Effect<string, McpTestServerError> =>
+  Effect.tryPromise({
+    try: () =>
+      new Promise<string>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        request.on("data", (chunk: Buffer) => chunks.push(chunk));
+        request.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+        request.on("error", reject);
+      }),
+    catch: (cause) => new McpTestServerError({ cause }),
+  });
+
+const decodeJsonBody = Schema.decodeUnknownOption(Schema.fromJsonString(Schema.Unknown));
 
 const isMcpPath = (url: string, path: string): boolean => {
   const parsed = new URL(url, "http://executor.test");
@@ -157,6 +174,24 @@ export const serveMcpServer = (factory: () => McpServer, options: McpTestServerO
             return;
           }
 
+          // Mirror the real v1 transport's stateful contract: only an
+          // `initialize` POST opens a session; any other sessionless POST
+          // (e.g. a v2 client's `server/discover` era probe) is rejected
+          // with 400 + a JSON-RPC error and no session is minted.
+          let parsedBody: unknown;
+          if (request.method === "POST") {
+            const body = yield* readRequestBody(request);
+            parsedBody = Option.getOrUndefined(decodeJsonBody(body));
+            if (!isInitializeRequest(parsedBody)) {
+              writeJson(response, 400, {
+                jsonrpc: "2.0",
+                error: { code: -32000, message: "Bad Request: Server not initialized" },
+                id: null,
+              });
+              return;
+            }
+          }
+
           const transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => crypto.randomUUID(),
             onsessioninitialized: (sid) => {
@@ -172,7 +207,7 @@ export const serveMcpServer = (factory: () => McpServer, options: McpTestServerO
             catch: (cause) => new McpTestServerError({ cause }),
           });
           yield* Effect.tryPromise({
-            try: () => transport.handleRequest(request, response),
+            try: () => transport.handleRequest(request, response, parsedBody),
             catch: (cause) => new McpTestServerError({ cause }),
           });
         }).pipe(


### PR DESCRIPTION
Reverts #1692, restoring #1591: remote Streamable HTTP connections auto-negotiate the 2026-07-28 protocol era, stdio opt-in negotiation (#1646) comes back with it, and the negotiated era is recorded on handshake spans.

The v2 client package was implicated in the Aug 19 latency incident (isolate reuse collapse). The isolate instrumentation from #1698 is now on main, so this deploy doubles as the planned production canary: monitoring p50 / cold-start rate after merge, rolling back via wrangler if reuse collapses again.