### PR TITLE
Enterprise-managed authorization console UI

### DIFF
--- a/apps/cloud/src/routes/app/org.tsx
+++ b/apps/cloud/src/routes/app/org.tsx
@@ -28,6 +28,7 @@ import {
   DropdownMenuTrigger,
 } from "@executor-js/react/components/dropdown-menu";
 import { orgMembersAtom } from "@executor-js/react/api/account-atoms";
+import { EnterpriseIdentityProviderSection } from "@executor-js/react/components/enterprise-idp-section";
 import { OrgPage as SharedOrgPage } from "@executor-js/react/pages/org";
 import { orgDomainsAtom, getDomainVerificationLink, deleteDomain } from "../../web/org-atoms";
 import { deleteOrganization, useAuth } from "../../web/auth";
@@ -61,6 +62,7 @@ function OrgPage() {
       {/* Shared members / roles / invite / org-name surface. */}
       <SharedOrgPage
         domainsSection={<DomainsSection />}
+        enterpriseIdpSection={<EnterpriseIdpSection />}
         upgradeAction={
           <Link to="/{-$orgSlug}/billing/plans">
             <Button size="sm">Upgrade plan</Button>
@@ -72,29 +74,44 @@ function OrgPage() {
   );
 }
 
+/** Whether the caller administers this organization, derived from the members
+ *  list already loaded for this page. False while it loads, so an admin-only
+ *  control never flashes for someone who cannot use it.
+ *
+ *  CLIENT-SIDE UX GATING ONLY: every endpoint behind these controls enforces
+ *  its own authorization. Hiding a control the server would refuse is a
+ *  courtesy, not the boundary. */
+function useIsOrgAdmin(): boolean {
+  const membersResult = useAtomValue(orgMembersAtom);
+  return AsyncResult.match(membersResult, {
+    onInitial: () => false,
+    onFailure: () => false,
+    onSuccess: ({ value }) =>
+      value.members.some((m) => m.isCurrentUser && m.status === "active" && m.role === "admin"),
+  });
+}
+
+// The organization's enterprise identity provider (MCP Enterprise-Managed
+// Authorization). Admin-only, on the same gate as the danger zone: registering
+// it decides how every member of the workspace authorizes to enterprise-managed
+// MCP servers, which is an administrator's call, not a member's.
+function EnterpriseIdpSection() {
+  return useIsOrgAdmin() ? <EnterpriseIdentityProviderSection /> : null;
+}
+
 // Destructive org teardown, admin-only. Hidden entirely for non-admins (the
 // backend enforces admin + name-confirmation regardless). Deleting the org
 // removes the workspace and all of its data for every member, cancels billing,
 // and logs the caller out.
 function DangerZoneSection() {
   const auth = useAuth();
-  const membersResult = useAtomValue(orgMembersAtom);
+  const isAdmin = useIsOrgAdmin();
   const doDelete = useAtomSet(deleteOrganization, { mode: "promiseExit" });
   const [open, setOpen] = useState(false);
   const [confirmText, setConfirmText] = useState("");
   const [deleting, setDeleting] = useState(false);
 
   const organizationName = auth.status === "authenticated" ? auth.organization?.name : undefined;
-
-  // Only admins may delete. Derive the caller's role from the members list
-  // (already loaded for this page); render nothing while it loads or for
-  // members, so a delete control never flashes for someone who can't use it.
-  const isAdmin = AsyncResult.match(membersResult, {
-    onInitial: () => false,
-    onFailure: () => false,
-    onSuccess: ({ value }) =>
-      value.members.some((m) => m.isCurrentUser && m.status === "active" && m.role === "admin"),
-  });
 
   if (!isAdmin || !organizationName) return null;
 

--- a/e2e/selfhost/mcp-enterprise-managed-console.test.ts
+++ b/e2e/selfhost/mcp-enterprise-managed-console.test.ts
@@ -1,0 +1,508 @@
+// Selfhost (browser, recorded): the CONSOLE half of MCP Enterprise-Managed
+// Authorization. The protocol half — the ID-JAG chain itself and the
+// administrator denial — is `mcp-enterprise-managed-auth.test.ts`; this
+// scenario is about what an administrator and a member can see and do.
+//
+// Three claims, in the order a workspace meets them:
+//
+//   1. An administrator marks a server as managed FROM THE UI, and that
+//      declaration survives `configureMcpAuth`. It is written through the same
+//      replace-mode save that rewrites the whole auth-method list, so a
+//      declaration the credential editor cannot express is one unrelated edit
+//      away from being erased — the assertion below is that it is not.
+//   2. A member's managed connection is visibly managed and offers NO local
+//      revocation. Remove would claim a revocation that did not happen (the
+//      identity provider still authorizes them, and the next call hands access
+//      straight back), and Reconnect re-runs a consent step this profile does
+//      not have. Both belong at the identity provider.
+//   3. An administrator's denial stops the connect and does NOT fall back to
+//      the interactive per-server flow. The MCP emulator's ledger is the proof:
+//      it shows the requests executor did NOT make.
+//
+// Two emulators stand in for the pilot's real parties: `okta` is the customer's
+// identity provider (it runs the real OIDC sign-on, mints ID-JAGs over RFC 8693
+// and enforces an administrator policy table), `mcp` is the third-party server
+// and its Resource Authorization Server.
+//
+// GAP, deliberately not papered over: minting the connection below goes through
+// the typed API, not the console, because `oauth.start`'s `enterprise` input
+// requires the caller to HOLD the identity assertion and no browser surface can
+// obtain one. See the branch's report; the console work here is everything
+// around that one leg.
+import { randomBytes } from "node:crypto";
+import { createServer } from "node:net";
+
+import { assert, expect } from "@effect/vitest";
+import { Effect, Predicate } from "effect";
+import type { Page } from "playwright";
+import { composePluginApi } from "@executor-js/api/server";
+import { createEmulator, type Emulator } from "@executor-js/emulate";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  OAuthClientSlug,
+} from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
+import { visit } from "../src/surfaces/browser";
+
+const api = composePluginApi([mcpHttpPlugin()] as const);
+
+const OKTA_USER = "testuser@okta.local";
+const OKTA_AUTH_SERVER = "default";
+const SSO_REDIRECT_URI = "http://localhost:3000/callback";
+const ID_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:id_token";
+
+// The reserved (owner, slug) the organization's identity provider is registered
+// under — the SAME identity the org settings section writes, so a server marked
+// managed in the console names exactly this app. Self-host has no organization
+// admin page, so the registration is seeded through the typed API here; the
+// browser drives everything downstream of it.
+const IDP_CLIENT = OAuthClientSlug.make("enterprise-identity-provider");
+
+const MANAGED_BADGE = "Managed by your organization";
+
+const freshSlug = (prefix: string): string => `${prefix}_${randomBytes(4).toString("hex")}`;
+
+const availablePort = Effect.callback<number>((resume) => {
+  const probe = createServer();
+  probe.listen(0, "127.0.0.1", () => {
+    const address = probe.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    probe.close(() => {
+      resume(Effect.succeed(port));
+    });
+  });
+});
+
+/** A locally spawned emulator on an OS-assigned port, closed with the scope.
+ *  Local rather than hosted: this scenario depends on behavior that shipped in
+ *  `@executor-js/emulate` 0.14.0 (Okta minting ID-JAGs), and the npm package is
+ *  the version this checkout pins. */
+const emulator = (service: "okta" | "mcp") =>
+  Effect.acquireRelease(
+    Effect.gen(function* () {
+      const port = yield* availablePort;
+      return yield* Effect.promise(() => createEmulator({ service, port }));
+    }),
+    (instance: Emulator) => Effect.promise(() => instance.close()).pipe(Effect.ignore),
+  );
+
+const requireString = (value: string | undefined | null, what: string): string => {
+  if (!value) throw new Error(`emulator returned no ${what}`);
+  return value;
+};
+
+/** Single sign-on at the identity provider, ending with the ID token the host
+ *  holds on the member's behalf. THE one step this console cannot yet perform
+ *  for itself — see the header. */
+const singleSignOn = (input: {
+  readonly issuerBaseUrl: string;
+  readonly clientId: string;
+  readonly clientSecret: string;
+}) =>
+  Effect.promise(async (): Promise<string> => {
+    const authorize = await fetch(
+      `${input.issuerBaseUrl}/oauth2/${OKTA_AUTH_SERVER}/v1/authorize/callback`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        redirect: "manual",
+        body: new URLSearchParams({
+          user_ref: OKTA_USER,
+          redirect_uri: SSO_REDIRECT_URI,
+          scope: "openid profile email",
+          client_id: input.clientId,
+          response_mode: "query",
+          auth_server_id: OKTA_AUTH_SERVER,
+        }),
+      },
+    );
+    if (authorize.status !== 302) {
+      throw new Error(`IdP authorize answered ${authorize.status}, expected a 302`);
+    }
+    const location = requireString(authorize.headers.get("location"), "authorize redirect");
+    const code = requireString(new URL(location).searchParams.get("code"), "authorization code");
+
+    const token = await fetch(`${input.issuerBaseUrl}/oauth2/${OKTA_AUTH_SERVER}/v1/token`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: SSO_REDIRECT_URI,
+        client_id: input.clientId,
+        client_secret: input.clientSecret,
+      }),
+    });
+    if (!token.ok) throw new Error(`IdP token endpoint answered ${token.status}`);
+    const body = (await token.json()) as { readonly id_token?: string };
+    return requireString(body.id_token, "id_token");
+  });
+
+const connectionsSection = (page: Page) =>
+  page.locator("section").filter({
+    has: page.getByRole("heading", { level: 3, name: "Connections" }),
+  });
+
+const callGetMeCode = (slug: string, connection: string) => `
+const result = await tools.${slug}.org.${connection}.get_me({});
+return { ok: result.ok, payload: result.ok ? result.data : result.error };
+`;
+
+scenario(
+  "MCP enterprise-managed authorization (console) · an administrator marks a server managed, and the managed connection offers no local revocation",
+  { timeout: 240_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const { client: makeApiClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      const okta = yield* emulator("okta");
+      const mcp = yield* emulator("mcp");
+      const mcpEndpoint = `${mcp.url}/mcp`;
+
+      // One client identity across both registrations (draft §5 client
+      // continuity): the app the member signs in to at the identity provider is
+      // the app that presents itself to the Resource Authorization Server.
+      const credential = yield* Effect.promise(() =>
+        okta.credentials.mint({
+          type: "oauth-authorization-code",
+          name: "Executor E2E enterprise client",
+          redirect_uris: [SSO_REDIRECT_URI],
+        }),
+      );
+      const clientId = requireString(credential.client_id, "IdP client_id");
+      const clientSecret = requireString(credential.client_secret, "IdP client_secret");
+      const idpTokenUrl = requireString(credential.token_url, "IdP token endpoint");
+      const idpAuthorizationUrl = requireString(credential.authorization_url, "IdP authorize URL");
+
+      const subjectToken = yield* singleSignOn({
+        issuerBaseUrl: okta.url,
+        clientId,
+        clientSecret,
+      });
+
+      const integration = IntegrationSlug.make(freshSlug("mcp_ema_ui"));
+      const serverClient = OAuthClientSlug.make(freshSlug("ema_server"));
+      const template = AuthTemplateSlug.make("oauth2");
+      const managedConnection = ConnectionName.make("main");
+
+      // The server starts life ORDINARY — a plain oauth2 MCP server with no
+      // enterprise declaration. Marking it managed is the browser's job below,
+      // which is the whole point: a declaration that only ever arrives through
+      // `addServer` would never exercise the save path that can erase it.
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: "Enterprise-managed MCP (emulate)",
+          endpoint: mcpEndpoint,
+          slug: String(integration),
+          authenticationTemplate: [{ kind: "oauth2" }],
+        },
+      });
+
+      yield* Effect.ensuring(
+        Effect.gen(function* () {
+          // The organization's identity provider, under the reserved identity
+          // the org settings section owns. Both endpoints are recorded exactly
+          // as that section records them.
+          yield* client.oauth.createClient({
+            payload: {
+              owner: "org",
+              slug: IDP_CLIENT,
+              authorizationUrl: idpAuthorizationUrl,
+              tokenUrl: idpTokenUrl,
+              grant: "authorization_code",
+              clientId,
+              clientSecret,
+            },
+          });
+          // The server-side registration an administrator makes through the
+          // OAuth app form's "Enterprise identity assertion" grant: `id_jag`
+          // plus the RFC 9728 resource discovery starts from.
+          yield* client.oauth.createClient({
+            payload: {
+              owner: "org",
+              slug: serverClient,
+              authorizationUrl: `${mcp.url}/authorize`,
+              tokenUrl: `${mcp.url}/token`,
+              grant: "id_jag",
+              clientId,
+              clientSecret,
+              resource: mcpEndpoint,
+            },
+          });
+
+          // -----------------------------------------------------------------
+          // 1. The administrator marks the server managed, in the console.
+          // -----------------------------------------------------------------
+          yield* browser.session(identity, async ({ page, step }) => {
+            await step("An administrator opens the MCP server they want to manage", async () => {
+              await visit(page, `/integrations/${String(integration)}`);
+              await page.getByRole("button", { name: "Edit" }).first().waitFor({ timeout: 30_000 });
+            });
+
+            await step("Turn on 'Managed by your organization'", async () => {
+              await page.getByRole("button", { name: "Edit" }).first().click();
+              const toggle = page.locator("#ema-managed-server");
+              await toggle.waitFor({ timeout: 30_000 });
+              expect(
+                await toggle.getAttribute("data-state"),
+                "an ordinary server starts unmanaged",
+              ).toBe("unchecked");
+              await toggle.click();
+              // Waited for on the DOM rather than read once: the switch
+              // animates, and this step's screenshot should show the state the
+              // administrator sees, not a frame mid-transition.
+              await page
+                .locator('#ema-managed-server[data-state="checked"]')
+                .waitFor({ timeout: 10_000 });
+              await page
+                .locator('#ema-managed-server [data-slot="switch-thumb"][data-state="checked"]')
+                .waitFor({ timeout: 10_000 });
+            });
+
+            await step("Save — the declaration is written onto the server", async () => {
+              await page.getByRole("button", { name: "Save" }).click();
+              await page
+                .getByText("Authentication methods updated.", { exact: true })
+                .waitFor({ timeout: 30_000 });
+            });
+
+            await step("Reopening the server shows it is still managed", async () => {
+              // Not a repeat of the save assertion: this reads the toggle back
+              // from the SERVER's stored declaration on a fresh mount, which is
+              // the state a second administrator would arrive at.
+              await page.getByRole("button", { name: "Edit" }).first().click();
+              const reopened = page.locator('#ema-managed-server[data-state="checked"]');
+              await reopened.waitFor({ timeout: 30_000 });
+              // Left open, and scrolled to: this step's screenshot is the
+              // artifact showing the stored declaration as an administrator
+              // finds it.
+              await reopened.scrollIntoViewIfNeeded();
+            });
+          });
+
+          // The declaration reached storage AND survived the replace-mode save
+          // that rewrote the whole method list. Read back through the catalog,
+          // which is where every connect path learns of it.
+          const catalog = yield* client.integrations.get({ params: { slug: integration } });
+          const declared = catalog.authMethods.find((method) => method.kind === "oauth");
+          expect(
+            declared?.oauth?.enterpriseIdentityProvider,
+            "the console's toggle declared the organization's identity provider on this server",
+          ).toEqual({ client: String(IDP_CLIENT), clientOwner: "org" });
+          expect(
+            declared?.oauth?.supportsDynamicRegistration,
+            "declaring an identity provider leaves the interactive route advertised",
+          ).toBe(true);
+          const enterprise = declared?.oauth?.enterpriseIdentityProvider;
+          assert(enterprise, "the connect below drives off the projected pointer");
+
+          // -----------------------------------------------------------------
+          // 2. A member connects with their work identity, and uses the server.
+          //    This leg goes through the typed API — see the file header.
+          // -----------------------------------------------------------------
+          const connected = yield* client.oauth.start({
+            payload: {
+              owner: "org",
+              client: serverClient,
+              clientOwner: "org",
+              name: managedConnection,
+              integration,
+              template,
+              enterprise: {
+                idpClient: enterprise.client,
+                idpClientOwner: enterprise.clientOwner,
+                subjectToken,
+                subjectTokenType: ID_TOKEN_TYPE,
+              },
+            },
+          });
+          assert(
+            connected.status === "connected",
+            "the enterprise grant connects with no authorize redirect",
+          );
+          expect(
+            connected.connection.enterpriseManaged,
+            "the connection reports itself managed, which is what the console branches on",
+          ).toBe(true);
+
+          const executed = yield* client.executions.execute({
+            payload: {
+              code: callGetMeCode(String(integration), String(managedConnection)),
+              autoApprove: true,
+            },
+          });
+          expect(executed.status, "the tool call completed").toBe("completed");
+          expect((JSON.parse(executed.text) as { readonly ok: boolean }).ok, executed.text).toBe(
+            true,
+          );
+
+          // -----------------------------------------------------------------
+          // 3. The member's view of the managed connection.
+          // -----------------------------------------------------------------
+          yield* browser.session(identity, async ({ page, step }) => {
+            const connections = connectionsSection(page);
+            const menuTrigger = connections.locator('button[aria-haspopup="menu"]').first();
+
+            await step("A member opens the managed server's connections", async () => {
+              await visit(page, `/integrations/${String(integration)}`);
+              await connections
+                .getByText(String(managedConnection), { exact: true })
+                .waitFor({ timeout: 30_000 });
+            });
+
+            await step("The connection is visibly managed by the organization", async () => {
+              await connections.getByText(MANAGED_BADGE, { exact: true }).waitFor({
+                timeout: 30_000,
+              });
+              // The badge is a claim; this is the consequence of it, said in
+              // words the member can act on.
+              await connections
+                .getByText(/Revoke access at your identity provider, not here\./)
+                .waitFor({ timeout: 30_000 });
+            });
+
+            await step("Its menu offers no Remove and no Reconnect", async () => {
+              await menuTrigger.click();
+              // Present: the actions that are still the member's to take.
+              await page.getByRole("menuitem", { name: "Check now" }).waitFor({ timeout: 30_000 });
+              await page.getByRole("menuitem", { name: "Edit" }).waitFor({ timeout: 30_000 });
+              // Absent: WITHHELD, not disabled. A local Remove would claim a
+              // revocation that did not happen, and Reconnect re-runs a consent
+              // step this profile does not have.
+              expect(
+                await page.getByRole("menuitem", { name: "Remove" }).count(),
+                "an enterprise-managed connection cannot be removed locally",
+              ).toBe(0);
+              expect(
+                await page.getByRole("menuitem", { name: "Reconnect" }).count(),
+                "an enterprise-managed connection has no interactive flow to re-run",
+              ).toBe(0);
+              // Left open on purpose: this step's screenshot is the artifact
+              // that shows the menu as the member sees it.
+            });
+          });
+
+          // -----------------------------------------------------------------
+          // 4. The administrator denies this client at the identity provider.
+          //    Clear both ledgers first so every entry below belongs to the
+          //    blocked attempt.
+          // -----------------------------------------------------------------
+          yield* Effect.promise(() => okta.ledger.clear());
+          yield* Effect.promise(() => mcp.ledger.clear());
+          yield* Effect.promise(() =>
+            okta.seed({
+              token_exchange_policies: [
+                { name: "Block the executor client", client_id: clientId, effect: "DENY" },
+              ],
+            }),
+          );
+
+          const blocked = yield* client.oauth
+            .start({
+              payload: {
+                owner: "org",
+                client: serverClient,
+                clientOwner: "org",
+                name: ConnectionName.make("blocked"),
+                integration,
+                template,
+                enterprise: {
+                  idpClient: enterprise.client,
+                  idpClientOwner: enterprise.clientOwner,
+                  subjectToken,
+                  subjectTokenType: ID_TOKEN_TYPE,
+                },
+              },
+            })
+            .pipe(Effect.flip);
+
+          assert(
+            Predicate.isTagged(blocked, "OAuthStartError"),
+            "a policy denial is a start failure, not a transport or decoding fault",
+          );
+          // The two fields the console branches on. It must never decide this
+          // from the wording of a message: getting it wrong means offering the
+          // interactive flow, which walks the member around the control the
+          // identity provider just exercised.
+          expect(blocked.blockedByAdmin, "the denial reaches the console as a FIELD").toBe(true);
+          expect(
+            blocked.oauthErrorCode,
+            "the provider's own code travels structurally, so support can trace it",
+          ).toBe("invalid_target");
+
+          // THE anti-fallback claim, proven by absence: had executor quietly
+          // offered the ordinary per-server flow, the MCP server would have seen
+          // an authorize request, a registration, or another redemption.
+          const afterDenial = yield* Effect.promise(() => mcp.ledger.list());
+          expect(
+            afterDenial.filter(
+              (entry) =>
+                entry.path === "/authorize" ||
+                entry.path === "/register" ||
+                entry.operationId === "mcp.oauth.jwtBearer",
+            ),
+            "a policy denial does not fall back to interactive OAuth",
+          ).toEqual([]);
+
+          const connections = yield* client.connections.list({ query: { integration } });
+          expect(
+            connections.map((connection) => String(connection.name)).sort(),
+            "the blocked attempt minted no connection",
+          ).toEqual([String(managedConnection)]);
+
+          // -----------------------------------------------------------------
+          // 5. The denial changes nothing the console offers: the managed row
+          //    still has no route around the identity provider's decision.
+          // -----------------------------------------------------------------
+          yield* browser.session(identity, async ({ page, step }) => {
+            const rows = connectionsSection(page);
+            await step("After the denial, the console still offers no way around it", async () => {
+              await visit(page, `/integrations/${String(integration)}`);
+              await rows
+                .getByText(String(managedConnection), { exact: true })
+                .waitFor({ timeout: 30_000 });
+              await rows.getByText(MANAGED_BADGE, { exact: true }).waitFor({ timeout: 30_000 });
+              await rows.locator('button[aria-haspopup="menu"]').first().click();
+              // Wait for a menu item that IS there before counting the ones
+              // that are not: an unopened menu would make every absence
+              // assertion below pass for the wrong reason.
+              await page.getByRole("menuitem", { name: "Check now" }).waitFor({ timeout: 30_000 });
+              expect(
+                await page.getByRole("menuitem", { name: "Reconnect" }).count(),
+                "the interactive route is exactly what the identity provider closed",
+              ).toBe(0);
+              expect(
+                await page.getByRole("menuitem", { name: "Remove" }).count(),
+                "and a denial does not turn revocation into a local action either",
+              ).toBe(0);
+            });
+          });
+        }),
+        Effect.gen(function* () {
+          yield* client.connections
+            .remove({
+              params: { owner: "org", integration, name: managedConnection },
+            })
+            .pipe(Effect.ignore);
+          yield* client.oauth
+            .removeClient({ params: { slug: serverClient }, payload: { owner: "org" } })
+            .pipe(Effect.ignore);
+          yield* client.oauth
+            .removeClient({ params: { slug: IDP_CLIENT }, payload: { owner: "org" } })
+            .pipe(Effect.ignore);
+          yield* client.mcp.removeServer({ params: { slug: integration } }).pipe(Effect.ignore);
+        }),
+      );
+    }),
+  ),
+);

