### PR TITLE
Bump free tier to 100k executions per month

### DIFF
--- a/apps/cloud/src/routes/app/billing_.plans.tsx
+++ b/apps/cloud/src/routes/app/billing_.plans.tsx
@@ -122,7 +122,7 @@ const PLAN_META: Record<string, { tagline: string; inherits?: string; features: 
     tagline: "For small teams getting started",
     features: [
       "Up to 3 members",
-      "10,000 included executions per month",
+      "100,000 included executions per month",
       "$0.20 per 1,000 additional executions",
       "Unlimited sources",
     ],

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -615,7 +615,7 @@ Source (and the place to start if something breaks): https://github.com/UsefulSo
               <ul class="check-list">
                 {[
                   "Up to 3 members",
-                  "10,000 included executions per month",
+                  "100,000 included executions per month",
                   "$0.20 per 1,000 additional executions",
                   "Unlimited integrations",
                 ].map((f) => (

--- a/autumn.config.ts
+++ b/autumn.config.ts
@@ -31,7 +31,7 @@ export const free = plan({
   items: [
     item({
       featureId: executions.id,
-      included: 10000,
+      included: 100000,
       reset: {
         interval: "month",
       },
@@ -47,7 +47,7 @@ export const freePayAsYouGo = plan({
   items: [
     item({
       featureId: executions.id,
-      included: 10000,
+      included: 100000,
       price: {
         amount: 0.2,
         billingUnits: 1000,


### PR DESCRIPTION
Raises included executions on the free tier from 10,000 to 100,000 per month.

- `autumn.config.ts`: `free` and `free-pay-as-you-go` plans now include 100,000 executions (pay-as-you-go kept in sync so adding a card doesn't reduce the included amount)
- Plans page and marketing pricing copy updated to match

Note: merging deploys the app copy, but the Autumn billing config still needs a manual `atmn push` to take effect on live billing.