### PR TITLE
Restore the marketing hero copy

### DIFF
--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -133,15 +133,14 @@ Source (and the place to start if something breaks): https://github.com/UsefulSo
             <h1
               class="rise-1 text-[clamp(2.8rem,7.2vw,6rem)] font-semibold tracking-[-0.025em] leading-[1.02] text-ink mb-6 mx-auto max-w-[18ch] text-balance"
             >
-              Executor connects any agent to <span class="serif-italic">everything</span>.
+              Connect any agent to <span class="serif-italic">everything</span>.
             </h1>
             <p
               class="rise-2 mx-auto mb-12 max-w-[50ch] text-[clamp(1.05rem,2.4vw,1.3rem)] leading-[1.5] text-ink-2"
             >
-              Executor is an integration platform and MCP gateway for AI agents.
-              It lets you securely connect services such as Google Workspace,
-              GitHub, and Slack, then read data and run the actions you request
-              through one endpoint.
+              Executor is an MCP gateway. Anything that speaks MCP, like Claude
+              Code, Cursor, or Codex, points at one endpoint and reaches every
+              tool you connect.
             </p>
             <div class="rise-3 max-w-[760px] mx-auto mb-12">
               <div class="surface-card p-6 sm:p-7">


### PR DESCRIPTION
Reverts the hero headline and subhead on the marketing homepage to the wording used before #1630, which replaced them with Google OAuth verification language as part of a Gmail scopes PR.

The dedicated /google-oauth, /google-workspace, and /about-executor pages are unchanged and still carry that description for reviewers.

Verified locally: astro dev renders the restored copy, astro build passes.