--- a/packages/core/api/src/connections/api.ts
+++ b/packages/core/api/src/connections/api.ts
@@ -62,6 +62,11 @@ const ConnectionResponse = Schema.Struct({
   // Last persisted health-check verdict (written by every checkHealth run),
   // so the list can show alive/expired at a glance without probing.
   lastHealth: Schema.NullOr(HealthCheckResult),
+  // True when the connection was minted through MCP Enterprise-Managed
+  // Authorization: it mirrors organization policy and holds no durable local
+  // grant, so a console must not offer to delete it. Read-only — nothing on
+  // this surface can set it.
+  enterpriseManaged: Schema.Boolean,
 });
 
 const ToolResponse = Schema.Struct({

--- a/packages/core/api/src/handlers/connections.ts
+++ b/packages/core/api/src/handlers/connections.ts
@@ -30,6 +30,7 @@ const toResponse = (c: Connection) => ({
   oauthScope: c.oauthScope ?? null,
   missingOAuthScopes: c.missingOAuthScopes ?? [],
   lastHealth: c.lastHealth ?? null,
+  enterpriseManaged: c.enterpriseManaged ?? false,
 });
 
 const toolToResponse = (t: Tool) => ({

--- a/packages/core/api/src/handlers/oauth.ts
+++ b/packages/core/api/src/handlers/oauth.ts
@@ -46,6 +46,7 @@ const connectionToResponse = (c: Connection) => ({
   oauthClientOwner: c.oauthClientOwner ?? null,
   oauthScope: c.oauthScope ?? null,
   missingOAuthScopes: c.missingOAuthScopes ?? [],
+  enterpriseManaged: c.enterpriseManaged ?? false,
 });
 
 const startResultToResponse = (result: ConnectResult) =>

--- a/packages/core/api/src/oauth/api.ts
+++ b/packages/core/api/src/oauth/api.ts
@@ -52,6 +52,12 @@ const ConnectionResponse = Schema.Struct({
   oauthClientOwner: Schema.NullOr(Owner),
   oauthScope: Schema.NullOr(Schema.String),
   missingOAuthScopes: Schema.Array(Schema.String),
+  // True when this connect took the enterprise-managed branch (the ID-JAG
+  // chain) rather than the interactive one. A `start` against an `id_jag`
+  // client can still land here as `false` — the profile falls back when the
+  // server does not advertise it — so the caller reads the outcome, not its
+  // own intent.
+  enterpriseManaged: Schema.Boolean,
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/sdk/src/connection.ts
+++ b/packages/core/sdk/src/connection.ts
@@ -61,6 +61,21 @@ export interface Connection {
    *  "has this expired?" at a glance in the connections list without probing.
    *  Null/absent = never checked. */
   readonly lastHealth?: HealthCheckResult | null;
+  /** True when this connection was minted through MCP Enterprise-Managed
+   *  Authorization and renews itself from the enterprise identity assertion
+   *  persisted alongside it (`ENTERPRISE_MANAGED_PROVIDER_STATE_KEY`).
+   *
+   *  A BOOLEAN, deliberately: the wiring behind it (which IdP registration,
+   *  which audience) is a server concern, and a console needs exactly one fact
+   *  from it — that this connection mirrors organization policy rather than a
+   *  grant the user holds. That single fact changes what the UI may offer:
+   *  there is no durable local grant to delete, so a local "remove" would be a
+   *  lie, and revocation belongs at the identity provider.
+   *
+   *  It is NOT derivable client-side from `oauthClient`: a client whose grant
+   *  is `id_jag` still falls back to the interactive flow against a server that
+   *  does not advertise the profile, and such a connection is ordinary. */
+  readonly enterpriseManaged?: boolean;
 }
 
 /** Identify one connection — unique by (owner, integration, name). */

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -818,6 +818,22 @@ const missingOAuthScopesFromProviderState = (value: unknown): readonly string[] 
     : [];
 };
 
+/** Project a credential-resolution failure's ADMINISTRATOR verdict onto the
+ *  health result, so the console reads "your organization declined this" as
+ *  structure rather than parsing the sentence in `detail`. Empty for every
+ *  ordinary failure — an expired grant, a dead refresh token — which keeps the
+ *  blocked branch impossible to reach by accident. */
+export const healthAdministratorVerdict = (failure: {
+  readonly blockedByAdmin?: boolean;
+  readonly oauthErrorCode?: string;
+}): { readonly blockedByAdmin?: true; readonly oauthErrorCode?: string } =>
+  failure.blockedByAdmin === true
+    ? {
+        blockedByAdmin: true,
+        ...(failure.oauthErrorCode === undefined ? {} : { oauthErrorCode: failure.oauthErrorCode }),
+      }
+    : {};
+
 /** The definitive refresh rejection recorded on `provider_state`, or null.
  *  Set when the AS rejects the grant itself (RFC 6749 invalid_grant — retrying
  *  cannot change the verdict); cleared by the reconnect mint, which rewrites
@@ -852,6 +868,10 @@ const rowToConnection = (row: ConnectionRow): Connection => {
     oauthScope: row.oauth_scope == null ? null : String(row.oauth_scope),
     missingOAuthScopes: missingOAuthScopesFromProviderState(row.provider_state),
     lastHealth: Option.getOrNull(decodeLastHealth(row.last_health)),
+    // Read from the SAME persisted state the renewal path follows, so the
+    // console and the credential lifecycle can never disagree about which
+    // connections are enterprise-managed.
+    enterpriseManaged: enterpriseManagedStateFrom(decodeJsonColumn(row.provider_state)) !== null,
   };
 };
 
@@ -3455,6 +3475,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             checkedAt: Date.now(),
             // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: CredentialResolutionError carries a typed `message` field
             detail: err.message,
+            ...healthAdministratorVerdict(err),
           })
         : Effect.fail(
             new StorageError({
@@ -3473,6 +3494,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             checkedAt: Date.now(),
             // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: CredentialResolutionError carries a typed `message` field
             detail: failure.message,
+            ...healthAdministratorVerdict(failure),
           }
         : {
             status: "degraded",

--- a/packages/core/sdk/src/health-check.ts
+++ b/packages/core/sdk/src/health-check.ts
@@ -81,6 +81,19 @@ export const HealthCheckResult = Schema.Struct({
   /** Bounded sample of scalar fields from the response body, for the live
    *  preview ("show me what this operation returns"). */
   responseSample: Schema.optional(Schema.Array(HealthCheckResponseSample)),
+  /** True when an enterprise identity provider declined to authorize this
+   *  connection under administrator policy while resolving its credential.
+   *
+   *  Carried as a FIELD beside `status` rather than folded into `detail`,
+   *  because the two verdicts demand different products: an expired grant says
+   *  "sign in again", an administrator decision says "your organization
+   *  decided this", and a console that offered the interactive flow for the
+   *  second would walk the user around the control the IdP just exercised. A
+   *  console must branch on this, never on the wording of `detail`. */
+  blockedByAdmin: Schema.optional(Schema.Boolean),
+  /** The authorization server's RFC 6749 §5.2 error code, when the failure came
+   *  from a token-endpoint refusal. Shown for support traceability. */
+  oauthErrorCode: Schema.optional(Schema.String),
 });
 export type HealthCheckResult = typeof HealthCheckResult.Type;
 

--- a/packages/plugins/mcp/src/react/EditMcpIntegration.tsx
+++ b/packages/plugins/mcp/src/react/EditMcpIntegration.tsx
@@ -14,18 +14,24 @@ import {
   type AuthMethodSeed,
 } from "@executor-js/react/components/auth-method-list-editor";
 import { Badge } from "@executor-js/react/components/badge";
+import { Label } from "@executor-js/react/components/label";
+import { Switch } from "@executor-js/react/components/switch";
+import { useEnterpriseIdentityProviderDescriptor } from "@executor-js/react/components/enterprise-idp-section";
 import { FormErrorAlert } from "@executor-js/react/lib/integration-add";
 
 import { configureMcpAuth, mcpServerAtom } from "./atoms";
 import type {
   McpAuthMethod,
   McpCanonicalAuthMethodInput,
+  McpEnterpriseIdentityProvider,
   McpIntegrationConfig,
 } from "../sdk/types";
 import {
   editorValueFromMcpAuthMethod,
   mcpAuthMethodInputFromEditorValue,
+  mcpOAuthMethodInput,
   mcpWireAuthInput,
+  sameEnterpriseIdentityProvider,
 } from "./auth-method-config";
 
 type McpServer = {
@@ -95,16 +101,44 @@ function RemoteEdit(props: {
 
   const [error, setError] = useState<string | null>(null);
 
+  // Whether this server is declared enterprise-managed, and by which
+  // registration. Read off the stored oauth2 method rather than kept as a
+  // parallel flag: the declaration IS the state, and the toggle below only
+  // decides whether the organization's registration is attached to it.
+  const declaredProvider = useMemo<McpEnterpriseIdentityProvider | undefined>(() => {
+    for (const method of server.config.authenticationTemplate) {
+      if (method.kind === "oauth2" && method.enterpriseIdentityProvider !== undefined) {
+        return method.enterpriseIdentityProvider;
+      }
+    }
+    return undefined;
+  }, [server.config.authenticationTemplate]);
+
+  const organizationProvider = useEnterpriseIdentityProviderDescriptor() ?? undefined;
+  const [managed, setManaged] = useState(declaredProvider !== undefined);
+  // The declaration this save would write: the organization's registration
+  // while the toggle is on, and — when the organization has since removed its
+  // registration — whatever the server already names, so an unrelated edit
+  // cannot quietly un-manage a live server.
+  const nextProvider: McpEnterpriseIdentityProvider | undefined = managed
+    ? (organizationProvider ?? declaredProvider)
+    : undefined;
+
   // The edited methods, slugs preserved for seeded rows so existing
   // connections (bound by template slug) stay attached. New rows omit the
-  // slug — the backend assigns kind-based ones.
+  // slug — the backend assigns kind-based ones. Each row is reconciled against
+  // the method it was seeded from, because `configureMcpAuth` runs in `replace`
+  // mode here: anything the credential editor cannot express — the
+  // enterprise-managed declaration above all — has to be carried forward
+  // deliberately or it is erased by an unrelated edit.
   const editedMethods = useMemo<readonly McpCanonicalAuthMethodInput[]>(
     () =>
       list.rows.map((row: AuthMethodRow): McpCanonicalAuthMethodInput => {
-        const input = mcpAuthMethodInputFromEditorValue(row.value);
-        return row.seedSlug !== undefined ? { ...input, slug: row.seedSlug } : input;
+        const edited = mcpAuthMethodInputFromEditorValue(row.value);
+        const declared = edited.kind === "oauth2" ? mcpOAuthMethodInput(nextProvider) : edited;
+        return row.seedSlug !== undefined ? { ...declared, slug: row.seedSlug } : declared;
       }),
-    [list.rows],
+    [list.rows, nextProvider],
   );
 
   const methodsChanged = useMemo(() => {
@@ -118,9 +152,24 @@ function RemoteEdit(props: {
       if (method.kind === "apikey" && current.kind === "apikey") {
         return !samePlacements(method.placements, current.placements);
       }
+      if (method.kind === "oauth2" && current.kind === "oauth2") {
+        return !sameEnterpriseIdentityProvider(
+          method.enterpriseIdentityProvider,
+          current.enterpriseIdentityProvider,
+        );
+      }
       return false;
     });
   }, [editedMethods, server.config.authenticationTemplate]);
+
+  const hasOAuthMethod = server.config.authenticationTemplate.some(
+    (method: McpAuthMethod) => method.kind === "oauth2",
+  );
+  // Offered only where it can mean something: this server authenticates with
+  // OAuth, and either the organization has registered an identity provider or
+  // this server is already managed by one (so it can still be turned off).
+  const canDeclareManaged =
+    hasOAuthMethod && (organizationProvider !== undefined || declaredProvider !== undefined);
 
   // Staged apply, run by the sheet's Save when the method list changed.
   const applyStaged = useCallback(async (): Promise<EditSheetApplyResult> => {
@@ -167,6 +216,38 @@ function RemoteEdit(props: {
         emptyHint="No methods declared. Add one, or save to mark this server as open (no authentication)."
         footerHint="Connections pick one of these methods. Removing a method detaches connections created against it."
       />
+
+      {/* Enterprise-Managed Authorization, per server. The organization's
+          identity provider is registered once (Organization settings); this is
+          where an administrator says WHICH servers authorize through it.
+          Declaring it can never take an ordinary server off the interactive
+          flow — the connect path still requires the server to advertise the
+          grant profile — so the copy promises a route, not an outcome. */}
+      {canDeclareManaged ? (
+        <div className="flex items-start gap-3 rounded-md border border-border/60 px-3 py-3">
+          <Switch
+            id="ema-managed-server"
+            checked={managed}
+            onCheckedChange={setManaged}
+            className="mt-0.5"
+          />
+          <div className="min-w-0 space-y-1">
+            <Label htmlFor="ema-managed-server" className="text-sm font-medium text-foreground">
+              Managed by your organization
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              Members connect with their work identity instead of consenting to this server. Your
+              identity provider decides who gets access, and revokes it.
+            </p>
+            {organizationProvider === undefined ? (
+              <p className="text-xs text-muted-foreground">
+                Your organization no longer has an identity provider registered. This server keeps
+                the one it already names until you turn this off.
+              </p>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
 
       {error && <FormErrorAlert message={error} />}
     </div>

--- a/packages/plugins/mcp/src/react/McpSignInButton.tsx
+++ b/packages/plugins/mcp/src/react/McpSignInButton.tsx
@@ -2,18 +2,14 @@ import { useMemo, useState } from "react";
 import { useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 
-import {
-  AuthTemplateSlug,
-  IntegrationSlug,
-  type Connection,
-  type Owner,
-} from "@executor-js/sdk/shared";
+import { IntegrationSlug, type Connection, type Owner } from "@executor-js/sdk/shared";
 import { connectionsAllAtom } from "@executor-js/react/api/atoms";
 import { AddAccountModal } from "@executor-js/react/components/add-account-modal";
 import { OAuthSignInButton } from "@executor-js/react/plugins/oauth-sign-in";
 import type { AuthMethod } from "@executor-js/react/lib/auth-placements";
 
 import { mcpServerAtom } from "./atoms";
+import { authMethodsFromConfig } from "./auth-method-config";
 import type { McpAuthMethod } from "../sdk/types";
 
 // ---------------------------------------------------------------------------
@@ -47,21 +43,15 @@ export default function McpSignInButton(props: { integrationId: string; owner?: 
     (connection: Connection) => connection.integration === slug,
   );
 
+  // Projected through the plugin's ONE codec rather than assembled here: the
+  // server's enterprise-managed declaration rides on this method, and a
+  // hand-built copy silently dropped it — leaving this button offering
+  // per-server consent for a server the organization manages.
   const methods = useMemo<readonly AuthMethod[]>(
     () =>
       remote === null || oauthMethod === null
         ? []
-        : [
-            {
-              id: oauthMethod.slug,
-              label: "OAuth",
-              kind: "oauth",
-              source: "spec",
-              template: AuthTemplateSlug.make(oauthMethod.slug),
-              placements: [],
-              oauth: { discoveryUrl: remote.endpoint, supportsDynamicRegistration: true },
-            },
-          ],
+        : authMethodsFromConfig([oauthMethod], remote.endpoint),
     [remote, oauthMethod],
   );
   const initialState = useMemo(

--- a/packages/plugins/mcp/src/react/auth-method-config.test.ts
+++ b/packages/plugins/mcp/src/react/auth-method-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
+import { OAuthClientSlug } from "@executor-js/sdk/shared";
 import type { AuthTemplateEditorValue } from "@executor-js/react/components/auth-template-editor";
 
 import {
@@ -6,6 +7,8 @@ import {
   editorValueFromMcpAuthMethod,
   mcpAuthMethodInputFromEditorValue,
   mcpAuthMethodInputsFromPlacements,
+  mcpOAuthMethodInput,
+  sameEnterpriseIdentityProvider,
 } from "./auth-method-config";
 
 describe("mcpAuthMethodInputFromEditorValue", () => {
@@ -172,6 +175,112 @@ describe("authMethodsFromConfig", () => {
       { carrier: "header", name: "Authorization", prefix: "Bearer ", variable: "api_token" },
       { carrier: "query", name: "team_id", prefix: "", variable: "team_id" },
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Enterprise-Managed Authorization: the per-server declaration.
+//
+// The declaration is a POINTER at the organization's identity-provider
+// registration, and it is what puts a server on the work-identity route
+// instead of per-server consent. Two things must hold or the feature silently
+// stops working: it has to reach the console (a dropped pointer means the
+// connect path offers ordinary consent for a managed server), and it must not
+// be invented by any surface that cannot see the organization's registration.
+// ---------------------------------------------------------------------------
+
+const PROVIDER = {
+  client: OAuthClientSlug.make("enterprise-identity-provider"),
+  clientOwner: "org",
+} as const;
+
+describe("authMethodsFromConfig · enterprise-managed declaration", () => {
+  it("carries the server's identity-provider pointer onto the rendered method", () => {
+    const methods = authMethodsFromConfig(
+      [{ slug: "oauth2", kind: "oauth2", enterpriseIdentityProvider: PROVIDER }],
+      "https://mcp.example.com/mcp",
+    );
+    expect(methods[0]?.oauth?.enterpriseIdentityProvider).toEqual(PROVIDER);
+  });
+
+  it("leaves the interactive route advertised beside it", () => {
+    // Declaring a provider asks the connect path to TRY the enterprise branch.
+    // Whether it is taken still depends on the server advertising the grant
+    // profile, so the ordinary route must remain available.
+    const methods = authMethodsFromConfig(
+      [{ slug: "oauth2", kind: "oauth2", enterpriseIdentityProvider: PROVIDER }],
+      "https://mcp.example.com/mcp",
+    );
+    expect(methods[0]?.oauth?.supportsDynamicRegistration).toBe(true);
+    expect(methods[0]?.oauth?.discoveryUrl).toBe("https://mcp.example.com/mcp");
+  });
+
+  it("declares nothing for an ordinary oauth2 server", () => {
+    const methods = authMethodsFromConfig(
+      [{ slug: "oauth2", kind: "oauth2" }],
+      "https://mcp.example.com/mcp",
+    );
+    expect(methods[0]?.oauth?.enterpriseIdentityProvider).toBeUndefined();
+  });
+});
+
+describe("mcpOAuthMethodInput", () => {
+  it("attaches the organization's registration when the server is managed", () => {
+    expect(mcpOAuthMethodInput(PROVIDER)).toEqual({
+      kind: "oauth2",
+      enterpriseIdentityProvider: PROVIDER,
+    });
+  });
+
+  it("omits the key entirely when it is not — never an explicit undefined", () => {
+    // `configureMcpAuth` decodes this against a union; an explicit
+    // `enterpriseIdentityProvider: undefined` is a different wire value and is
+    // rejected, so absence has to be real absence.
+    const input = mcpOAuthMethodInput(undefined);
+    expect(input).toEqual({ kind: "oauth2" });
+    expect(Object.hasOwn(input, "enterpriseIdentityProvider")).toBe(false);
+  });
+});
+
+describe("mcpAuthMethodInputFromEditorValue · enterprise-managed declaration", () => {
+  it("invents no declaration from the credential editor", () => {
+    // The editor edits credentials. Server policy is not one, and a surface
+    // that cannot see the organization's registration must not guess at it —
+    // the save path re-attaches it deliberately instead.
+    expect(
+      mcpAuthMethodInputFromEditorValue({
+        kind: "oauth",
+        authorizationUrl: "",
+        tokenUrl: "",
+        scopes: [],
+      }),
+    ).toEqual({ kind: "oauth2" });
+  });
+});
+
+describe("sameEnterpriseIdentityProvider", () => {
+  it("compares the pointer by value, not by reference", () => {
+    // The stored copy is decoded from JSON, so it is never the same object as
+    // the one the console just built; a reference check would report every
+    // save as a change.
+    expect(sameEnterpriseIdentityProvider({ ...PROVIDER }, { ...PROVIDER })).toBe(true);
+  });
+
+  it("distinguishes a different registration", () => {
+    expect(sameEnterpriseIdentityProvider(PROVIDER, { ...PROVIDER, clientOwner: "user" })).toBe(
+      false,
+    );
+    expect(
+      sameEnterpriseIdentityProvider(PROVIDER, {
+        ...PROVIDER,
+        client: OAuthClientSlug.make("other"),
+      }),
+    ).toBe(false);
+  });
+
+  it("treats declaring and not declaring as different", () => {
+    expect(sameEnterpriseIdentityProvider(PROVIDER, undefined)).toBe(false);
+    expect(sameEnterpriseIdentityProvider(undefined, undefined)).toBe(true);
   });
 });
 

--- a/packages/plugins/mcp/src/react/auth-method-config.ts
+++ b/packages/plugins/mcp/src/react/auth-method-config.ts
@@ -21,6 +21,8 @@ import type {
   McpAuthMethod,
   McpAuthMethodInput,
   McpCanonicalAuthMethodInput,
+  McpEnterpriseIdentityProvider,
+  McpOAuthMethod,
   McpStdioEnvMethod,
 } from "../sdk/types";
 
@@ -48,20 +50,37 @@ export const mcpWireAuthInput = (
   method: McpAuthMethod | McpCanonicalAuthMethodInput,
 ): McpAuthMethodInput => wireAuthInputFromShared(method) as McpAuthMethodInput;
 
-const oauthAuthMethod = (slug: string, endpoint: string): AuthMethod => ({
-  id: slug,
+const oauthAuthMethod = (method: McpOAuthMethod, endpoint: string): AuthMethod => ({
+  id: method.slug,
   label: "OAuth",
   kind: "oauth",
-  source: slug.startsWith("custom_") ? "custom" : "spec",
-  template: AuthTemplateSlug.make(slug),
+  source: method.slug.startsWith("custom_") ? "custom" : "spec",
+  template: AuthTemplateSlug.make(method.slug),
   placements: [],
-  oauth: { discoveryUrl: endpoint, supportsDynamicRegistration: true },
+  oauth: {
+    discoveryUrl: endpoint,
+    supportsDynamicRegistration: true,
+    // The server's own enterprise-managed declaration, carried onto the
+    // presentational method. `supportsDynamicRegistration` stays true beside
+    // it on purpose: declaring an identity provider is an ADDITIONAL route, not
+    // a replacement, and a server that turns out not to advertise the ID-JAG
+    // profile must still be connectable the ordinary way.
+    ...(method.enterpriseIdentityProvider === undefined
+      ? {}
+      : { enterpriseIdentityProvider: method.enterpriseIdentityProvider }),
+  },
 });
 
 /** Convert a generic editor value into one MCP auth-method input (no slug —
  *  the backend assigns carrier-derived slugs). An apikey value keeps every
  *  named placement (headers and query params mix freely); one with no usable
- *  placement falls back to `none`. */
+ *  placement falls back to `none`.
+ *
+ *  Deliberately carries NO enterprise-managed declaration: that is server
+ *  policy, not a credential, so it has no editor field to come from. The
+ *  surface that saves a managed server (`EditMcpIntegration`) re-attaches it
+ *  explicitly from its own toggle, which is what keeps `configureMcpAuth`'s
+ *  `replace` mode from erasing it on an unrelated edit. */
 export function mcpAuthMethodInputFromEditorValue(
   value: AuthTemplateEditorValue,
 ): McpCanonicalAuthMethodInput {
@@ -70,6 +89,31 @@ export function mcpAuthMethodInputFromEditorValue(
     kind: "none",
   }) as McpCanonicalAuthMethodInput;
 }
+
+/** One oauth2 method input carrying the organization's declaration, or none.
+ *
+ *  The single place an enterprise-managed pointer is attached to a method on
+ *  the way out. Written as a constructor rather than a spread at each call site
+ *  so the absent case stays genuinely ABSENT: an explicit
+ *  `enterpriseIdentityProvider: undefined` is a different value on the wire,
+ *  and the union that decodes it rejects it. */
+export const mcpOAuthMethodInput = (
+  provider: McpEnterpriseIdentityProvider | undefined,
+): McpCanonicalAuthMethodInput =>
+  provider === undefined
+    ? { kind: "oauth2" }
+    : { kind: "oauth2", enterpriseIdentityProvider: provider };
+
+/** Whether two enterprise-managed declarations name the same registration.
+ *  Compared field-by-field because the pointer travels through JSON and a
+ *  decoded copy is never reference-equal to the stored one. */
+export const sameEnterpriseIdentityProvider = (
+  a: McpEnterpriseIdentityProvider | undefined,
+  b: McpEnterpriseIdentityProvider | undefined,
+): boolean =>
+  a === undefined || b === undefined
+    ? a === b
+    : String(a.client) === String(b.client) && a.clientOwner === b.clientOwner;
 
 /** Convert one stored MCP method into the generic editor value. */
 export function editorValueFromMcpAuthMethod(method: McpAuthMethod): AuthTemplateEditorValue {
@@ -89,7 +133,7 @@ export function authMethodsFromConfig(
   endpoint: string,
 ): AuthMethod[] {
   return methods.map((method: McpAuthMethod): AuthMethod => {
-    if (method.kind === "oauth2") return oauthAuthMethod(method.slug, endpoint);
+    if (method.kind === "oauth2") return oauthAuthMethod(method, endpoint);
     if (method.kind === "stdio_env") return stdioEnvAuthMethod(method);
     return authMethodFromSharedTemplate(method);
   });

--- a/packages/react/src/api/atoms.tsx
+++ b/packages/react/src/api/atoms.tsx
@@ -400,6 +400,9 @@ export const addConnectionOptimistic = Atom.family((owner: Owner) =>
             oauthScope: null,
             missingOAuthScopes: [],
             lastHealth: null,
+            // A pasted credential is never enterprise-managed: that state is
+            // only ever written by the ID-JAG connect path.
+            enterpriseManaged: false,
           };
           return [optimistic, ...rows];
         }),

--- a/packages/react/src/components/accounts-section.tsx
+++ b/packages/react/src/components/accounts-section.tsx
@@ -15,6 +15,12 @@ import {
 } from "../api/atoms";
 import { connectionWriteKeys } from "../api/reactivity-keys";
 import { HEALTH_INDICATOR_COLOR, HEALTH_STATUS_LABEL } from "../lib/health-display";
+import {
+  MANAGED_CONNECTION_BADGE,
+  MANAGED_CONNECTION_BLOCKED_LABEL,
+  MANAGED_CONNECTION_REVOCATION_HINT,
+  connectionRowPolicy,
+} from "../lib/managed-connection";
 import { useConnectionHealth } from "../lib/use-connection-health";
 import { messageFromExit } from "../api/error-reporting";
 import { ownerLabel, useOwnerDisplay } from "../api/owner-display";
@@ -114,8 +120,19 @@ function AccountRow(props: {
       : null) ?? (probe?.identity && probe.identity.length > 0 ? probe.identity : null);
   const displayLabel = identity ?? String(connection.name);
 
+  // What this row may OFFER, decided from the connection's persisted
+  // enterprise-managed state and the structured administrator verdict on its
+  // freshest health result — never from a status word or a message.
+  const policy = connectionRowPolicy(connection, probe);
+
   const expired = status === "expired";
+  // An administrator decision outranks the health word. "Expired" would invite
+  // a reconnect that cannot succeed, because the route it re-runs is exactly
+  // the one the identity provider just closed.
   const needsHealthAttention = status === "expired" || status === "degraded";
+  const statusLabel = policy.blockedByAdmin
+    ? MANAGED_CONNECTION_BLOCKED_LABEL
+    : HEALTH_STATUS_LABEL[status];
   const healthDetail = needsHealthAttention ? probe?.detail : undefined;
   const missingOAuthScopes = connection.missingOAuthScopes ?? [];
 
@@ -152,9 +169,26 @@ function AccountRow(props: {
             className={`size-2 shrink-0 rounded-full ${indicator.dot}`}
           />
           <span className="truncate">{displayLabel}</span>
+          {policy.managed ? (
+            // Grayscale, a word, no hue — this is a fact about the connection,
+            // not a fault (design.md, "Status and semantics"). It reads
+            // distinctly from the personal rows beside it, which is the point:
+            // an additional personal account on the same integration stays
+            // possible and must stay visibly different.
+            <Badge
+              variant="outline"
+              className="shrink-0 border-border text-muted-foreground"
+              data-slot="managed-connection-badge"
+            >
+              {MANAGED_CONNECTION_BADGE}
+            </Badge>
+          ) : null}
           {needsHealthAttention ? (
-            <Badge variant={expired ? "destructive" : "outline"} className="shrink-0">
-              {HEALTH_STATUS_LABEL[status]}
+            <Badge
+              variant={expired && !policy.blockedByAdmin ? "destructive" : "outline"}
+              className="shrink-0"
+            >
+              {statusLabel}
             </Badge>
           ) : null}
           {needsReconsent ? (
@@ -183,6 +217,16 @@ function AccountRow(props: {
             Missing scopes: {missingOAuthScopes.join(", ")}
           </CardStackEntryDescription>
         ) : null}
+        {policy.managed ? (
+          <CardStackEntryDescription className="mt-1 overflow-visible whitespace-normal text-clip text-xs text-muted-foreground">
+            {MANAGED_CONNECTION_REVOCATION_HINT}
+          </CardStackEntryDescription>
+        ) : null}
+        {policy.oauthErrorCode === null ? null : (
+          <CardStackEntryDescription className="mt-1 font-mono text-[11px] text-muted-foreground">
+            Reference: {policy.oauthErrorCode}
+          </CardStackEntryDescription>
+        )}
       </CardStackEntryContent>
       <CardStackEntryActions className="self-start pt-0.5">
         {props.showOwnerLabel ? (
@@ -213,12 +257,22 @@ function AccountRow(props: {
             <DropdownMenuItem className="text-sm" onClick={props.onEdit}>
               Edit
             </DropdownMenuItem>
-            <DropdownMenuItem className="text-sm" onClick={props.onReconnect}>
-              Reconnect
-            </DropdownMenuItem>
-            <DropdownMenuItem variant="destructive" className="text-sm" onClick={props.onRemove}>
-              Remove
-            </DropdownMenuItem>
+            {/* Reconnect and Remove are WITHHELD, not disabled, for an
+                enterprise-managed connection. Reconnect re-runs the interactive
+                consent this profile has no step for, and Remove would claim the
+                member revoked access they cannot revoke here — the identity
+                provider still authorizes them, and the next call would hand it
+                straight back. Both live at the provider. */}
+            {policy.canReconnect ? (
+              <DropdownMenuItem className="text-sm" onClick={props.onReconnect}>
+                Reconnect
+              </DropdownMenuItem>
+            ) : null}
+            {policy.canRemove ? (
+              <DropdownMenuItem variant="destructive" className="text-sm" onClick={props.onRemove}>
+                Remove
+              </DropdownMenuItem>
+            ) : null}
           </DropdownMenuContent>
         </DropdownMenu>
       </CardStackEntryActions>

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -44,6 +44,7 @@ import {
   oauthClientWriteKeys,
 } from "../api/reactivity-keys";
 import { HEALTH_INDICATOR_COLOR, HEALTH_STATUS_LABEL } from "../lib/health-display";
+import { AdminBlockNotice } from "./admin-block-notice";
 import { FreeformCombobox, type FreeformComboboxOption } from "./combobox";
 import { messageFromExit } from "../api/error-reporting";
 import { trackEvent } from "../api/analytics";
@@ -1618,6 +1619,10 @@ function AddAccountModalView(props: AddAccountModalProps) {
   const isBuiltInGoogleClient =
     chosenClient?.origin.kind === "first_party" &&
     String(chosenClient.slug) === "first-party:google";
+  // The server names an enterprise identity provider (MCP Enterprise-Managed
+  // Authorization). Read STRUCTURALLY off the declared method — never from the
+  // grant of a picked app, which an ordinary connection can also carry.
+  const managedByOrganization = isOAuth && method?.oauth?.enterpriseIdentityProvider !== undefined;
   const oauthBusy = ccBusy || oauthPopup.busy;
   const cimdConnecting = cimdBusy || oauthPopup.busy;
   const dcrConnecting = dcrBusy || oauthPopup.busy;
@@ -2952,11 +2957,33 @@ function AddAccountModalView(props: AddAccountModalProps) {
                 {continueError}
               </p>
             ) : null}
+            {/* The server is declared enterprise-managed. Copy only, and
+                deliberately: whether this connect actually takes the
+                enterprise branch is decided at discovery — the server has to
+                advertise the ID-JAG grant profile — so the notice describes the
+                arrangement rather than promising an outcome the console cannot
+                guarantee. It is withdrawn while an administrator denial stands,
+                where the denial is the more specific truth. */}
+            {managedByOrganization && oauthPopup.adminBlock === null ? (
+              <p
+                data-slot="enterprise-managed-notice"
+                className="mx-1 rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-xs text-muted-foreground"
+              >
+                Your organization manages this server. Where it supports work identities, you sign
+                in with yours and your identity provider decides the access — no consent screen, and
+                nothing to revoke here.
+              </p>
+            ) : null}
             {/* Above the footer, not inside the method tab: the automatic
                 (CIMD/DCR) flows render no tab panel at all, and putting the
                 sign-in error in there left a blocked popup with nothing on
                 screen but the button returning to "Connect". */}
-            {isOAuth && oauthPopup.error ? (
+            {/* An enterprise policy denial replaces the ordinary error line —
+                it is not a transient fault, and the footer below withdraws
+                every connect action while it stands. */}
+            {isOAuth && oauthPopup.adminBlock !== null ? (
+              <AdminBlockNotice block={oauthPopup.adminBlock} className="mx-1" />
+            ) : isOAuth && oauthPopup.error ? (
               <p role="alert" className="px-1 text-xs text-destructive">
                 {oauthPopup.error}
               </p>
@@ -2978,7 +3005,12 @@ function AddAccountModalView(props: AddAccountModalProps) {
               - registering a BYO app: the form owns its own submit, no footer;
               - picked BYO OAuth app: Connect with OAuth / Connect (client creds);
               - credential/no-auth method: Add connection. */}
-              {cimdActive ? (
+              {/* Blocked by administrator: offer NOTHING that reconnects.
+                  Every branch below is a route to the same authorization the
+                  enterprise just refused, and the interactive one would route
+                  the user around the control outright. Close is the only
+                  action left. */}
+              {isOAuth && oauthPopup.adminBlock !== null ? null : cimdActive ? (
                 <Button
                   type="button"
                   onClick={() => void handleCimdConnect()}

--- a/packages/react/src/components/admin-block-notice.tsx
+++ b/packages/react/src/components/admin-block-notice.tsx
@@ -1,0 +1,40 @@
+import {
+  ADMIN_BLOCK_NEXT_STEP,
+  ADMIN_BLOCK_TITLE,
+  adminBlockReference,
+  type OAuthAdminBlock,
+} from "../plugins/oauth-admin-block";
+
+// ---------------------------------------------------------------------------
+// The blocked-by-administrator notice.
+//
+// Presented as an ORGANIZATION DECISION, not an error the user can work
+// around: no retry, no alternative sign-in, no "try again" — every one of those
+// would offer the route the identity provider just closed. What it does give is
+// the provider's own code, so a member can quote it to whoever administers the
+// policy.
+//
+// Grayscale, per design.md: destructive red is for irreversible actions and
+// faults, and this is neither. It is a policy outcome.
+// ---------------------------------------------------------------------------
+
+export function AdminBlockNotice(props: {
+  readonly block: OAuthAdminBlock;
+  readonly className?: string;
+}) {
+  const reference = adminBlockReference(props.block);
+  return (
+    <div
+      role="alert"
+      data-slot="admin-block-notice"
+      className={`space-y-1 rounded-lg border border-border bg-muted/40 p-3 ${props.className ?? ""}`}
+    >
+      <p className="text-sm font-medium text-foreground">{ADMIN_BLOCK_TITLE}</p>
+      <p className="text-xs text-muted-foreground">{props.block.message}</p>
+      <p className="text-xs text-muted-foreground">{ADMIN_BLOCK_NEXT_STEP}</p>
+      {reference === null ? null : (
+        <p className="font-mono text-[11px] text-muted-foreground">{reference}</p>
+      )}
+    </div>
+  );
+}

--- a/packages/react/src/components/enterprise-idp-section.test.ts
+++ b/packages/react/src/components/enterprise-idp-section.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "@effect/vitest";
+import { OAuthClientSlug, type OAuthClientSummary } from "@executor-js/sdk/shared";
+
+import {
+  ENTERPRISE_IDENTITY_PROVIDER_CLIENT_OWNER,
+  ENTERPRISE_IDENTITY_PROVIDER_CLIENT_SLUG,
+  canSubmitEnterpriseIdentityProvider,
+  enterpriseIdentityProviderPayload,
+  findEnterpriseIdentityProvider,
+} from "./enterprise-idp-section";
+
+const client = (overrides: Partial<OAuthClientSummary>): OAuthClientSummary => ({
+  owner: "org",
+  slug: OAuthClientSlug.make("some-app"),
+  grant: "authorization_code",
+  authorizationUrl: "https://example.com/authorize",
+  tokenUrl: "https://example.com/token",
+  clientId: "client-id",
+  origin: { kind: "manual" },
+  ...overrides,
+});
+
+describe("findEnterpriseIdentityProvider", () => {
+  it("finds the workspace registration under the reserved slug", () => {
+    const provider = client({ slug: ENTERPRISE_IDENTITY_PROVIDER_CLIENT_SLUG });
+    expect(findEnterpriseIdentityProvider([client({}), provider])).toBe(provider);
+  });
+
+  it("returns null when the organization has registered none", () => {
+    expect(findEnterpriseIdentityProvider([client({})])).toBeNull();
+  });
+
+  it("ignores a personal app that happens to carry the reserved slug", () => {
+    // The provider is an ORGANIZATION control; a user-owned app under the same
+    // slug is a different app and must never stand in for it.
+    expect(
+      findEnterpriseIdentityProvider([
+        client({ owner: "user", slug: ENTERPRISE_IDENTITY_PROVIDER_CLIENT_SLUG }),
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe("canSubmitEnterpriseIdentityProvider", () => {
+  const valid = { submitting: false, tokenUrl: "https://idp.example/token", clientId: "abc" };
+
+  it("accepts a public client with no secret", () => {
+    expect(canSubmitEnterpriseIdentityProvider(valid)).toBe(true);
+  });
+
+  it("requires the token endpoint the assertion exchange is POSTed to", () => {
+    expect(canSubmitEnterpriseIdentityProvider({ ...valid, tokenUrl: "   " })).toBe(false);
+  });
+
+  it("requires the client id the exchange authenticates as", () => {
+    expect(canSubmitEnterpriseIdentityProvider({ ...valid, clientId: "" })).toBe(false);
+  });
+
+  it("refuses a second submit while one is in flight", () => {
+    expect(canSubmitEnterpriseIdentityProvider({ ...valid, submitting: true })).toBe(false);
+  });
+});
+
+describe("enterpriseIdentityProviderPayload", () => {
+  it("registers the workspace-owned app under the reserved slug", () => {
+    const payload = enterpriseIdentityProviderPayload({
+      tokenUrl: "  https://idp.example/token  ",
+      clientId: " abc ",
+      clientSecret: " shh ",
+    });
+    expect(payload.owner).toBe(ENTERPRISE_IDENTITY_PROVIDER_CLIENT_OWNER);
+    expect(String(payload.slug)).toBe(String(ENTERPRISE_IDENTITY_PROVIDER_CLIENT_SLUG));
+    expect(payload.tokenUrl).toBe("https://idp.example/token");
+    expect(payload.clientId).toBe("abc");
+    expect(payload.clientSecret).toBe("shh");
+  });
+
+  it("records no authorization URL, because this app never runs a redirect", () => {
+    // The enterprise-managed chain exchanges an assertion the member already
+    // holds at the token endpoint; there is no authorization endpoint to store,
+    // and inventing one would claim a flow this registration does not run.
+    expect(
+      enterpriseIdentityProviderPayload({
+        tokenUrl: "https://idp.example/token",
+        clientId: "abc",
+        clientSecret: "",
+      }).authorizationUrl,
+    ).toBe("");
+  });
+
+  it("stamps no originating integration — it backs every managed server", () => {
+    expect(
+      enterpriseIdentityProviderPayload({
+        tokenUrl: "https://idp.example/token",
+        clientId: "abc",
+        clientSecret: "",
+      }).originIntegration,
+    ).toBeNull();
+  });
+});

--- a/packages/react/src/components/enterprise-idp-section.test.ts
+++ b/packages/react/src/components/enterprise-idp-section.test.ts
@@ -4,6 +4,7 @@ import { OAuthClientSlug, type OAuthClientSummary } from "@executor-js/sdk/share
 import {
   ENTERPRISE_IDENTITY_PROVIDER_CLIENT_OWNER,
   ENTERPRISE_IDENTITY_PROVIDER_CLIENT_SLUG,
+  ENTERPRISE_IDENTITY_PROVIDER_DESCRIPTOR,
   canSubmitEnterpriseIdentityProvider,
   enterpriseIdentityProviderPayload,
   findEnterpriseIdentityProvider,
@@ -42,14 +43,20 @@ describe("findEnterpriseIdentityProvider", () => {
 });
 
 describe("canSubmitEnterpriseIdentityProvider", () => {
-  const valid = { submitting: false, tokenUrl: "https://idp.example/token", clientId: "abc" };
+  const valid = {
+    submitting: false,
+    issuerUrl: "https://idp.example/oauth2/default",
+    clientId: "abc",
+  };
 
   it("accepts a public client with no secret", () => {
     expect(canSubmitEnterpriseIdentityProvider(valid)).toBe(true);
   });
 
-  it("requires the token endpoint the assertion exchange is POSTed to", () => {
-    expect(canSubmitEnterpriseIdentityProvider({ ...valid, tokenUrl: "   " })).toBe(false);
+  it("requires the issuer the endpoints are discovered from", () => {
+    // Endpoints are never typed: they are probed off the issuer, so the issuer
+    // is the field the registration cannot proceed without.
+    expect(canSubmitEnterpriseIdentityProvider({ ...valid, issuerUrl: "   " })).toBe(false);
   });
 
   it("requires the client id the exchange authenticates as", () => {
@@ -62,9 +69,14 @@ describe("canSubmitEnterpriseIdentityProvider", () => {
 });
 
 describe("enterpriseIdentityProviderPayload", () => {
+  const discovered = {
+    authorizationUrl: "  https://idp.example/authorize  ",
+    tokenUrl: "  https://idp.example/token  ",
+  };
+
   it("registers the workspace-owned app under the reserved slug", () => {
     const payload = enterpriseIdentityProviderPayload({
-      tokenUrl: "  https://idp.example/token  ",
+      ...discovered,
       clientId: " abc ",
       clientSecret: " shh ",
     });
@@ -75,26 +87,45 @@ describe("enterpriseIdentityProviderPayload", () => {
     expect(payload.clientSecret).toBe("shh");
   });
 
-  it("records no authorization URL, because this app never runs a redirect", () => {
-    // The enterprise-managed chain exchanges an assertion the member already
-    // holds at the token endpoint; there is no authorization endpoint to store,
-    // and inventing one would claim a flow this registration does not run.
+  it("records the authorization endpoint the work-identity link needs", () => {
+    // The ID-JAG exchange itself only touches the token endpoint. The
+    // authorization endpoint is here for the hop that produces the subject
+    // token in the first place: an assertion issued BY this provider and
+    // audienced to THIS client, which a brokered login does not yield.
     expect(
-      enterpriseIdentityProviderPayload({
-        tokenUrl: "https://idp.example/token",
-        clientId: "abc",
-        clientSecret: "",
-      }).authorizationUrl,
-    ).toBe("");
+      enterpriseIdentityProviderPayload({ ...discovered, clientId: "abc", clientSecret: "" })
+        .authorizationUrl,
+    ).toBe("https://idp.example/authorize");
+  });
+
+  it("registers the authorization-code grant, not the enterprise grant", () => {
+    // `id_jag` names the registration at an MCP server's authorization server.
+    // THIS app is the registration at the identity provider — it authenticates
+    // the exchange and runs the work-identity hop, both authorization-code
+    // shaped.
+    expect(
+      enterpriseIdentityProviderPayload({ ...discovered, clientId: "abc", clientSecret: "" }).grant,
+    ).toBe("authorization_code");
   });
 
   it("stamps no originating integration — it backs every managed server", () => {
     expect(
-      enterpriseIdentityProviderPayload({
-        tokenUrl: "https://idp.example/token",
-        clientId: "abc",
-        clientSecret: "",
-      }).originIntegration,
+      enterpriseIdentityProviderPayload({ ...discovered, clientId: "abc", clientSecret: "" })
+        .originIntegration,
     ).toBeNull();
+  });
+});
+
+describe("ENTERPRISE_IDENTITY_PROVIDER_DESCRIPTOR", () => {
+  it("names the same registration the section writes", () => {
+    // A server declaration and a connect request both point at the provider by
+    // (owner, slug). If this descriptor and the payload ever disagreed, every
+    // managed server would name a registration that does not exist.
+    expect(String(ENTERPRISE_IDENTITY_PROVIDER_DESCRIPTOR.client)).toBe(
+      String(ENTERPRISE_IDENTITY_PROVIDER_CLIENT_SLUG),
+    );
+    expect(ENTERPRISE_IDENTITY_PROVIDER_DESCRIPTOR.clientOwner).toBe(
+      ENTERPRISE_IDENTITY_PROVIDER_CLIENT_OWNER,
+    );
   });
 });

--- a/packages/react/src/components/enterprise-idp-section.tsx
+++ b/packages/react/src/components/enterprise-idp-section.tsx
@@ -2,12 +2,18 @@ import { useState } from "react";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
-import { OAuthClientSlug, type OAuthClientSummary, type Owner } from "@executor-js/sdk/shared";
+import {
+  OAuthClientSlug,
+  type EnterpriseIdentityProviderDescriptor,
+  type OAuthClientSummary,
+  type Owner,
+} from "@executor-js/sdk/shared";
 import { toast } from "sonner";
 
 import {
   createOAuthClientOptimistic,
   oauthClientsOptimisticAtom,
+  probeOAuth,
   removeOAuthClientOptimistic,
 } from "../api/atoms";
 import { trackEvent } from "../api/analytics";
@@ -75,31 +81,43 @@ export const findEnterpriseIdentityProvider = (
       String(client.slug) === String(ENTERPRISE_IDENTITY_PROVIDER_CLIENT_SLUG),
   ) ?? null;
 
-/** Registering the provider needs the token endpoint the RFC 8693 exchange is
- *  POSTed to and the client id it authenticates as. The secret is optional: an
- *  IdP may treat the client as public. */
+/** The descriptor a managed server points at — the shape an MCP server's
+ *  `enterpriseIdentityProvider` declaration and `oauth.start`'s `enterprise`
+ *  input both speak. Derived from the reserved identity, never typed by hand. */
+export const ENTERPRISE_IDENTITY_PROVIDER_DESCRIPTOR: EnterpriseIdentityProviderDescriptor = {
+  client: ENTERPRISE_IDENTITY_PROVIDER_CLIENT_SLUG,
+  clientOwner: ENTERPRISE_IDENTITY_PROVIDER_CLIENT_OWNER,
+};
+
+/** Registering the provider needs the issuer to discover endpoints from and the
+ *  client id the exchange authenticates as. The secret is optional: an identity
+ *  provider may treat the registration as a public client. */
 export const canSubmitEnterpriseIdentityProvider = (input: {
   readonly submitting: boolean;
-  readonly tokenUrl: string;
+  readonly issuerUrl: string;
   readonly clientId: string;
 }): boolean =>
-  !input.submitting && input.tokenUrl.trim().length > 0 && input.clientId.trim().length > 0;
+  !input.submitting && input.issuerUrl.trim().length > 0 && input.clientId.trim().length > 0;
 
 /** The `oauth.createClient` payload for the organization's identity provider.
  *
- *  `authorizationUrl` is empty by construction and that is not an omission: the
- *  enterprise-managed chain never runs a browser redirect through this
- *  registration. It exchanges an assertion the user already holds at the token
- *  endpoint (draft §4.3), so there is no authorization endpoint to record — and
- *  inventing one would claim a flow this app does not run. */
+ *  BOTH endpoints are recorded, and the authorization endpoint is the one worth
+ *  explaining. The RFC 8693 exchange that mints an ID-JAG only ever touches the
+ *  token endpoint — but the exchange needs a subject token ISSUED BY THIS
+ *  PROVIDER and audienced to THIS client, and a WorkOS-brokered login does not
+ *  produce one: there, WorkOS is the client at the customer's identity
+ *  provider, and what executor holds is a WorkOS token. Closing that gap needs
+ *  one authorization-code hop against this registration — the member's "link
+ *  your work identity" step — and that hop needs an authorize endpoint. */
 export const enterpriseIdentityProviderPayload = (input: {
+  readonly authorizationUrl: string;
   readonly tokenUrl: string;
   readonly clientId: string;
   readonly clientSecret: string;
 }) => ({
   owner: ENTERPRISE_IDENTITY_PROVIDER_CLIENT_OWNER,
   slug: ENTERPRISE_IDENTITY_PROVIDER_CLIENT_SLUG,
-  authorizationUrl: "",
+  authorizationUrl: input.authorizationUrl.trim(),
   tokenUrl: input.tokenUrl.trim(),
   grant: "authorization_code" as const,
   clientId: input.clientId.trim(),
@@ -108,6 +126,22 @@ export const enterpriseIdentityProviderPayload = (input: {
   // enterprise-managed server in the workspace.
   originIntegration: null,
 });
+
+/**
+ * The organization's identity-provider pointer, or null when none is
+ * registered.
+ *
+ * The pointer, deliberately, and not the registration: a server declaration and
+ * a connect request both need to NAME the provider, and neither has any
+ * business holding its endpoints or its client id.
+ */
+export function useEnterpriseIdentityProviderDescriptor(): EnterpriseIdentityProviderDescriptor | null {
+  const clientsResult = useAtomValue(oauthClientsOptimisticAtom);
+  return AsyncResult.isSuccess(clientsResult) &&
+    findEnterpriseIdentityProvider(clientsResult.value) !== null
+    ? ENTERPRISE_IDENTITY_PROVIDER_DESCRIPTOR
+    : null;
+}
 
 // ---------------------------------------------------------------------------
 // The registration dialog. Self-contained: its form state lives here and dies
@@ -122,19 +156,36 @@ function EnterpriseIdentityProviderDialog(props: {
   readonly current: OAuthClientSummary | null;
 }) {
   const { current } = props;
-  const [tokenUrl, setTokenUrl] = useState(current === null ? "" : current.tokenUrl);
+  const [issuerUrl, setIssuerUrl] = useState(current === null ? "" : current.tokenUrl);
   const [clientId, setClientId] = useState(current === null ? "" : current.clientId);
   const [clientSecret, setClientSecret] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const doCreate = useAtomSet(createOAuthClientOptimistic, { mode: "promiseExit" });
+  const doProbe = useAtomSet(probeOAuth, { mode: "promiseExit" });
 
-  const canSubmit = canSubmitEnterpriseIdentityProvider({ submitting, tokenUrl, clientId });
+  const canSubmit = canSubmitEnterpriseIdentityProvider({ submitting, issuerUrl, clientId });
 
   const handleSubmit = async () => {
     if (!canSubmit) return;
     setSubmitting(true);
+    // Endpoints are DISCOVERED from the issuer, never typed. An administrator
+    // knows their tenant's issuer; asking them to also transcribe an authorize
+    // and a token path invites the one typo whose only symptom is every
+    // member's connect failing later, at the identity provider, with a message
+    // about the wrong host.
+    const probed = await doProbe({ payload: { url: issuerUrl.trim() }, reactivityKeys: [] });
+    if (Exit.isFailure(probed)) {
+      setSubmitting(false);
+      toast.error("Couldn't read that issuer's OpenID configuration. Check the URL, then retry.");
+      return;
+    }
     const exit = await doCreate({
-      payload: enterpriseIdentityProviderPayload({ tokenUrl, clientId, clientSecret }),
+      payload: enterpriseIdentityProviderPayload({
+        authorizationUrl: probed.value.authorizationUrl,
+        tokenUrl: probed.value.tokenUrl,
+        clientId,
+        clientSecret,
+      }),
       reactivityKeys: oauthClientWriteKeys,
     });
     trackEvent("oauth_client_registered", {
@@ -145,7 +196,7 @@ function EnterpriseIdentityProviderDialog(props: {
     });
     if (Exit.isFailure(exit)) {
       setSubmitting(false);
-      toast.error("Couldn't save the identity provider. Check the token URL, then retry.");
+      toast.error("Couldn't save the identity provider. Check the issuer URL, then retry.");
       return;
     }
     toast.success(current === null ? "Identity provider registered" : "Identity provider updated");
@@ -166,23 +217,27 @@ function EnterpriseIdentityProviderDialog(props: {
             {current === null ? "Register Identity Provider" : "Edit Identity Provider"}
           </DialogTitle>
           <DialogDescription className="text-sm leading-relaxed">
-            Executor exchanges each member&apos;s single sign-on assertion at this endpoint for a
-            grant naming one MCP server. Your identity provider decides which members may reach
-            which servers.
+            Register Executor as an application in your own identity provider, then paste its
+            details here. Executor exchanges each member&apos;s work identity there for a grant
+            naming one MCP server, so your identity provider — not the member — decides who reaches
+            which server.
           </DialogDescription>
         </DialogHeader>
 
         <div className="grid gap-4 py-1">
           <div className="grid gap-1.5">
-            <Label htmlFor="ema-idp-token-url" className="text-xs text-muted-foreground">
-              Token URL
+            <Label htmlFor="ema-idp-issuer-url" className="text-xs text-muted-foreground">
+              Issuer URL
+              <span className="font-normal text-muted-foreground/70">
+                endpoints are read from it
+              </span>
             </Label>
             <Input
-              id="ema-idp-token-url"
+              id="ema-idp-issuer-url"
               autoComplete="off"
-              placeholder="https://example.okta.com/oauth2/default/v1/token"
-              value={tokenUrl}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTokenUrl(e.target.value)}
+              placeholder="https://example.okta.com/oauth2/default"
+              value={issuerUrl}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setIssuerUrl(e.target.value)}
               className="font-mono text-sm"
             />
           </div>
@@ -226,7 +281,11 @@ function EnterpriseIdentityProviderDialog(props: {
             </Button>
           </DialogClose>
           <Button size="sm" onClick={() => void handleSubmit()} disabled={!canSubmit}>
-            {submitting ? "Saving…" : current === null ? "Register Provider" : "Save Provider"}
+            {submitting
+              ? "Reading issuer…"
+              : current === null
+                ? "Register Provider"
+                : "Save Provider"}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -261,8 +320,9 @@ export function EnterpriseIdentityProviderSection() {
         <div>
           <h2 className="text-sm font-medium text-foreground">Enterprise Identity Provider</h2>
           <p className="mt-0.5 text-sm text-muted-foreground">
-            Register the app Executor uses at your identity provider. MCP servers pointed at it
-            connect through your organization instead of asking each member for consent.
+            Register Executor&apos;s application from your own identity provider. MCP servers marked
+            as managed then connect with each member&apos;s work identity, instead of asking them to
+            consent server by server.
           </p>
         </div>
         {provider === null ? (
@@ -282,7 +342,7 @@ export function EnterpriseIdentityProviderSection() {
         onSuccess: () =>
           provider === null ? (
             <p className="py-6 text-center text-sm text-muted-foreground">
-              No identity provider yet. Register one so MCP servers can authorize members through
+              No identity provider yet. Register one before marking any MCP server as managed by
               your organization.
             </p>
           ) : (
@@ -336,8 +396,8 @@ export function EnterpriseIdentityProviderSection() {
               </div>
               <div className="border-t border-border px-4 py-3">
                 <p className="text-xs text-muted-foreground">
-                  Members never see a consent screen for servers pointed at this provider, and
-                  access is revoked at the provider, not here.
+                  On a managed server, members connect with their work identity instead of a consent
+                  screen — and access is revoked at your identity provider, not here.
                 </p>
               </div>
             </div>

--- a/packages/react/src/components/enterprise-idp-section.tsx
+++ b/packages/react/src/components/enterprise-idp-section.tsx
@@ -1,0 +1,354 @@
+import { useState } from "react";
+import { useAtomValue, useAtomSet } from "@effect/atom-react";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+import * as Exit from "effect/Exit";
+import { OAuthClientSlug, type OAuthClientSummary, type Owner } from "@executor-js/sdk/shared";
+import { toast } from "sonner";
+
+import {
+  createOAuthClientOptimistic,
+  oauthClientsOptimisticAtom,
+  removeOAuthClientOptimistic,
+} from "../api/atoms";
+import { trackEvent } from "../api/analytics";
+import { oauthClientWriteKeys } from "../api/reactivity-keys";
+import { Badge } from "./badge";
+import { Button } from "./button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./dropdown-menu";
+import { Input } from "./input";
+import { Label } from "./label";
+
+// ---------------------------------------------------------------------------
+// Enterprise Identity Provider — the organization-level registration behind MCP
+// Enterprise-Managed Authorization.
+//
+// An organization has exactly ONE enterprise identity provider, so this is not
+// a list: it is a single registration under a reserved workspace-owned slug.
+// What is registered is the client's OAuth app AT THE IdP (draft §5) — the
+// relationship that authenticates the RFC 8693 exchange that mints an ID-JAG.
+// It is a DIFFERENT registration from the per-server app at each MCP server's
+// Resource Authorization Server, which is why an admin does this once here and
+// then points individual servers at it.
+//
+// This is a shared component but not a shared page: only hosts that HAVE an
+// organization admin surface compose it (cloud does, from its org page). The
+// admin gate is the composing host's, because who counts as an admin is the
+// host's model, not this component's.
+// ---------------------------------------------------------------------------
+
+/** The reserved `(owner, slug)` the organization's identity-provider app is
+ *  registered under. Fixed rather than user-entered because the whole point is
+ *  that servers can name it without an admin re-typing a slug, and because
+ *  `oauth.createClient` upserts by `(owner, slug)` — so editing the provider is
+ *  re-registering it under the same identity. */
+export const ENTERPRISE_IDENTITY_PROVIDER_CLIENT_SLUG = OAuthClientSlug.make(
+  "enterprise-identity-provider",
+);
+
+/** The organization owns it: every member's connections authorize through the
+ *  same registration, which is what makes it an enterprise control. */
+export const ENTERPRISE_IDENTITY_PROVIDER_CLIENT_OWNER: Owner = "org";
+
+/** The organization's registered identity provider, or null when none is
+ *  registered. Matched on the reserved `(owner, slug)` — never on a URL or a
+ *  name, which an admin can change. */
+export const findEnterpriseIdentityProvider = (
+  clients: readonly OAuthClientSummary[],
+): OAuthClientSummary | null =>
+  clients.find(
+    (client) =>
+      client.owner === ENTERPRISE_IDENTITY_PROVIDER_CLIENT_OWNER &&
+      String(client.slug) === String(ENTERPRISE_IDENTITY_PROVIDER_CLIENT_SLUG),
+  ) ?? null;
+
+/** Registering the provider needs the token endpoint the RFC 8693 exchange is
+ *  POSTed to and the client id it authenticates as. The secret is optional: an
+ *  IdP may treat the client as public. */
+export const canSubmitEnterpriseIdentityProvider = (input: {
+  readonly submitting: boolean;
+  readonly tokenUrl: string;
+  readonly clientId: string;
+}): boolean =>
+  !input.submitting && input.tokenUrl.trim().length > 0 && input.clientId.trim().length > 0;
+
+/** The `oauth.createClient` payload for the organization's identity provider.
+ *
+ *  `authorizationUrl` is empty by construction and that is not an omission: the
+ *  enterprise-managed chain never runs a browser redirect through this
+ *  registration. It exchanges an assertion the user already holds at the token
+ *  endpoint (draft §4.3), so there is no authorization endpoint to record — and
+ *  inventing one would claim a flow this app does not run. */
+export const enterpriseIdentityProviderPayload = (input: {
+  readonly tokenUrl: string;
+  readonly clientId: string;
+  readonly clientSecret: string;
+}) => ({
+  owner: ENTERPRISE_IDENTITY_PROVIDER_CLIENT_OWNER,
+  slug: ENTERPRISE_IDENTITY_PROVIDER_CLIENT_SLUG,
+  authorizationUrl: "",
+  tokenUrl: input.tokenUrl.trim(),
+  grant: "authorization_code" as const,
+  clientId: input.clientId.trim(),
+  clientSecret: input.clientSecret.trim(),
+  // Not registered from any one integration's dialog: it backs every
+  // enterprise-managed server in the workspace.
+  originIntegration: null,
+});
+
+// ---------------------------------------------------------------------------
+// The registration dialog. Self-contained: its form state lives here and dies
+// with it, so re-opening after a cancel never resurfaces a half-typed secret.
+// ---------------------------------------------------------------------------
+
+function EnterpriseIdentityProviderDialog(props: {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  /** The current registration when editing; null when registering the first
+   *  one. The secret is never returned by the server, so it is always retyped. */
+  readonly current: OAuthClientSummary | null;
+}) {
+  const { current } = props;
+  const [tokenUrl, setTokenUrl] = useState(current === null ? "" : current.tokenUrl);
+  const [clientId, setClientId] = useState(current === null ? "" : current.clientId);
+  const [clientSecret, setClientSecret] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const doCreate = useAtomSet(createOAuthClientOptimistic, { mode: "promiseExit" });
+
+  const canSubmit = canSubmitEnterpriseIdentityProvider({ submitting, tokenUrl, clientId });
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    const exit = await doCreate({
+      payload: enterpriseIdentityProviderPayload({ tokenUrl, clientId, clientSecret }),
+      reactivityKeys: oauthClientWriteKeys,
+    });
+    trackEvent("oauth_client_registered", {
+      owner: ENTERPRISE_IDENTITY_PROVIDER_CLIENT_OWNER,
+      grant: "authorization_code",
+      via_dcr: false,
+      success: Exit.isSuccess(exit),
+    });
+    if (Exit.isFailure(exit)) {
+      setSubmitting(false);
+      toast.error("Couldn't save the identity provider. Check the token URL, then retry.");
+      return;
+    }
+    toast.success(current === null ? "Identity provider registered" : "Identity provider updated");
+    props.onOpenChange(false);
+  };
+
+  return (
+    <Dialog
+      open={props.open}
+      onOpenChange={(next: boolean) => {
+        if (submitting) return;
+        props.onOpenChange(next);
+      }}
+    >
+      <DialogContent className="sm:max-w-[460px]">
+        <DialogHeader>
+          <DialogTitle className="font-display text-xl">
+            {current === null ? "Register Identity Provider" : "Edit Identity Provider"}
+          </DialogTitle>
+          <DialogDescription className="text-sm leading-relaxed">
+            Executor exchanges each member&apos;s single sign-on assertion at this endpoint for a
+            grant naming one MCP server. Your identity provider decides which members may reach
+            which servers.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-1">
+          <div className="grid gap-1.5">
+            <Label htmlFor="ema-idp-token-url" className="text-xs text-muted-foreground">
+              Token URL
+            </Label>
+            <Input
+              id="ema-idp-token-url"
+              autoComplete="off"
+              placeholder="https://example.okta.com/oauth2/default/v1/token"
+              value={tokenUrl}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTokenUrl(e.target.value)}
+              className="font-mono text-sm"
+            />
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="ema-idp-client-id" className="text-xs text-muted-foreground">
+              Client ID
+            </Label>
+            <Input
+              id="ema-idp-client-id"
+              autoComplete="off"
+              placeholder="client id"
+              value={clientId}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setClientId(e.target.value)}
+              className="font-mono text-sm"
+            />
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="ema-idp-client-secret" className="text-xs text-muted-foreground">
+              Client Secret
+              <span className="font-normal text-muted-foreground/70">
+                optional for public clients
+              </span>
+            </Label>
+            <Input
+              id="ema-idp-client-secret"
+              type="password"
+              autoComplete="new-password"
+              placeholder={current === null ? "optional client secret" : "re-enter to change"}
+              value={clientSecret}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setClientSecret(e.target.value)}
+              className="font-mono text-sm"
+              data-ph-block
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost" size="sm" disabled={submitting}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button size="sm" onClick={() => void handleSubmit()} disabled={!canSubmit}>
+            {submitting ? "Saving…" : current === null ? "Register Provider" : "Save Provider"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function EnterpriseIdentityProviderSection() {
+  const clientsResult = useAtomValue(oauthClientsOptimisticAtom);
+  const doRemove = useAtomSet(removeOAuthClientOptimistic, { mode: "promiseExit" });
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const provider = AsyncResult.isSuccess(clientsResult)
+    ? findEnterpriseIdentityProvider(clientsResult.value)
+    : null;
+
+  const handleRemove = async () => {
+    const exit = await doRemove({
+      params: { slug: ENTERPRISE_IDENTITY_PROVIDER_CLIENT_SLUG },
+      payload: { owner: ENTERPRISE_IDENTITY_PROVIDER_CLIENT_OWNER },
+      reactivityKeys: oauthClientWriteKeys,
+    });
+    trackEvent("oauth_client_removed", { owner: ENTERPRISE_IDENTITY_PROVIDER_CLIENT_OWNER });
+    toast[Exit.isSuccess(exit) ? "success" : "error"](
+      Exit.isSuccess(exit) ? "Identity provider removed" : "Failed to remove identity provider",
+    );
+  };
+
+  return (
+    <section className="mb-2">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h2 className="text-sm font-medium text-foreground">Enterprise Identity Provider</h2>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            Register the app Executor uses at your identity provider. MCP servers pointed at it
+            connect through your organization instead of asking each member for consent.
+          </p>
+        </div>
+        {provider === null ? (
+          <Button size="sm" className="ml-4 min-w-32 shrink-0" onClick={() => setDialogOpen(true)}>
+            Register Provider
+          </Button>
+        ) : null}
+      </div>
+
+      {AsyncResult.match(clientsResult, {
+        onInitial: () => <div className="h-16 animate-pulse rounded-lg bg-muted/50" />,
+        onFailure: () => (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
+            <p className="text-sm text-destructive">Failed to load the identity provider</p>
+          </div>
+        ),
+        onSuccess: () =>
+          provider === null ? (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              No identity provider yet. Register one so MCP servers can authorize members through
+              your organization.
+            </p>
+          ) : (
+            <div className="rounded-lg border border-border">
+              <div className="flex items-center gap-3 px-4 py-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <p
+                      id="ema-idp-token-url-value"
+                      className="truncate font-mono text-sm text-foreground"
+                    >
+                      {provider.tokenUrl}
+                    </p>
+                    {/* Grayscale by design: status is a word plus tone, never a
+                        hue (see design.md, Status and semantics). */}
+                    <Badge className="shrink-0 bg-muted text-foreground">Registered</Badge>
+                  </div>
+                  <p className="mt-0.5 truncate font-mono text-xs text-muted-foreground">
+                    {provider.clientId}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-1.5">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-7"
+                        aria-label="Identity provider actions"
+                      >
+                        <svg viewBox="0 0 16 16" className="size-3">
+                          <circle cx="8" cy="3" r="1.2" fill="currentColor" />
+                          <circle cx="8" cy="8" r="1.2" fill="currentColor" />
+                          <circle cx="8" cy="13" r="1.2" fill="currentColor" />
+                        </svg>
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-52">
+                      <DropdownMenuItem className="text-sm" onClick={() => setDialogOpen(true)}>
+                        Edit Provider
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        className="text-sm text-destructive focus:text-destructive"
+                        onClick={() => void handleRemove()}
+                      >
+                        Remove Provider
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              </div>
+              <div className="border-t border-border px-4 py-3">
+                <p className="text-xs text-muted-foreground">
+                  Members never see a consent screen for servers pointed at this provider, and
+                  access is revoked at the provider, not here.
+                </p>
+              </div>
+            </div>
+          ),
+      })}
+
+      {/* Mounted only while open so the form — including a typed secret — is
+          created and destroyed with the dialog. */}
+      {dialogOpen ? (
+        <EnterpriseIdentityProviderDialog open onOpenChange={setDialogOpen} current={provider} />
+      ) : null}
+    </section>
+  );
+}

--- a/packages/react/src/components/oauth-client-form.test.ts
+++ b/packages/react/src/components/oauth-client-form.test.ts
@@ -112,6 +112,60 @@ describe("canSubmitOAuthClientForm", () => {
       }),
     ).toBe(false);
   });
+
+  // MCP Enterprise-Managed Authorization (`id_jag`). The app registered here is
+  // the client's registration at the MCP server's Resource Authorization
+  // Server; discovery starts from the resource identifier, so that field — not
+  // the authorization URL — is what the grant cannot do without.
+  it("requires a resource URL for enterprise identity assertion clients", () => {
+    expect(
+      canSubmitOAuthClientForm({
+        ...validBase,
+        grant: "id_jag",
+        authorizationUrl: "",
+        resource: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts an enterprise identity assertion client with no authorization URL", () => {
+    // There is no browser redirect in this profile: the client presents an
+    // identity assertion instead of walking the user through consent.
+    expect(
+      canSubmitOAuthClientForm({
+        ...validBase,
+        grant: "id_jag",
+        authorizationUrl: "",
+        resource: "https://mcp.example.com/mcp",
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts a public enterprise identity assertion client with no secret", () => {
+    // The ID-JAG itself is the proof of authorization at the Resource
+    // Authorization Server (draft §4.4), so a secret is not mandatory.
+    expect(
+      canSubmitOAuthClientForm({
+        ...validBase,
+        grant: "id_jag",
+        clientSecret: "",
+        authorizationUrl: "",
+        resource: "https://mcp.example.com/mcp",
+      }),
+    ).toBe(true);
+  });
+
+  it("still requires a token URL for enterprise identity assertion clients", () => {
+    expect(
+      canSubmitOAuthClientForm({
+        ...validBase,
+        grant: "id_jag",
+        authorizationUrl: "",
+        tokenUrl: "",
+        resource: "https://mcp.example.com/mcp",
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("oauthAppSetupFor", () => {

--- a/packages/react/src/components/oauth-client-form.tsx
+++ b/packages/react/src/components/oauth-client-form.tsx
@@ -99,13 +99,25 @@ export const canSubmitOAuthClientForm = (input: {
   readonly clientSecret: string;
   readonly authorizationUrl: string;
   readonly tokenUrl: string;
+  /** RFC 9728 resource identifier of the protected resource. Required for the
+   *  `id_jag` grant — it is what enterprise-managed discovery starts from — and
+   *  ignored for the other two, where it is a discovery by-product. */
+  readonly resource?: string | null;
 }): boolean =>
   !input.submitting &&
   input.name.trim().length > 0 &&
   input.clientId.trim().length > 0 &&
-  (input.grant === "authorization_code" || input.clientSecret.trim().length > 0) &&
+  // Only client credentials has no other way to authenticate. The
+  // authorization-code grant may be a public PKCE client, and an `id_jag`
+  // client may be public at its Resource Authorization Server too — the ID-JAG
+  // itself is the proof of authorization there (draft §4.4).
+  (input.grant !== "client_credentials" || input.clientSecret.trim().length > 0) &&
   input.tokenUrl.trim().length > 0 &&
-  (input.grant === "client_credentials" || input.authorizationUrl.trim().length > 0);
+  // No browser redirect exists for client credentials, and an enterprise-
+  // managed client never runs one: it presents an assertion instead of walking
+  // the user through consent.
+  (input.grant !== "authorization_code" || input.authorizationUrl.trim().length > 0) &&
+  (input.grant !== "id_jag" || (input.resource ?? "").trim().length > 0);
 
 export function OAuthClientForm(props: {
   /** Human label for the integration this app backs (used in toasts + default name). */
@@ -217,6 +229,10 @@ export function OAuthClientForm(props: {
   // client id/secret + owner.
   const endpointsKnown = (prefill?.tokenUrl ?? "").length > 0;
   const [showEndpoints, setShowEndpoints] = useState(!endpointsKnown);
+  // The enterprise-managed grant needs a resource identifier that no prefill
+  // carries (discovery starts from it), so its endpoint panel never collapses —
+  // a required field must not hide behind an "Edit".
+  const endpointsCollapsible = endpointsKnown && grant !== "id_jag";
 
   const doCreate = useAtomSet(createOAuthClientOptimistic, { mode: "promiseExit" });
   const doProbe = useAtomSet(probeOAuth, { mode: "promiseExit" });
@@ -232,6 +248,7 @@ export function OAuthClientForm(props: {
     clientSecret,
     authorizationUrl,
     tokenUrl,
+    resource,
   });
 
   // DCR is offered when the server advertises a registration endpoint AND we
@@ -454,6 +471,16 @@ export function OAuthClientForm(props: {
                 label: "Client credentials",
                 hint: "App-to-app, no user",
               },
+              {
+                // MCP Enterprise-Managed Authorization. The app registered here
+                // is the client's registration at the MCP server's Resource
+                // Authorization Server; the second registration (at the
+                // enterprise identity provider) is the organization's, and the
+                // server points at it separately.
+                value: "id_jag",
+                label: "Enterprise identity assertion",
+                hint: "Your identity provider authorizes, no per-server consent",
+              },
             ] as const
           ).map((option) => (
             <Label
@@ -524,18 +551,18 @@ export function OAuthClientForm(props: {
         <div className="space-y-1.5">
           <Label htmlFor="oauth-client-secret" className="text-xs text-muted-foreground">
             Client secret
-            {grant === "authorization_code" ? (
+            {grant === "client_credentials" ? null : (
               <span className="font-normal text-muted-foreground/70">
                 optional for public clients
               </span>
-            ) : null}
+            )}
           </Label>
           <Input
             id="oauth-client-secret"
             type="password"
             autoComplete="new-password"
             placeholder={
-              grant === "authorization_code" ? "optional client secret" : "required client secret"
+              grant === "client_credentials" ? "required client secret" : "optional client secret"
             }
             value={clientSecret}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => setClientSecret(e.target.value)}
@@ -546,7 +573,7 @@ export function OAuthClientForm(props: {
       </div>
 
       {/* endpoints */}
-      {endpointsKnown && !showEndpoints ? (
+      {endpointsCollapsible && !showEndpoints ? (
         <Button
           type="button"
           variant="outline"
@@ -613,7 +640,32 @@ export function OAuthClientForm(props: {
             />
           </div>
 
-          {endpointsKnown ? (
+          {/* Enterprise-managed only: the RFC 9728 resource identifier of the
+              MCP server. Enterprise-managed connect discovers the Resource
+              Authorization Server FROM this value, and the discovered issuer is
+              what the ID-JAG must name as its audience, so it is required here
+              and not merely a discovery by-product. */}
+          {grant === "id_jag" ? (
+            <div className="space-y-1.5">
+              <Label htmlFor="ema-resource-url" className="text-xs text-muted-foreground">
+                Resource URL
+                <span className="font-normal text-muted-foreground/70">
+                  the MCP server this app is registered at
+                </span>
+              </Label>
+              <Input
+                id="ema-resource-url"
+                placeholder="https://mcp.example.com/mcp"
+                value={resource ?? ""}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setResource(e.target.value === "" ? null : e.target.value)
+                }
+                className="font-mono"
+              />
+            </div>
+          ) : null}
+
+          {endpointsCollapsible ? (
             <Button
               type="button"
               variant="ghost"

--- a/packages/react/src/lib/auth-placements.tsx
+++ b/packages/react/src/lib/auth-placements.tsx
@@ -16,7 +16,10 @@
 // ---------------------------------------------------------------------------
 
 import { AuthTemplateSlug } from "@executor-js/sdk/shared";
-import type { AuthMethodDescriptor } from "@executor-js/sdk/shared";
+import type {
+  AuthMethodDescriptor,
+  EnterpriseIdentityProviderDescriptor,
+} from "@executor-js/sdk/shared";
 
 export type Carrier = "header" | "query" | "env";
 
@@ -74,6 +77,17 @@ export interface AuthMethodOAuth {
    *  `client_id` is this host's metadata document URL, with no provider-side app
    *  registration. */
   readonly supportsClientIdMetadataDocument?: boolean;
+  /** MCP Enterprise-Managed Authorization: which registered OAuth app stands for
+   *  the organization's identity provider for this server. Present only when the
+   *  server declares one.
+   *
+   *  A POINTER, and only a pointer — no assertion, no secret. Its presence means
+   *  "this server is enterprise-managed": the connect path may name the
+   *  organization's identity provider on `oauth.start` instead of walking the
+   *  member through per-server consent. It never removes the interactive route,
+   *  because the server still has to advertise the grant profile for the
+   *  enterprise branch to be taken at all. */
+  readonly enterpriseIdentityProvider?: EnterpriseIdentityProviderDescriptor;
 }
 
 export interface AuthMethod {
@@ -177,6 +191,12 @@ function authMethodFromDescriptor(descriptor: AuthMethodDescriptor): AuthMethod 
         discoveryUrl: oauth?.discoveryUrl,
         supportsDynamicRegistration: oauth?.supportsDynamicRegistration,
         supportsClientIdMetadataDocument: oauth?.supportsClientIdMetadataDocument,
+        // Carried, not re-derived: the deployment declared WHICH app stands for
+        // the organization's identity provider, and the connect path has to
+        // name that exact registration on `oauth.start`. Dropping it here would
+        // silently turn every enterprise-managed server back into an ordinary
+        // one in the console while the backend still expected the pointer.
+        enterpriseIdentityProvider: oauth?.enterpriseIdentityProvider,
       },
     };
   }

--- a/packages/react/src/lib/managed-connection.test.ts
+++ b/packages/react/src/lib/managed-connection.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  AuthTemplateSlug,
+  ConnectionAddress,
+  ConnectionName,
+  IntegrationSlug,
+  ProviderKey,
+  type Connection,
+  type HealthCheckResult,
+} from "@executor-js/sdk/shared";
+
+import { connectionRowPolicy } from "./managed-connection";
+
+const connection = (overrides: Partial<Connection> = {}): Connection => ({
+  owner: "org",
+  integration: IntegrationSlug.make("linear_mcp"),
+  name: ConnectionName.make("main"),
+  template: AuthTemplateSlug.make("oauth2"),
+  provider: ProviderKey.make("default"),
+  address: ConnectionAddress.make("linear_mcp.org.main"),
+  ...overrides,
+});
+
+const health = (overrides: Partial<HealthCheckResult> = {}): HealthCheckResult => ({
+  status: "healthy",
+  checkedAt: 0,
+  ...overrides,
+});
+
+describe("connectionRowPolicy", () => {
+  it("offers Remove and Reconnect on an ordinary connection", () => {
+    const policy = connectionRowPolicy(connection(), health());
+    expect(policy).toMatchObject({ managed: false, canRemove: true, canReconnect: true });
+  });
+
+  it("withholds Remove on an enterprise-managed connection", () => {
+    // There is nothing local to delete: renewal re-runs the ID-JAG chain from
+    // the stored assertion, so a row that vanished would claim a revocation
+    // that did not happen — the provider still authorizes the member.
+    expect(connectionRowPolicy(connection({ enterpriseManaged: true }), health()).canRemove).toBe(
+      false,
+    );
+  });
+
+  it("withholds Reconnect on an enterprise-managed connection", () => {
+    // Reconnect exists to re-consent through the browser. This profile has no
+    // consent step, and the console holds no identity assertion to present.
+    expect(
+      connectionRowPolicy(connection({ enterpriseManaged: true }), health()).canReconnect,
+    ).toBe(false);
+  });
+
+  it("withholds Reconnect from an ORDINARY connection an administrator blocked", () => {
+    // The interactive flow is exactly the route the identity provider just
+    // closed; offering it would route the user around the decision.
+    const policy = connectionRowPolicy(
+      connection(),
+      health({ status: "expired", blockedByAdmin: true }),
+    );
+    expect(policy.canReconnect).toBe(false);
+    // Removing an ordinary connection is still the member's own call.
+    expect(policy.canRemove).toBe(true);
+  });
+
+  it("reads the administrator verdict from the field, never the status word", () => {
+    expect(connectionRowPolicy(connection(), health({ status: "expired" })).blockedByAdmin).toBe(
+      false,
+    );
+  });
+
+  it("surfaces the provider's code only while the block stands", () => {
+    expect(
+      connectionRowPolicy(
+        connection(),
+        health({ blockedByAdmin: true, oauthErrorCode: "invalid_target" }),
+      ).oauthErrorCode,
+    ).toBe("invalid_target");
+    // A code left over from some other refusal is not an administrator
+    // decision, and must not be presented as one.
+    expect(
+      connectionRowPolicy(connection(), health({ oauthErrorCode: "invalid_grant" })).oauthErrorCode,
+    ).toBeNull();
+  });
+
+  it("treats a never-checked connection as unblocked", () => {
+    expect(connectionRowPolicy(connection({ enterpriseManaged: true }), null)).toMatchObject({
+      managed: true,
+      blockedByAdmin: false,
+      oauthErrorCode: null,
+    });
+  });
+
+  it("does not infer managed state from an absent field", () => {
+    // `enterpriseManaged` is projected server-side from the connection's
+    // persisted state. An older row that carries nothing is ordinary, not
+    // ambiguous.
+    expect(connectionRowPolicy(connection(), undefined).managed).toBe(false);
+  });
+});

--- a/packages/react/src/lib/managed-connection.ts
+++ b/packages/react/src/lib/managed-connection.ts
@@ -1,0 +1,78 @@
+import type { Connection, HealthCheckResult } from "@executor-js/sdk/shared";
+
+// ---------------------------------------------------------------------------
+// Enterprise-managed connections — what a row may offer.
+//
+// An enterprise-managed connection mirrors organization policy. It holds no
+// durable grant of its own: renewal re-runs the ID-JAG chain from the identity
+// assertion, and the enterprise identity provider decides every time. Two
+// consequences drive everything below.
+//
+//   1. There is nothing local to delete. A "Remove" that dropped the row would
+//      claim the user had revoked access when they had not — the identity
+//      provider still authorizes them, and the next connect would hand it
+//      straight back. Revocation lives at the provider.
+//
+//   2. There is no interactive route to re-run. Reconnect exists to re-consent
+//      through the browser, and this profile has no consent step; the console
+//      also holds no identity assertion to present. Offering it would produce
+//      a failure the user cannot act on.
+//
+// Connect stays available for ADDITIONAL personal accounts on the same
+// integration: enterprise-managed authorization binds exactly one enterprise
+// identity, and it does not claim the integration.
+// ---------------------------------------------------------------------------
+
+/** Grayscale, a word, no hue — see design.md, "Status and semantics". */
+export const MANAGED_CONNECTION_BADGE = "Managed by your organization";
+
+/** Why the row offers no Remove. Shown as helper text, sentence case. */
+export const MANAGED_CONNECTION_REVOCATION_HINT =
+  "This connection follows your organization's policy. Revoke access at your identity provider, not here.";
+
+/** What an enterprise-managed row shows when the identity provider has since
+ *  declined to renew it. The status word for this state — NOT "Expired",
+ *  which would invite a reconnect that cannot succeed. */
+export const MANAGED_CONNECTION_BLOCKED_LABEL = "Blocked by your organization";
+
+export interface ConnectionRowPolicy {
+  /** The connection was minted through enterprise-managed authorization. */
+  readonly managed: boolean;
+  /** An administrator decision is the CURRENT state of this connection: the
+   *  last credential resolution was refused by the identity provider. */
+  readonly blockedByAdmin: boolean;
+  /** The provider's RFC 6749 §5.2 code, for support traceability. */
+  readonly oauthErrorCode: string | null;
+  /** Whether the row may offer to delete this connection. */
+  readonly canRemove: boolean;
+  /** Whether the row may offer to re-run an interactive OAuth flow. */
+  readonly canReconnect: boolean;
+}
+
+/**
+ * What one connection row may offer, from the connection and its freshest
+ * health verdict.
+ *
+ * Both inputs are read STRUCTURALLY: `enterpriseManaged` is projected from the
+ * connection's persisted provider state, and `blockedByAdmin` is a typed field
+ * on the health result. Neither is inferred from a message, a status word, or
+ * the grant of the OAuth app behind the connection — an `id_jag` app still
+ * falls back to the interactive flow against a server that does not advertise
+ * the profile, and such a connection is ordinary in every way.
+ */
+export const connectionRowPolicy = (
+  connection: Connection,
+  health: HealthCheckResult | null | undefined,
+): ConnectionRowPolicy => {
+  const managed = connection.enterpriseManaged === true;
+  const blockedByAdmin = health?.blockedByAdmin === true;
+  return {
+    managed,
+    blockedByAdmin,
+    oauthErrorCode: blockedByAdmin ? (health?.oauthErrorCode ?? null) : null,
+    canRemove: !managed,
+    // A blocked connection is never reconnectable either, managed or not: the
+    // interactive flow is exactly the route the enterprise just closed.
+    canReconnect: !managed && !blockedByAdmin,
+  };
+};

--- a/packages/react/src/pages/org.tsx
+++ b/packages/react/src/pages/org.tsx
@@ -135,6 +135,11 @@ function formatLastActive(lastActiveAt: string | null): string {
 
 export function OrgPage(props: {
   domainsSection?: React.ReactNode;
+  // Cloud injects the enterprise identity provider registration here (MCP
+  // Enterprise-Managed Authorization). Self-host has no organization-admin
+  // model to gate it behind, so it omits the slot entirely rather than
+  // rendering an ungated enterprise control.
+  enterpriseIdpSection?: React.ReactNode;
   // Cloud injects the plan-upgrade call to action (a link to billing/plans).
   // When set and the org is at its seat limit, clicking "Invite member" opens
   // an upgrade prompt instead of the invite form. Self-host has no seat limit,
@@ -253,6 +258,7 @@ export function OrgPage(props: {
         </div>
       </section>
       {props.domainsSection && props.domainsSection}
+      {props.enterpriseIdpSection}
 
       <section className="mb-10">
         <div className="flex items-center justify-between mb-4">

--- a/packages/react/src/plugins/oauth-admin-block.test.ts
+++ b/packages/react/src/plugins/oauth-admin-block.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Exit from "effect/Exit";
+import { OAuthStartError } from "@executor-js/sdk/shared";
+
+import { adminBlockFrom, adminBlockFromExit, adminBlockReference } from "./oauth-admin-block";
+
+// The claim these tests defend is a product claim, not a parsing one: a console
+// may only withdraw the interactive route when the identity provider actually
+// refused under policy. Reading it wrong in one direction strands a user with a
+// recoverable error and no retry; in the other, it walks them around the exact
+// control the enterprise just exercised.
+
+const denial = new OAuthStartError({
+  message: "Your organization does not permit this server.",
+  blockedByAdmin: true,
+  oauthErrorCode: "invalid_target",
+});
+
+describe("adminBlockFrom", () => {
+  it("reads the verdict off the typed field", () => {
+    expect(adminBlockFrom(denial)).toEqual({
+      message: "Your organization does not permit this server.",
+      oauthErrorCode: "invalid_target",
+    });
+  });
+
+  it("carries a null reference when the provider returned no code", () => {
+    expect(
+      adminBlockFrom(new OAuthStartError({ message: "Refused.", blockedByAdmin: true }))
+        ?.oauthErrorCode,
+    ).toBeNull();
+  });
+
+  it("leaves an ordinary start failure alone", () => {
+    // No verdict means the interactive route stays open — an expired app, a
+    // bad endpoint, a network fault are all things a retry can fix.
+    expect(
+      adminBlockFrom(new OAuthStartError({ message: "Failed to reach the token endpoint." })),
+    ).toBeNull();
+  });
+
+  it("does not treat an explicitly-false verdict as a denial", () => {
+    expect(
+      adminBlockFrom(new OAuthStartError({ message: "Refused.", blockedByAdmin: false })),
+    ).toBeNull();
+  });
+
+  it("never infers a denial from the wording of a message", () => {
+    // The whole reason the field exists. A message that says the words is
+    // still not a verdict, and a console that matched on text would start
+    // withdrawing the retry for failures the user could have recovered from.
+    expect(
+      adminBlockFrom(
+        new OAuthStartError({ message: "blocked by admin: your organization declined" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("finds the verdict through the popup flow's one level of wrapping", () => {
+    // `openAuthorization` rejects with its own error carrying the server's
+    // failure as `cause`; the verdict has to survive that hop or the modal
+    // sees only a sentence.
+    expect(adminBlockFrom({ message: "Failed to start sign-in", cause: denial })).toEqual({
+      message: "Your organization does not permit this server.",
+      oauthErrorCode: "invalid_target",
+    });
+  });
+
+  it("does not go hunting down a cause chain", () => {
+    // One level is the contract. A chain is not a search space: something
+    // deeper is not this connect's verdict.
+    expect(adminBlockFrom({ cause: { cause: denial } })).toBeNull();
+  });
+
+  it("reads nothing out of values that are not start failures", () => {
+    expect(adminBlockFrom(null)).toBeNull();
+    expect(adminBlockFrom("blocked")).toBeNull();
+    expect(adminBlockFrom({ blockedByAdmin: true })).toBeNull();
+  });
+});
+
+describe("adminBlockFromExit", () => {
+  it("reads the verdict out of a failed exit", () => {
+    expect(adminBlockFromExit(Exit.fail(denial))?.oauthErrorCode).toBe("invalid_target");
+  });
+
+  it("has no verdict for a successful exit", () => {
+    expect(adminBlockFromExit(Exit.succeed({ status: "connected" }))).toBeNull();
+  });
+});
+
+describe("adminBlockReference", () => {
+  it("quotes the provider's own code so a member can trace it", () => {
+    expect(adminBlockReference({ message: "…", oauthErrorCode: "invalid_target" })).toBe(
+      "Reference: invalid_target",
+    );
+  });
+
+  it("shows no reference line when there is no code to show", () => {
+    expect(adminBlockReference({ message: "…", oauthErrorCode: null })).toBeNull();
+  });
+});

--- a/packages/react/src/plugins/oauth-admin-block.ts
+++ b/packages/react/src/plugins/oauth-admin-block.ts
@@ -1,0 +1,75 @@
+import * as Exit from "effect/Exit";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import { OAuthStartError } from "@executor-js/sdk/shared";
+
+// ---------------------------------------------------------------------------
+// Blocked by administrator — reading an enterprise policy denial as STRUCTURE.
+//
+// When an enterprise identity provider refuses to mint an ID-JAG, the failure
+// is an administrator's decision, not a credential problem. `OAuthStartError`
+// says so in a typed field (`blockedByAdmin`) precisely so a console never has
+// to read the sentence: matching on message text would silently start passing
+// or failing whenever the wording changed, and the consequence of getting it
+// wrong is offering the interactive per-server flow — which would route the
+// user straight around the control the enterprise just exercised.
+//
+// So: this module decodes the field, and NOTHING here inspects `message`
+// except to display it.
+// ---------------------------------------------------------------------------
+
+/** An enterprise identity provider declined this connect under administrator
+ *  policy. Terminal by construction: there is no retry and no alternative
+ *  route to offer, only the decision and a code support can trace. */
+export interface OAuthAdminBlock {
+  /** The failure's own message, shown verbatim. */
+  readonly message: string;
+  /** The identity provider's RFC 6749 §5.2 code (`unauthorized_client`,
+   *  `invalid_target`, …), when it returned one. Null otherwise. */
+  readonly oauthErrorCode: string | null;
+}
+
+const decodeStartError = Schema.decodeUnknownOption(OAuthStartError);
+
+/** One level of wrapping: the popup flow wraps a start failure in its own
+ *  tagged error before it reaches a renderer, and the verdict must survive
+ *  that hop. Exactly one level — a `cause` chain is not a search space. */
+const decodeWrapped = Schema.decodeUnknownOption(Schema.Struct({ cause: Schema.Unknown }));
+
+const directAdminBlock = (error: unknown): OAuthAdminBlock | null =>
+  Option.match(decodeStartError(error), {
+    onNone: () => null,
+    onSome: (start) =>
+      start.blockedByAdmin === true
+        ? { message: start.message, oauthErrorCode: start.oauthErrorCode ?? null }
+        : null,
+  });
+
+/** The administrator verdict carried by a failed `oauth.start`, or null when
+ *  the failure is anything else — including every other OAuth start failure,
+ *  which leaves the interactive route open. */
+export const adminBlockFrom = (error: unknown): OAuthAdminBlock | null =>
+  directAdminBlock(error) ??
+  Option.match(decodeWrapped(error), {
+    onNone: () => null,
+    onSome: (wrapper) => directAdminBlock(wrapper.cause),
+  });
+
+/** `adminBlockFrom` over an `Exit`, for the mutation call sites that hold one. */
+export const adminBlockFromExit = (exit: Exit.Exit<unknown, unknown>): OAuthAdminBlock | null =>
+  Option.match(Exit.findErrorOption(exit), {
+    onNone: () => null,
+    onSome: adminBlockFrom,
+  });
+
+/** What the user is told. Sentence case per the design system's voice rules:
+ *  what happened, then what to do next — and the next step is a person, not a
+ *  button, because no action in this console can change the verdict. */
+export const ADMIN_BLOCK_TITLE = "Blocked by your organization";
+export const ADMIN_BLOCK_NEXT_STEP =
+  "Ask an administrator to allow this server at your identity provider.";
+
+/** The support-traceable reference line, or null when the provider returned no
+ *  code. Mono metadata, per the design system. */
+export const adminBlockReference = (block: OAuthAdminBlock): string | null =>
+  block.oauthErrorCode === null ? null : `Reference: ${block.oauthErrorCode}`;

--- a/packages/react/src/plugins/oauth-sign-in.tsx
+++ b/packages/react/src/plugins/oauth-sign-in.tsx
@@ -16,6 +16,7 @@ import {
 } from "../api/oauth-popup";
 import { connectionWriteKeys } from "../api/reactivity-keys";
 import { getActiveOrgSlug } from "../api/server-connection";
+import { adminBlockFromExit, type OAuthAdminBlock } from "./oauth-admin-block";
 
 export type DesktopBridge = {
   readonly openExternal: (url: string) => Promise<void>;
@@ -193,6 +194,10 @@ export function useOAuthPopupFlow<
   const blockedMessage = popupBlockedMessage ?? POPUP_BLOCKED_MESSAGE;
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // The enterprise verdict, held apart from `error` on purpose: a renderer must
+  // be able to tell "this failed, try again" from "your organization decided
+  // this" WITHOUT reading either string.
+  const [adminBlock, setAdminBlock] = useState<OAuthAdminBlock | null>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
   const sessionRef = useRef<{ readonly state: string } | null>(null);
   // A window reserved on the click but not yet handed to a flow owns nothing
@@ -274,6 +279,7 @@ export function useOAuthPopupFlow<
       }
       setBusy(true);
       setError(null);
+      setAdminBlock(null);
       // Desktop hosts open the auth URL in the user's real browser, so they
       // reserve no in-page window and rely on the polling channel for the
       // result.
@@ -294,6 +300,12 @@ export function useOAuthPopupFlow<
       );
       if (Exit.isFailure(startExit)) {
         const message = messageFromExit(startExit, startErrorMessage ?? "Failed to start sign-in");
+        // Read the enterprise verdict off the failure BEFORE it is reduced to a
+        // string. Present means the identity provider refused under
+        // administrator policy, and this flow ends here: the popup closes and
+        // no retry is offered, because retrying is the route the enterprise
+        // just closed.
+        const blocked = adminBlockFromExit(startExit);
         reportHandledError(startExit.cause, {
           surface: "oauth",
           action: "start",
@@ -302,6 +314,7 @@ export function useOAuthPopupFlow<
         });
         reservedPopup?.popup.close();
         setBusy(false);
+        setAdminBlock(blocked);
         setError(message);
         input.onError?.(message);
         return;
@@ -455,29 +468,37 @@ export function useOAuthPopupFlow<
               newConnection: input.payload.newConnection,
               redirectUri: input.payload.redirectUri ?? oauthCallbackUrl(callbackPath),
             },
-          }).then((exit) =>
-            Exit.isSuccess(exit)
-              ? // The redirect branch carries `authorizationUrl` + `state`; the
-                // inline "connected" (client_credentials) branch has no URL to
-                // open and no redirect, so `state` is intentionally empty — it
-                // is never read for an already-minted connection.
-                exit.value.status === "redirect"
+          }).then((exit) => {
+            if (Exit.isSuccess(exit)) {
+              // The redirect branch carries `authorizationUrl` + `state`; the
+              // inline "connected" (client_credentials / enterprise-managed)
+              // branch has no URL to open and no redirect, so `state` is
+              // intentionally empty — it is never read for an already-minted
+              // connection.
+              return exit.value.status === "redirect"
                 ? { state: exit.value.state, authorizationUrl: exit.value.authorizationUrl }
-                : { state: "", authorizationUrl: null }
-              : Effect.runPromise(
-                  Effect.fail({
-                    message: messageFromExit(exit, startErrorMessage ?? "Failed to start sign-in"),
-                  }),
-                ),
-          ),
+                : { state: "", authorizationUrl: null };
+            }
+            // Reject with the server's OWN typed failure, cause and all — not
+            // with a message extracted from it. `openAuthorization` wraps this
+            // as the `cause` of its start error, and that is where the
+            // enterprise verdict (`blockedByAdmin`) is read from; flattening it
+            // to a string here would leave the console with only a sentence to
+            // branch on, which is exactly what it must not decide from.
+            return Effect.runPromise(Effect.failCause(exit.cause));
+          }),
       });
     },
-    [callbackPath, doStartOAuth, openAuthorization, startErrorMessage],
+    [callbackPath, doStartOAuth, openAuthorization],
   );
 
   return {
     busy,
     error,
+    /** The enterprise policy denial behind `error`, when there was one. A
+     *  renderer branches on this — never on `error`'s wording — and must not
+     *  offer a retry while it is set. */
+    adminBlock,
     setError,
     start,
     openAuthorization,


### PR DESCRIPTION
Org-admin Enterprise Identity Provider section (issuer probe, admin-gated), id_jag grant in the OAuth app form, per-server managed declaration in the MCP edit sheet, managed-connection badge with Remove/Reconnect withheld and revocation pointed at the IdP, and blocked-by-admin rendered from the structured verdict with no interactive fallback offered. Evidence: e2e scenario against the Okta and MCP emulators with screenshots and session video. The member connect click ships separately once the work-identity backend lands.