### PR TITLE
Drop eager MCP schema preload in workerd isolates

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1243,10 +1243,11 @@
   },
   "patchedDependencies": {
     "@electric-sql/pglite-socket@0.1.4": "patches/@electric-sql%2Fpglite-socket@0.1.4.patch",
-    "libsql@0.5.29": "patches/libsql@0.5.29.patch",
-    "@1password/sdk-core@0.4.1-beta.1": "patches/@1password%2Fsdk-core@0.4.1-beta.1.patch",
     "agents@0.17.3": "patches/agents@0.17.3.patch",
     "postgres@3.4.9": "patches/postgres@3.4.9.patch",
+    "@modelcontextprotocol/client@2.0.0": "patches/@modelcontextprotocol%2Fclient@2.0.0.patch",
+    "libsql@0.5.29": "patches/libsql@0.5.29.patch",
+    "@1password/sdk-core@0.4.1-beta.1": "patches/@1password%2Fsdk-core@0.4.1-beta.1.patch",
   },
   "catalog": {
     "@effect/atom-react": "4.0.0-beta.59",

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "@cloudflare/vite-plugin@1.31.2": "patches/@cloudflare%2Fvite-plugin@1.31.2.patch",
     "agents@0.17.3": "patches/agents@0.17.3.patch",
     "libsql@0.5.29": "patches/libsql@0.5.29.patch",
-    "@electric-sql/pglite-socket@0.1.4": "patches/@electric-sql%2Fpglite-socket@0.1.4.patch"
+    "@electric-sql/pglite-socket@0.1.4": "patches/@electric-sql%2Fpglite-socket@0.1.4.patch",
+    "@modelcontextprotocol/client@2.0.0": "patches/@modelcontextprotocol%2Fclient@2.0.0.patch"
   }
 }

--- a/patches/@modelcontextprotocol%2Fclient@2.0.0.patch
+++ b/patches/@modelcontextprotocol%2Fclient@2.0.0.patch
@@ -1,0 +1,39 @@
+diff --git a/dist/shimsWorkerd.cjs b/dist/shimsWorkerd.cjs
+index 29ef3a5b9872dbc934ec094d7419f6c965808e86..4b2dc3e755e5566edbbfd56087587e5c080ade02 100644
+--- a/dist/shimsWorkerd.cjs
++++ b/dist/shimsWorkerd.cjs
+@@ -7,7 +7,11 @@ const require_cfWorkerProvider = require('./cfWorkerProvider-B3dvjU3F.cjs');
+ *
+ * This file is selected via package.json export conditions when running in workerd.
+ */
+-require_src.preloadSchemas();
++/* executor-patch: no-preload-schemas — the upstream warm-up eagerly builds
++ * both protocol eras' zod schemas (~15MB heap) in EVERY isolate at module
++ * eval; under Cloudflare memory pressure this collapsed isolate reuse
++ * (~5-7 -> ~3 requests/isolate, 2026-08-25 latency incident). Schemas stay
++ * lazy+memoized; the first MCP use in an isolate pays ~15ms CPU instead. */
+ /**
+ * Whether `fetch()` may throw `TypeError` due to CORS. CORS is a browser-only concept —
+ * in Cloudflare Workers, a `TypeError` from `fetch` is always a real network/configuration
+diff --git a/dist/shimsWorkerd.mjs b/dist/shimsWorkerd.mjs
+index 02d2730aca540adf88d52487ec3f3a9b3f8e80ee..beb9604d2f7f486f711ef4ba7f93a85caf72c2dc 100644
+--- a/dist/shimsWorkerd.mjs
++++ b/dist/shimsWorkerd.mjs
+@@ -1,4 +1,3 @@
+-import { n as preloadSchemas } from "./src-D_zzAWoS.mjs";
+ import { t as CfWorkerJsonSchemaValidator } from "./cfWorkerProvider-BylNJ1R5.mjs";
+ 
+ //#region src/shimsWorkerd.ts
+@@ -7,7 +6,11 @@ import { t as CfWorkerJsonSchemaValidator } from "./cfWorkerProvider-BylNJ1R5.mj
+ *
+ * This file is selected via package.json export conditions when running in workerd.
+ */
+-preloadSchemas();
++/* executor-patch: no-preload-schemas — the upstream warm-up eagerly builds
++ * both protocol eras' zod schemas (~15MB heap) in EVERY isolate at module
++ * eval; under Cloudflare memory pressure this collapsed isolate reuse
++ * (~5-7 -> ~3 requests/isolate, 2026-08-25 latency incident). Schemas stay
++ * lazy+memoized; the first MCP use in an isolate pays ~15ms CPU instead. */
+ /**
+ * Whether `fetch()` may throw `TypeError` due to CORS. CORS is a browser-only concept —
+ * in Cloudflare Workers, a `TypeError` from `fetch` is always a real network/configuration

--- a/scripts/check-patched-deps.ts
+++ b/scripts/check-patched-deps.ts
@@ -81,6 +81,21 @@ const runtimeChecks: readonly RuntimeCheck[] = [
     // not exist in the upstream 0.17.3 dist.
     sentinels: ["markStreamUndelivered", "replayUndeliveredResponses"],
   },
+  {
+    package: "@modelcontextprotocol/client@2.0.0 (dist/shimsWorkerd.mjs)",
+    purpose:
+      "drops the workerd shim's module-eval preloadSchemas() (~15MB heap per isolate; " +
+      "collapsed isolate reuse in the 2026-08-25 latency incident) — schemas build lazily",
+    resolveEntry: () => {
+      // The workerd shim is only reachable through the `workerd` export
+      // condition, which require.resolve doesn't use — resolve the package
+      // main from the workspace package that depends on it and take the
+      // sibling shim file.
+      const main = resolveFrom("@modelcontextprotocol/client", "packages/plugins/mcp");
+      return resolve(main, "..", "shimsWorkerd.mjs");
+    },
+    sentinels: ["executor-patch: no-preload-schemas"],
+  },
 ];
 
 for (const check of runtimeChecks) {


### PR DESCRIPTION
Since #1733, p95 on authenticated API routes roughly doubled (2-2.5s -> 4.5-5.5s) and isolate reuse halved (~5-7 -> ~3 requests per isolate), version-correlated in traces: in the same 15-minute window the old version served p95 2.4s while #1733's deploy served 5.3s.

Mechanism: `@modelcontextprotocol/client`'s workerd shim runs `preloadSchemas()` at module eval, building both protocol eras' zod schemas in every isolate. Measured under the workerd export condition: importing the barrel costs ~30MB heap upstream vs ~11MB with this patch. That ~19MB per-isolate baseline is what pressures Cloudflare into evicting isolates, collapsing reuse; every extra cold isolate then eats the first-await startup penalty on whatever authenticated request lands on it.

Fix: `bun patch` the package to drop the eager preload. Schema construction stays lazy and memoized (upstream's documented default on other runtimes); the first MCP use in an isolate pays ~15ms CPU once. A sentinel in `scripts/check-patched-deps.ts` guards against the patch silently not applying, since a revert would reproduce the incident with no functional signal.

Worth an upstream issue: the warm-up default is actively harmful for large-bundle workers; it should be opt-in.

Verify after deploy: requests/isolate back to ~5-7 and `http.server` p95 back under ~2.5s in the executor-cloud dataset.