### PR TITLE
Add research page: how agents see MCP tools

### DIFF
--- a/apps/marketing/src/assets/logos/opencode.svg
+++ b/apps/marketing/src/assets/logos/opencode.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="#111" fill-rule="evenodd" clip-rule="evenodd" d="M16 6H8v12h8V6zm4 16H4V2h16v20z"/></svg>

--- a/apps/marketing/src/pages/research/mcp-tool-visibility.astro
+++ b/apps/marketing/src/pages/research/mcp-tool-visibility.astro
@@ -1,5 +1,9 @@
 ---
 import Layout from "../../layouts/Layout.astro";
+import claudeLogo from "../../assets/logos/claude.svg?url";
+import codexLogo from "../../assets/logos/codex.svg?url";
+import cursorLogo from "../../assets/logos/cursor.svg?url";
+import opencodeLogo from "../../assets/logos/opencode.svg?url";
 
 const GH = "https://github.com/UsefulSoftwareCo/executor";
 const title = "How agents actually see your MCP tools";
@@ -8,12 +12,12 @@ const description =
 
 // Δ prompt tokens for the 31 per-integration search tools, provider-reported.
 const costs = [
-  { name: "Claude Code", detail: "2.1.247 · inline", delta: 3464, plain: "36,013", search: "39,477" },
-  { name: "opencode (beta)", detail: "default · inline", delta: 3400, plain: "22,118", search: "25,518" },
-  { name: "opencode", detail: "1.18.15 · inline", delta: 3399, plain: "17,458", search: "20,857" },
-  { name: "opencode (beta)", detail: "code mode · TS signatures", delta: 1280, plain: "16,126", search: "17,406" },
-  { name: "Cursor CLI", detail: "2026.07.23 · names only", delta: 170, plain: "16,140", search: "16,310" },
-  { name: "Codex CLI", detail: "0.147.0 · code mode", delta: 0, plain: "15,776", search: "15,776" },
+  { name: "Claude Code", icon: claudeLogo, detail: "2.1.247 · inline", delta: 3464, plain: "36,013", search: "39,477" },
+  { name: "opencode (beta)", icon: opencodeLogo, detail: "default · inline", delta: 3400, plain: "22,118", search: "25,518" },
+  { name: "opencode", icon: opencodeLogo, detail: "1.18.15 · inline", delta: 3399, plain: "17,458", search: "20,857" },
+  { name: "opencode (beta)", icon: opencodeLogo, detail: "code mode · TS signatures", delta: 1280, plain: "16,126", search: "17,406" },
+  { name: "Cursor CLI", icon: cursorLogo, detail: "2026.07.23 · names only", delta: 170, plain: "16,140", search: "16,310" },
+  { name: "Codex CLI", icon: codexLogo, detail: "0.147.0 · code mode", delta: 0, plain: "15,776", search: "15,776" },
 ];
 const max = Math.max(...costs.map((c) => c.delta));
 ---
@@ -85,9 +89,15 @@ const max = Math.max(...costs.map((c) => c.delta));
             {/* Inliners */}
             <div class="persp surface-card">
               <div class="persp-head">
-                <div>
-                  <span class="persp-name">Claude Code · opencode</span>
-                  <span class="persp-family">family: inline — every definition, every turn</span>
+                <div class="persp-id">
+                  <span class="persp-icons">
+                    <img src={claudeLogo} alt="Claude" width="20" height="20" />
+                    <img src={opencodeLogo} alt="opencode" width="20" height="20" />
+                  </span>
+                  <div>
+                    <span class="persp-name">Claude Code · opencode</span>
+                    <span class="persp-family">family: inline — every definition, every turn</span>
+                  </div>
                 </div>
                 <span class="persp-cost">+3,399–3,464 tokens</span>
               </div>
@@ -130,9 +140,14 @@ const max = Math.max(...costs.map((c) => c.delta));
             {/* opencode code mode */}
             <div class="persp surface-card">
               <div class="persp-head">
-                <div>
-                  <span class="persp-name">opencode · code mode</span>
-                  <span class="persp-family">family: code mode, transparent — tools become typed signatures</span>
+                <div class="persp-id">
+                  <span class="persp-icons">
+                    <img src={opencodeLogo} alt="opencode" width="20" height="20" />
+                  </span>
+                  <div>
+                    <span class="persp-name">opencode · code mode</span>
+                    <span class="persp-family">family: code mode, transparent — tools become typed signatures</span>
+                  </div>
                 </div>
                 <span class="persp-cost">+1,280 tokens</span>
               </div>
@@ -172,9 +187,14 @@ const max = Math.max(...costs.map((c) => c.delta));
             {/* Cursor */}
             <div class="persp surface-card">
               <div class="persp-head">
-                <div>
-                  <span class="persp-name">Cursor CLI</span>
-                  <span class="persp-family">family: virtualized — a names-only catalog</span>
+                <div class="persp-id">
+                  <span class="persp-icons">
+                    <img src={cursorLogo} alt="Cursor" width="20" height="20" />
+                  </span>
+                  <div>
+                    <span class="persp-name">Cursor CLI</span>
+                    <span class="persp-family">family: virtualized — a names-only catalog</span>
+                  </div>
                 </div>
                 <span class="persp-cost">+170 tokens</span>
               </div>
@@ -219,9 +239,14 @@ const max = Math.max(...costs.map((c) => c.delta));
             {/* Codex */}
             <div class="persp surface-card">
               <div class="persp-head">
-                <div>
-                  <span class="persp-name">Codex CLI</span>
-                  <span class="persp-family">family: code mode, opaque — nothing reaches the prompt</span>
+                <div class="persp-id">
+                  <span class="persp-icons">
+                    <img src={codexLogo} alt="Codex" width="20" height="20" />
+                  </span>
+                  <div>
+                    <span class="persp-name">Codex CLI</span>
+                    <span class="persp-family">family: code mode, opaque — nothing reaches the prompt</span>
+                  </div>
                 </div>
                 <span class="persp-cost">+0 tokens</span>
               </div>
@@ -277,8 +302,11 @@ const max = Math.max(...costs.map((c) => c.delta));
               costs.map((c) => (
                 <div class="cost-row">
                   <div class="cost-name">
-                    {c.name}
-                    <span class="cost-detail">{c.detail}</span>
+                    <img src={c.icon} alt="" width="16" height="16" class="cost-icon" />
+                    <span>
+                      {c.name}
+                      <span class="cost-detail">{c.detail}</span>
+                    </span>
                   </div>
                   <div class="cost-track" title={`plain ${c.plain} → search ${c.search}`}>
                     <div
@@ -423,6 +451,23 @@ const max = Math.max(...costs.map((c) => c.delta));
     color: var(--color-ink);
     white-space: nowrap;
   }
+  .persp-id {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-width: 0;
+  }
+  .persp-icons {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+  .persp-icons img {
+    display: block;
+    height: 20px;
+    width: 20px;
+  }
   .persp-body {
     display: grid;
     grid-template-columns: 340px 1fr;
@@ -559,9 +604,18 @@ const max = Math.max(...costs.map((c) => c.delta));
     }
   }
   .cost-name {
+    display: flex;
+    align-items: center;
+    gap: 10px;
     font-size: 14px;
     font-weight: 500;
     color: var(--color-ink);
+  }
+  .cost-icon {
+    display: block;
+    height: 16px;
+    width: 16px;
+    flex-shrink: 0;
   }
   .cost-detail {
     display: block;

--- a/apps/marketing/src/pages/research/mcp-tool-visibility.astro
+++ b/apps/marketing/src/pages/research/mcp-tool-visibility.astro
@@ -77,6 +77,11 @@ const max = Math.max(...costs.map((c) => c.delta));
         <div class="mx-auto max-w-[1100px]">
           <span class="eyebrow">The model's context window, per harness</span>
           <h2 class="section-title mt-4 max-w-[26ch]">Same server, four context windows</h2>
+          <p class="section-sub mt-4 max-w-[66ch]">
+            Everything below is verbatim from the captured request each harness sent to its model.
+            For these runs the server also returned an MCP <code class="mono-inline">instructions</code>
+            field carrying a tracer string, to pin down where server instructions surface.
+          </p>
 
           <div class="viewer surface-card mt-10">
             <div class="viewer-tabs" role="tablist" aria-label="Harness">
@@ -109,94 +114,156 @@ const max = Math.max(...costs.map((c) => c.delta));
 
             {/* Claude Code */}
             <div class="pane" data-pane="claude">
-              <div class="blk blk-quiet"><span class="blk-tag">system prompt</span></div>
-              <div class="blk blk-quiet"><span class="blk-tag">built-in tools</span> 12 — Bash, Read, Edit, …</div>
+              <div class="blk blk-quiet">
+                <span class="blk-tag">system · 27,294 chars</span>
+                <pre>{`You are a Claude agent, built on Anthropic's Claude Agent SDK.
+
+You are an interactive agent that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
+⋮ (no MCP content anywhere in the system prompt)`}</pre>
+              </div>
               <div class="blk blk-loud">
-                <span class="blk-tag">your MCP tools · 38 of 38 in context</span>
+                <span class="blk-tag">tools · 50 entries — 12 built-in + 38 from your server, verbatim</span>
                 <pre>{`{
   "name": "mcp__executor__search_mcp_linear_app",
-  "description": "Search this integration's tools; empty query lists all.
-    Run results with execute.",
-  "input_schema": { "type": "object",
-    "properties": { "query": { "type": "string" } } }
-}`}</pre>
-                <span class="blk-note">full name + description + schema, × 38, resent every turn</span>
+  "description": "Search this integration's tools; empty query lists all. Run results with execute.",
+  "input_schema": {
+    "type": "object",
+    "properties": { "query": { "type": "string" } },
+    "$schema": "http://json-schema.org/draft-07/schema#"
+  }
+}
+⋮ × 38, resent every turn`}</pre>
               </div>
-              <div class="blk blk-quiet"><span class="blk-tag">conversation</span></div>
+              <div class="blk blk-loud">
+                <span class="blk-tag">messages[0] · your server's instructions, injected into the first user turn</span>
+                <pre>{`<system-reminder>
+# MCP Server Instructions
+
+The following MCP servers have provided instructions for how to use their tools and resources:
+
+## executor
+Executor exposes every connected integration through search and execute. INSTRUCTIONS-MARKER-9F3 Prefer the search tools for discovery.
+</system-reminder>`}</pre>
+              </div>
+              <div class="elems">
+                <span>server instructions → <b>first message</b></span>
+                <span>tool descriptions → <b>tools array</b></span>
+                <span>tool arguments → <b>tools array, full JSON Schema</b></span>
+              </div>
               <div class="pane-measure">prompt 36,013 → 39,477 tokens · Δ +3,464</div>
             </div>
 
             {/* opencode, code mode off */}
             <div class="pane" data-pane="opencode-off" hidden>
-              <div class="blk blk-quiet"><span class="blk-tag">system prompt</span></div>
-              <div class="blk blk-quiet"><span class="blk-tag">built-in tools</span> 13</div>
+              <div class="blk blk-quiet">
+                <span class="blk-tag">system · 30,060 chars — your server's instructions embedded at char 8,577</span>
+                <pre>{`You are OpenCode, the best coding agent on the planet.
+⋮
+<mcp_instructions>
+  <server name="executor">
+    Executor exposes every connected integration through search and execute. INSTRUCTIONS-MARKER-9F3 Prefer the search tools for discovery.
+  </server>
+</mcp_instructions>
+⋮`}</pre>
+              </div>
               <div class="blk blk-loud">
-                <span class="blk-tag">your MCP tools · 38 of 38 in context</span>
+                <span class="blk-tag">tools · 51 entries — 13 built-in + 38 from your server, verbatim</span>
                 <pre>{`{
   "name": "executor_search_mcp_linear_app",
-  "description": "Search this integration's tools; empty query lists all.
-    Run results with execute.",
-  "inputSchema": { "type": "object",
-    "properties": { "query": { "type": "string" } } }
-}`}</pre>
-                <span class="blk-note">full name + description + schema, × 38, resent every turn</span>
+  "description": "Search this integration's tools; empty query lists all. Run results with execute.",
+  "input_schema": {
+    "type": "object",
+    "properties": { "query": { "type": "string" } },
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false
+  },
+  "eager_input_streaming": true
+}
+⋮ × 38, resent every turn`}</pre>
               </div>
-              <div class="blk blk-quiet"><span class="blk-tag">conversation</span></div>
+              <div class="elems">
+                <span>server instructions → <b>system prompt</b></span>
+                <span>tool descriptions → <b>tools array</b></span>
+                <span>tool arguments → <b>tools array, full JSON Schema</b></span>
+              </div>
               <div class="pane-measure">prompt 17,458 → 20,857 tokens · Δ +3,399</div>
             </div>
 
             {/* opencode, code mode on */}
             <div class="pane" data-pane="opencode-on" hidden>
-              <div class="blk blk-quiet"><span class="blk-tag">system prompt</span></div>
-              <div class="blk blk-quiet"><span class="blk-tag">built-in tools</span> 13</div>
-              <div class="blk blk-loud">
-                <span class="blk-tag">one execute tool — your 38 MCP tools inside its description</span>
-                <pre>{`- tools.executor.search_mcp_linear_app(input: {
-    query?: string,
-  }): Promise<unknown> // Search this integration's tools;
-    empty query lists all. Run results with execute.`}</pre>
-                <span class="blk-note">TypeScript signatures — 2.7× denser than JSON definitions</span>
+              <div class="blk blk-quiet">
+                <span class="blk-tag">system · 30,034 chars — same <code class="mono-inline">&lt;mcp_instructions&gt;</code> block as code mode off</span>
               </div>
-              <div class="blk blk-quiet"><span class="blk-tag">conversation</span></div>
+              <div class="blk blk-loud">
+                <span class="blk-tag">tools · 14 entries — your 38 MCP tools live inside execute's 10,182-char description</span>
+                <pre>{`"name": "execute",
+"description": "Run a confined orchestration script with access to connected MCP tools.
+This is a restricted JavaScript language for calling tools, not a general-purpose runtime.
+⋮
+  - tools.executor.search_mcp_linear_app(input: {
+    query?: string,
+  }): Promise<unknown> // Search this integration's tools; empty query lists all. Run results with execute.
+⋮ × 38 signatures`}</pre>
+              </div>
+              <div class="elems">
+                <span>server instructions → <b>system prompt</b></span>
+                <span>tool descriptions → <b>comments in execute's description</b></span>
+                <span>tool arguments → <b>TypeScript types in execute's description</b></span>
+              </div>
               <div class="pane-measure">prompt 16,126 → 17,406 tokens · Δ +1,280</div>
             </div>
 
             {/* Cursor */}
             <div class="pane" data-pane="cursor" hidden>
-              <div class="blk blk-quiet"><span class="blk-tag">system prompt</span></div>
               <div class="blk blk-quiet">
-                <span class="blk-tag">built-in tools</span> 19 — incl. <code class="mono-inline">GetDynamicTools</code> / <code class="mono-inline">CallDynamicTool</code>
+                <span class="blk-tag">prompt — not directly observable; composed by Cursor's backend</span>
+                What follows is the model's own account of its context, corroborated by the MCP
+                wire capture and Cursor's per-request usage meter.
               </div>
               <div class="blk blk-loud">
-                <span class="blk-tag">your MCP tools · names only</span>
-                <pre>{`executor: execute · skills · resume ·
+                <span class="blk-tag">namespace catalog · the model's quoted view of your server</span>
+                <pre>{`name="executor"  source="mcp"
+namespaceUseInstructions:
+  "Executor exposes every connected integration through search and execute. INSTRUCTIONS-MARKER-9F3 Prefer the search tools for discovery."
+tools: execute · skills · resume ·
   search_axiom_mcp · search_github_rest · search_google_gmail ·
-  search_mcp_linear_app · …`}</pre>
-                <span class="blk-note">≈5.5 tokens per tool</span>
+  search_mcp_linear_app · … (names only, ≈5.5 tokens each)`}</pre>
               </div>
               <div class="blk blk-dashed">
-                descriptions &amp; schemas — sent only when the model calls
-                <code class="mono-inline">GetDynamicTools</code>
+                descriptions &amp; schemas — fetched by the model via
+                <code class="mono-inline">GetDynamicTools</code>; the wire shows Cursor downloads
+                them all at session start but withholds them from the prompt
               </div>
-              <div class="blk blk-quiet"><span class="blk-tag">conversation</span></div>
+              <div class="elems">
+                <span>server instructions → <b>namespace catalog</b></span>
+                <span>tool descriptions → <b>on demand only</b></span>
+                <span>tool arguments → <b>on demand only</b></span>
+              </div>
               <div class="pane-measure">prompt 16,140 → 16,310 tokens · Δ +170 (Cursor's usage meter)</div>
             </div>
 
             {/* Codex */}
             <div class="pane" data-pane="codex" hidden>
-              <div class="blk blk-quiet"><span class="blk-tag">system prompt</span></div>
               <div class="blk blk-quiet">
-                <span class="blk-tag">native tools</span> 9 — <code class="mono-inline">exec</code>, collaboration, …
+                <span class="blk-tag">input · additional_tools + 6 messages — no system field, no tools array</span>
+                <pre>{`input[0]  type: "additional_tools"   9 native tools: exec, wait,
+          request_user_input, collaboration.* — 24,220 chars, none yours
+input[1…] type: "message"            developer + user turns
+⋮ your server appears in NONE of it — prompts byte-identical with 7 vs 38 tools`}</pre>
               </div>
               <div class="blk blk-never">
-                <span class="blk-tag"><s>your MCP tools</s></span>
-                <pre>{`"code_mode_tool_names": {
-  "search_mcp_linear_app": { "namespace": "mcp__executor" },
-  … 37 more
-}`}</pre>
-                <span class="blk-note">request metadata — never rendered into the prompt; callable only from code inside <code class="mono-inline">exec</code></span>
+                <span class="blk-tag"><s>your MCP tools · request metadata the model never reads</s></span>
+                <pre>{`"client_metadata": { "code_mode_tool_names": {
+  "search_google_gmail": { "name": "search_google_gmail", "namespace": "mcp__executor" },
+  ⋮ 37 more
+} }`}</pre>
+                <span class="blk-note">callable only as JS inside <code class="mono-inline">exec</code>; server instructions dropped too — the marker appears nowhere</span>
               </div>
-              <div class="blk blk-quiet"><span class="blk-tag">conversation</span></div>
+              <div class="elems">
+                <span>server instructions → <b>dropped</b></span>
+                <span>tool descriptions → <b>dropped</b></span>
+                <span>tool arguments → <b>dropped</b></span>
+              </div>
               <div class="pane-measure">prompt 15,776 → 15,776 tokens · Δ 0, byte-identical</div>
             </div>
           </div>
@@ -553,6 +620,22 @@ const max = Math.max(...costs.map((c) => c.delta));
     font-size: 12px;
     color: var(--color-ink-3);
     text-align: right;
+  }
+  .elems {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 24px;
+    padding: 12px 14px;
+    border: 1px solid var(--color-rule);
+    border-radius: 6px;
+    background: var(--color-surface-2);
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    color: var(--color-ink-3);
+  }
+  .elems b {
+    font-weight: 500;
+    color: var(--color-ink);
   }
 
   /* ── cost chart ── */

--- a/apps/marketing/src/pages/research/mcp-tool-visibility.astro
+++ b/apps/marketing/src/pages/research/mcp-tool-visibility.astro
@@ -88,19 +88,20 @@ const max = Math.max(...costs.map((c) => c.delta));
           <div class="mt-10 grid gap-6">
             {/* Inliners */}
             <div class="persp surface-card">
-              <div class="persp-head">
-                <div class="persp-id">
-                  <span class="persp-icons">
-                    <img src={claudeLogo} alt="Claude" width="20" height="20" />
-                    <img src={opencodeLogo} alt="opencode" width="20" height="20" />
-                  </span>
-                  <div>
-                    <span class="persp-name">Claude Code · opencode</span>
-                    <span class="persp-family">family: inline — every definition, every turn</span>
-                  </div>
-                </div>
+              <div class="persp-bar">
+                <span class="persp-dot"></span><span class="persp-dot"></span><span class="persp-dot"></span>
+                <span class="persp-icons">
+                  <img src={claudeLogo} alt="Claude" width="18" height="18" />
+                  <img src={opencodeLogo} alt="opencode" width="18" height="18" />
+                </span>
+                <span class="persp-name">Claude Code · opencode</span>
+                <span class="persp-ver">2.1.247 · 1.18.15</span>
                 <span class="persp-cost">+3,399–3,464 tokens</span>
               </div>
+              <p class="persp-lede">
+                Every definition is pasted into the prompt, every turn — name, description, and
+                schema for all 38 tools.
+              </p>
               <div class="persp-body">
                 <div class="ctx">
                   <div class="ctx-label">the model's context window</div>
@@ -139,18 +140,19 @@ const max = Math.max(...costs.map((c) => c.delta));
 
             {/* opencode code mode */}
             <div class="persp surface-card">
-              <div class="persp-head">
-                <div class="persp-id">
-                  <span class="persp-icons">
-                    <img src={opencodeLogo} alt="opencode" width="20" height="20" />
-                  </span>
-                  <div>
-                    <span class="persp-name">opencode · code mode</span>
-                    <span class="persp-family">family: code mode, transparent — tools become typed signatures</span>
-                  </div>
-                </div>
+              <div class="persp-bar">
+                <span class="persp-dot"></span><span class="persp-dot"></span><span class="persp-dot"></span>
+                <span class="persp-icons">
+                  <img src={opencodeLogo} alt="opencode" width="18" height="18" />
+                </span>
+                <span class="persp-name">opencode · code mode</span>
+                <span class="persp-ver">OPENCODE_EXPERIMENTAL_CODE_MODE</span>
                 <span class="persp-cost">+1,280 tokens</span>
               </div>
+              <p class="persp-lede">
+                Your tools collapse into one <code class="mono-inline">execute</code> tool and
+                reappear inside its description as typed signatures — still readable, 2.7× denser.
+              </p>
               <div class="persp-body">
                 <div class="ctx">
                   <div class="ctx-label">the model's context window</div>
@@ -186,18 +188,19 @@ const max = Math.max(...costs.map((c) => c.delta));
 
             {/* Cursor */}
             <div class="persp surface-card">
-              <div class="persp-head">
-                <div class="persp-id">
-                  <span class="persp-icons">
-                    <img src={cursorLogo} alt="Cursor" width="20" height="20" />
-                  </span>
-                  <div>
-                    <span class="persp-name">Cursor CLI</span>
-                    <span class="persp-family">family: virtualized — a names-only catalog</span>
-                  </div>
-                </div>
+              <div class="persp-bar">
+                <span class="persp-dot"></span><span class="persp-dot"></span><span class="persp-dot"></span>
+                <span class="persp-icons">
+                  <img src={cursorLogo} alt="Cursor" width="18" height="18" />
+                </span>
+                <span class="persp-name">Cursor CLI</span>
+                <span class="persp-ver">2026.07.23</span>
                 <span class="persp-cost">+170 tokens</span>
               </div>
+              <p class="persp-lede">
+                The model gets a names-only catalog. Descriptions and schemas exist on Cursor's
+                side, but the model has to ask for them.
+              </p>
               <div class="persp-body">
                 <div class="ctx">
                   <div class="ctx-label">the model's context window</div>
@@ -238,18 +241,19 @@ const max = Math.max(...costs.map((c) => c.delta));
 
             {/* Codex */}
             <div class="persp surface-card">
-              <div class="persp-head">
-                <div class="persp-id">
-                  <span class="persp-icons">
-                    <img src={codexLogo} alt="Codex" width="20" height="20" />
-                  </span>
-                  <div>
-                    <span class="persp-name">Codex CLI</span>
-                    <span class="persp-family">family: code mode, opaque — nothing reaches the prompt</span>
-                  </div>
-                </div>
+              <div class="persp-bar">
+                <span class="persp-dot"></span><span class="persp-dot"></span><span class="persp-dot"></span>
+                <span class="persp-icons">
+                  <img src={codexLogo} alt="Codex" width="18" height="18" />
+                </span>
+                <span class="persp-name">Codex CLI</span>
+                <span class="persp-ver">0.147.0</span>
                 <span class="persp-cost">+0 tokens</span>
               </div>
+              <p class="persp-lede">
+                Nothing about your tools reaches the prompt. They exist only as callables inside
+                Codex's code sandbox — the model discovers them by writing code.
+              </p>
               <div class="persp-body">
                 <div class="ctx">
                   <div class="ctx-label">the model's context window</div>
@@ -422,51 +426,75 @@ const max = Math.max(...costs.map((c) => c.delta));
     padding: 0;
     overflow: hidden;
   }
-  .persp-head {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 16px;
-    padding: 18px 24px;
-    border-bottom: 1px solid var(--color-rule);
-  }
-  .persp-name {
-    font-weight: 600;
-    font-size: 17px;
-    letter-spacing: -0.01em;
-    color: var(--color-ink);
-  }
-  .persp-family {
-    display: block;
-    margin-top: 3px;
-    font-family: var(--font-mono);
-    font-size: 11px;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--color-ink-3);
-  }
-  .persp-cost {
-    font-family: var(--font-mono);
-    font-size: 13px;
-    color: var(--color-ink);
-    white-space: nowrap;
-  }
-  .persp-id {
+  /* window titlebar — the card IS the harness's window */
+  .persp-bar {
     display: flex;
     align-items: center;
-    gap: 12px;
-    min-width: 0;
+    gap: 10px;
+    padding: 12px 18px;
+    border-bottom: 1px solid var(--color-rule);
+    background: var(--color-surface-2);
+  }
+  .persp-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 9999px;
+    background: var(--color-rule-strong);
+    flex-shrink: 0;
+  }
+  .persp-dot + .persp-dot {
+    margin-left: -3px;
   }
   .persp-icons {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 7px;
     flex-shrink: 0;
+    margin-left: 8px;
   }
   .persp-icons img {
     display: block;
-    height: 20px;
-    width: 20px;
+    height: 18px;
+    width: 18px;
+  }
+  .persp-name {
+    font-weight: 600;
+    font-size: 15px;
+    letter-spacing: -0.01em;
+    color: var(--color-ink);
+    white-space: nowrap;
+  }
+  .persp-ver {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-ink-3);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+  .persp-cost {
+    font-family: var(--font-mono);
+    font-size: 12.5px;
+    color: var(--color-ink);
+    white-space: nowrap;
+    margin-left: auto;
+  }
+  @media (max-width: 640px) {
+    .persp-ver {
+      display: none;
+    }
+  }
+  .persp-lede {
+    padding: 16px 24px 0;
+    font-size: 14.5px;
+    line-height: 1.6;
+    color: var(--color-ink-2);
+    max-width: 72ch;
+  }
+  /* one window chrome per card: inner excerpts keep a filename bar, no dots */
+  .persp-detail .code-dot {
+    display: none;
   }
   .persp-body {
     display: grid;

--- a/apps/marketing/src/pages/research/mcp-tool-visibility.astro
+++ b/apps/marketing/src/pages/research/mcp-tool-visibility.astro
@@ -1,0 +1,598 @@
+---
+import Layout from "../../layouts/Layout.astro";
+
+const GH = "https://github.com/UsefulSoftwareCo/executor";
+const title = "How agents actually see your MCP tools";
+const description =
+  "The same MCP server was connected to five coding agents and the model-bound traffic was measured. Each harness shows the model something different: full definitions, bare names, or nothing at all.";
+
+// Δ prompt tokens for the 31 per-integration search tools, provider-reported.
+const costs = [
+  { name: "Claude Code", detail: "2.1.247 · inline", delta: 3464, plain: "36,013", search: "39,477" },
+  { name: "opencode (beta)", detail: "default · inline", delta: 3400, plain: "22,118", search: "25,518" },
+  { name: "opencode", detail: "1.18.15 · inline", delta: 3399, plain: "17,458", search: "20,857" },
+  { name: "opencode (beta)", detail: "code mode · TS signatures", delta: 1280, plain: "16,126", search: "17,406" },
+  { name: "Cursor CLI", detail: "2026.07.23 · names only", delta: 170, plain: "16,140", search: "16,310" },
+  { name: "Codex CLI", detail: "0.147.0 · code mode", delta: 0, plain: "15,776", search: "15,776" },
+];
+const max = Math.max(...costs.map((c) => c.delta));
+---
+
+<Layout title={`${title} — Executor`} description={description}>
+  <main class="bg-soft relative min-h-dvh antialiased">
+    <div
+      class="pattern-bg pattern-graph"
+      style="position:absolute;top:0;left:0;right:0;height:60vh;z-index:1;pointer-events:none;"
+    >
+    </div>
+    <div
+      style="position:absolute;top:0;left:0;right:0;height:60vh;z-index:2;pointer-events:none;background:linear-gradient(180deg,transparent 0%,transparent 55%,var(--color-surface) 100%);"
+    >
+    </div>
+
+    <div class="relative z-10">
+      <nav>
+        <div class="mx-auto flex h-14 max-w-[1200px] items-center justify-between px-6 sm:px-10">
+          <a href="/" class="flex items-center gap-2.5">
+            <img src="/favicon-192.png" alt="" class="h-5 w-5" />
+            <span class="text-[15px] font-semibold tracking-[-0.01em] text-ink">executor</span>
+          </a>
+          <div class="flex items-center gap-5">
+            <a href="/blog" class="text-[14px] font-medium text-ink-2 transition-colors hover:text-ink">Blog</a>
+            <a
+              href="https://executor.sh/docs"
+              class="hidden text-[14px] font-medium text-ink-2 transition-colors hover:text-ink sm:inline">Docs</a
+            >
+            <a href={GH} class="text-[14px] font-medium text-ink-2 transition-colors hover:text-ink">GitHub</a>
+            <a href="/#install" class="btn-primary">Get started →</a>
+          </div>
+        </div>
+      </nav>
+
+      {/* ─── HEADER ─── */}
+      <section class="px-6 pt-16 pb-10 sm:px-10 sm:pt-24 sm:pb-14">
+        <div class="mx-auto max-w-[820px]">
+          <span class="eyebrow">Research · August 2026</span>
+          <h1
+            class="mt-5 text-[clamp(2.2rem,5vw,3.6rem)] font-semibold leading-[1.05] tracking-[-0.025em] text-ink text-balance"
+          >
+            {title}
+          </h1>
+          <p class="mt-5 max-w-[62ch] text-[17px] leading-[1.6] text-ink-2 text-pretty">
+            {description} We connected one Executor workspace — 31 integrations — to Claude Code,
+            Cursor's CLI, Codex, and two versions of opencode, twice each: once plain, once with
+            Executor's <code class="mono-inline">?search_tools=true</code> option, which adds one
+            minimal <code class="mono-inline">search_&lt;integration&gt;</code> tool per connected
+            integration. The difference between those two sessions is exactly what 31 extra tool
+            definitions cost, and where they end up.
+          </p>
+        </div>
+      </section>
+
+      {/* ─── THE THREE REALITIES ─── */}
+      <section class="border-t border-rule px-6 py-14 sm:px-10 sm:py-20">
+        <div class="mx-auto max-w-[1100px]">
+          <span class="eyebrow">What each harness shows the model</span>
+          <h2 class="section-title mt-4 max-w-[24ch]">Five harnesses, three different realities</h2>
+          <p class="section-sub mt-4 max-w-[62ch]">
+            "The model sees your tools" hides three different mechanisms. Every card below is one
+            harness's view of the same server, drawn from the captured request that actually went
+            to the model. Solid blocks are in the context window on every turn; dashed blocks are
+            fetched on demand; crossed-out blocks never reach the model at all.
+          </p>
+
+          <div class="mt-10 grid gap-6">
+            {/* Inliners */}
+            <div class="persp surface-card">
+              <div class="persp-head">
+                <div>
+                  <span class="persp-name">Claude Code · opencode</span>
+                  <span class="persp-family">family: inline — every definition, every turn</span>
+                </div>
+                <span class="persp-cost">+3,399–3,464 tokens</span>
+              </div>
+              <div class="persp-body">
+                <div class="ctx">
+                  <div class="ctx-label">the model's context window</div>
+                  <div class="ctx-block ctx-quiet">system prompt</div>
+                  <div class="ctx-block ctx-loud">
+                    <b>38 tool definitions — full JSON schema each</b>
+                    <span>name + description + parameters for every tool, inlined as API function tools</span>
+                  </div>
+                  <div class="ctx-block ctx-quiet">conversation</div>
+                </div>
+                <div class="persp-detail">
+                  <div class="code-window">
+                    <div class="code-titlebar">
+                      <span class="code-dot"></span><span class="code-dot"></span><span class="code-dot"></span>
+                      <span class="code-filename">tools[7] of 38 — as sent to the model</span>
+                    </div>
+                    <pre
+                      class="code-body">{`{
+  "name": "mcp__executor__search_mcp_linear_app",
+  "description": "Search this integration's tools;
+    empty query lists all. Run results with execute.",
+  "input_schema": {
+    "type": "object",
+    "properties": { "query": { "type": "string" } }
+  }
+}`}</pre>
+                  </div>
+                  <p class="persp-path">
+                    <span class="persp-path-label">To search Linear’s tools</span>
+                    one call — <code class="mono-inline">search_mcp_linear_app({"{ query }"})</code>,
+                    the definition is already in context.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* opencode code mode */}
+            <div class="persp surface-card">
+              <div class="persp-head">
+                <div>
+                  <span class="persp-name">opencode · code mode</span>
+                  <span class="persp-family">family: code mode, transparent — tools become typed signatures</span>
+                </div>
+                <span class="persp-cost">+1,280 tokens</span>
+              </div>
+              <div class="persp-body">
+                <div class="ctx">
+                  <div class="ctx-label">the model's context window</div>
+                  <div class="ctx-block ctx-quiet">system prompt</div>
+                  <div class="ctx-block ctx-quiet">13 built-in tools</div>
+                  <div class="ctx-block ctx-loud">
+                    <b>one <code class="mono-inline">execute</code> tool</b>
+                    <span>its description lists every MCP tool as a TypeScript signature — 2.7× denser than JSON definitions</span>
+                  </div>
+                  <div class="ctx-block ctx-quiet">conversation</div>
+                </div>
+                <div class="persp-detail">
+                  <div class="code-window">
+                    <div class="code-titlebar">
+                      <span class="code-dot"></span><span class="code-dot"></span><span class="code-dot"></span>
+                      <span class="code-filename">inside execute's description</span>
+                    </div>
+                    <pre
+                      class="code-body">{`- tools.executor.search_google_gmail(input: {
+    query?: string,
+  }): Promise<unknown> // Search this integration's
+    tools; empty query lists all. Run results
+    with execute.`}</pre>
+                  </div>
+                  <p class="persp-path">
+                    <span class="persp-path-label">To search Linear’s tools</span>
+                    one call through code —
+                    <code class="mono-inline">execute("await tools.executor.search_mcp_linear_app(…)")</code>.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Cursor */}
+            <div class="persp surface-card">
+              <div class="persp-head">
+                <div>
+                  <span class="persp-name">Cursor CLI</span>
+                  <span class="persp-family">family: virtualized — a names-only catalog</span>
+                </div>
+                <span class="persp-cost">+170 tokens</span>
+              </div>
+              <div class="persp-body">
+                <div class="ctx">
+                  <div class="ctx-label">the model's context window</div>
+                  <div class="ctx-block ctx-quiet">system prompt</div>
+                  <div class="ctx-block ctx-quiet">19 first-party tools, incl. <code class="mono-inline">GetDynamicTools</code> / <code class="mono-inline">CallDynamicTool</code></div>
+                  <div class="ctx-block ctx-loud">
+                    <b>catalog: bare tool names, grouped by server</b>
+                    <span>≈5.5 tokens per tool — the name is all the model gets</span>
+                  </div>
+                  <div class="ctx-block ctx-dashed">
+                    descriptions &amp; schemas — fetched on demand via <code class="mono-inline">GetDynamicTools</code>
+                  </div>
+                  <div class="ctx-block ctx-quiet">conversation</div>
+                </div>
+                <div class="persp-detail">
+                  <div class="code-window">
+                    <div class="code-titlebar">
+                      <span class="code-dot"></span><span class="code-dot"></span><span class="code-dot"></span>
+                      <span class="code-filename">the model's catalog view</span>
+                    </div>
+                    <pre
+                      class="code-body">{`executor: execute · skills · resume ·
+  search_axiom_mcp · search_github_rest ·
+  search_google_gmail · search_mcp_linear_app · …
+
+(full definition available via GetDynamicTools —
+ not fetched unless the model asks)`}</pre>
+                  </div>
+                  <p class="persp-path">
+                    <span class="persp-path-label">To search Linear’s tools</span>
+                    the name is visible; call it through
+                    <code class="mono-inline">CallDynamicTool("search_mcp_linear_app", …)</code>,
+                    optionally fetching the schema first.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Codex */}
+            <div class="persp surface-card">
+              <div class="persp-head">
+                <div>
+                  <span class="persp-name">Codex CLI</span>
+                  <span class="persp-family">family: code mode, opaque — nothing reaches the prompt</span>
+                </div>
+                <span class="persp-cost">+0 tokens</span>
+              </div>
+              <div class="persp-body">
+                <div class="ctx">
+                  <div class="ctx-label">the model's context window</div>
+                  <div class="ctx-block ctx-quiet">system prompt</div>
+                  <div class="ctx-block ctx-quiet">9 native tools — <code class="mono-inline">exec</code>, collaboration, …</div>
+                  <div class="ctx-block ctx-never">
+                    <b>your MCP tools</b>
+                    <span>carried only in request metadata the model never reads; prompts were byte-identical with 7 vs 38 tools</span>
+                  </div>
+                  <div class="ctx-block ctx-quiet">conversation</div>
+                </div>
+                <div class="persp-detail">
+                  <div class="code-window">
+                    <div class="code-titlebar">
+                      <span class="code-dot"></span><span class="code-dot"></span><span class="code-dot"></span>
+                      <span class="code-filename">request metadata — not model-visible</span>
+                    </div>
+                    <pre
+                      class="code-body">{`"code_mode_tool_names": {
+  "search_google_gmail":
+    { "namespace": "mcp__executor" },
+  … 37 more
+}`}</pre>
+                  </div>
+                  <p class="persp-path">
+                    <span class="persp-path-label">To search Linear’s tools</span>
+                    the model must call <code class="mono-inline">exec</code> and write code —
+                    <code class="mono-inline">await tools.mcp__executor__search_mcp_linear_app(…)</code> —
+                    discovering what exists only from inside the sandbox.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ─── COST ─── */}
+      <section class="border-t border-rule px-6 py-14 sm:px-10 sm:py-20">
+        <div class="mx-auto max-w-[1100px]">
+          <span class="eyebrow">Measured, not estimated</span>
+          <h2 class="section-title mt-4 max-w-[26ch]">What 31 tool definitions cost, by harness</h2>
+          <p class="section-sub mt-4 max-w-[62ch]">
+            Δ prompt tokens between the plain and <code class="mono-inline">?search_tools=true</code> sessions,
+            as reported by the provider's usage accounting (input + cache write + cache read). Same
+            workspace, same prompt; only the endpoint query differs.
+          </p>
+          <div class="mt-10 surface-card cost-card">
+            {
+              costs.map((c) => (
+                <div class="cost-row">
+                  <div class="cost-name">
+                    {c.name}
+                    <span class="cost-detail">{c.detail}</span>
+                  </div>
+                  <div class="cost-track" title={`plain ${c.plain} → search ${c.search}`}>
+                    <div
+                      class={`cost-bar${c.delta === 0 ? " cost-bar--zero" : ""}`}
+                      style={`width:${(c.delta / max) * 100}%`}
+                    />
+                  </div>
+                  <div class="cost-val">{c.delta === 0 ? "0" : `+${c.delta.toLocaleString()}`}</div>
+                </div>
+              ))
+            }
+          </div>
+          <p class="mt-4 text-[13px] leading-[1.6] text-ink-3">
+            Cursor's model traffic terminates at its backend, so its pair comes from Cursor's own
+            per-request usage meter rather than a captured prompt. JSON tool definitions tokenize at
+            roughly 2.4 characters per token — schema punctuation is token-dense.
+          </p>
+        </div>
+      </section>
+
+      {/* ─── TAKEAWAYS ─── */}
+      <section class="border-t border-rule px-6 py-14 sm:px-10 sm:py-20">
+        <div class="mx-auto max-w-[1100px]">
+          <span class="eyebrow">If you ship an MCP server</span>
+          <h2 class="section-title mt-4 max-w-[24ch]">Design for the weakest channel</h2>
+          <div class="cap-grid mt-10" style="grid-template-columns:repeat(auto-fit,minmax(240px,1fr));">
+            <div class="cap-card">
+              <span class="cap-num">01</span>
+              <h3>The name is the only universal channel</h3>
+              <p>
+                Every harness that shows tools at all shows the name. Descriptions reach only the
+                inliners; schemas effectively reach only the inliners. If information must arrive,
+                put it in the name.
+              </p>
+            </div>
+            <div class="cap-card">
+              <span class="cap-num">02</span>
+              <h3>Schema tricks don't travel</h3>
+              <p>
+                An enum of options inside a parameter looks clever and costs less — and is invisible
+                in Cursor and Codex, the two harnesses where you'd need it most.
+              </p>
+            </div>
+            <div class="cap-card">
+              <span class="cap-num">03</span>
+              <h3>Keep definitions small anyway</h3>
+              <p>
+                Where tools are inlined, every byte is paid on every turn, multiplied by tool count.
+                One shared description sentence and a single parameter cut this surface by more than half.
+              </p>
+            </div>
+            <div class="cap-card">
+              <span class="cap-num">04</span>
+              <h3>Measure with provider usage, not estimates</h3>
+              <p>
+                Client-side token meters and character counts both mislead. Run the same session
+                twice and diff what the provider bills — that number is the truth.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ─── BOTTOM CTA ─── */}
+      <section class="border-t border-rule py-16 sm:py-20">
+        <div class="mx-auto max-w-[720px] px-6 text-center sm:px-10">
+          <h2 class="section-title mx-auto mb-7 max-w-[20ch]">
+            Connect any agent to <span class="serif-italic">everything</span>.
+          </h2>
+          <div class="flex flex-wrap items-center justify-center gap-3">
+            <a href="/#install" class="btn-primary btn-primary--hero">Get started →</a>
+            <a href={GH} class="btn-secondary">Star on GitHub</a>
+          </div>
+        </div>
+      </section>
+
+      {/* ─── FOOTER ─── */}
+      <footer class="border-t border-rule py-10">
+        <div
+          class="mx-auto flex max-w-[1200px] flex-col items-start justify-between gap-6 px-6 sm:flex-row sm:items-center sm:px-10"
+        >
+          <div class="flex items-center gap-2.5">
+            <img src="/favicon-192.png" alt="" class="h-4 w-4 opacity-80" />
+            <span class="text-[13px] font-medium text-ink-2">executor</span>
+            <span class="ml-2 text-[12px] text-ink-3">© {new Date().getFullYear()}</span>
+          </div>
+          <div class="flex items-center gap-6 text-[13px] text-ink-2">
+            <a href="/blog" class="transition-colors hover:text-ink">Blog</a>
+            <a href="https://executor.sh/docs" class="transition-colors hover:text-ink">Docs</a>
+            <a href={GH} class="transition-colors hover:text-ink">GitHub</a>
+            <a href="/privacy" class="transition-colors hover:text-ink">Privacy</a>
+            <a href="/terms" class="transition-colors hover:text-ink">Terms</a>
+          </div>
+        </div>
+      </footer>
+    </div>
+  </main>
+</Layout>
+
+<style>
+  .mono-inline {
+    font-family: var(--font-mono);
+    font-size: 0.88em;
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-rule);
+    border-radius: 4px;
+    padding: 1px 5px;
+    white-space: nowrap;
+  }
+
+  /* ── perspective cards ── */
+  .persp {
+    padding: 0;
+    overflow: hidden;
+  }
+  .persp-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 18px 24px;
+    border-bottom: 1px solid var(--color-rule);
+  }
+  .persp-name {
+    font-weight: 600;
+    font-size: 17px;
+    letter-spacing: -0.01em;
+    color: var(--color-ink);
+  }
+  .persp-family {
+    display: block;
+    margin-top: 3px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-ink-3);
+  }
+  .persp-cost {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    color: var(--color-ink);
+    white-space: nowrap;
+  }
+  .persp-body {
+    display: grid;
+    grid-template-columns: 340px 1fr;
+    gap: 0;
+  }
+  @media (max-width: 820px) {
+    .persp-body {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* context-window schematic */
+  .ctx {
+    padding: 20px 24px;
+    border-right: 1px solid var(--color-rule);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  @media (max-width: 820px) {
+    .ctx {
+      border-right: 0;
+      border-bottom: 1px solid var(--color-rule);
+    }
+  }
+  .ctx-label {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-ink-3);
+    margin-bottom: 4px;
+  }
+  .ctx-block {
+    border-radius: 6px;
+    padding: 9px 12px;
+    font-size: 12.5px;
+    line-height: 1.45;
+  }
+  .ctx-quiet {
+    border: 1px solid var(--color-rule);
+    background: var(--color-surface-2);
+    color: var(--color-ink-2);
+  }
+  .ctx-loud {
+    border: 1px solid var(--color-rule-strong);
+    background: var(--color-surface);
+    color: var(--color-ink);
+  }
+  .ctx-loud b {
+    display: block;
+    font-weight: 600;
+    font-size: 13px;
+  }
+  .ctx-loud span {
+    display: block;
+    margin-top: 2px;
+    color: var(--color-ink-2);
+    font-size: 12px;
+  }
+  .ctx-dashed {
+    border: 1px dashed var(--color-rule-strong);
+    color: var(--color-ink-3);
+    background: transparent;
+  }
+  .ctx-never {
+    border: 1px dashed var(--color-rule);
+    background: transparent;
+    color: var(--color-ink-3);
+  }
+  .ctx-never b {
+    display: block;
+    font-weight: 500;
+    font-size: 13px;
+    text-decoration: line-through;
+    color: var(--color-ink-3);
+  }
+  .ctx-never span {
+    display: block;
+    margin-top: 2px;
+    font-size: 12px;
+  }
+
+  .persp-detail {
+    padding: 20px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    min-width: 0;
+  }
+  .persp-detail .code-window {
+    margin: 0;
+  }
+  .persp-detail .code-body {
+    font-size: 12px;
+    line-height: 1.6;
+    overflow-x: auto;
+  }
+  .persp-path {
+    font-size: 13.5px;
+    line-height: 1.6;
+    color: var(--color-ink-2);
+  }
+  .persp-path-label {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-ink-3);
+    margin-bottom: 3px;
+  }
+
+  /* ── cost chart ── */
+  .cost-card {
+    padding: 10px 24px;
+  }
+  .cost-row {
+    display: grid;
+    grid-template-columns: 240px 1fr 84px;
+    align-items: center;
+    gap: 16px;
+    padding: 11px 0;
+  }
+  .cost-row + .cost-row {
+    border-top: 1px solid var(--color-rule);
+  }
+  @media (max-width: 640px) {
+    .cost-row {
+      grid-template-columns: 1fr 84px;
+    }
+    .cost-track {
+      display: none;
+    }
+  }
+  .cost-name {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--color-ink);
+  }
+  .cost-detail {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-ink-3);
+    margin-top: 2px;
+  }
+  .cost-track {
+    position: relative;
+    height: 20px;
+  }
+  .cost-bar {
+    position: absolute;
+    top: 3px;
+    bottom: 3px;
+    left: 0;
+    background: var(--color-ink);
+    border-radius: 0 4px 4px 0;
+    min-width: 3px;
+  }
+  .cost-bar--zero {
+    background: transparent;
+    border-left: 2px solid var(--color-ink);
+    border-radius: 0;
+    min-width: 0;
+  }
+  .cost-val {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    text-align: right;
+    color: var(--color-ink);
+  }
+</style>

--- a/apps/marketing/src/pages/research/mcp-tool-visibility.astro
+++ b/apps/marketing/src/pages/research/mcp-tool-visibility.astro
@@ -8,7 +8,7 @@ import opencodeLogo from "../../assets/logos/opencode.svg?url";
 const GH = "https://github.com/UsefulSoftwareCo/executor";
 const title = "How agents actually see your MCP tools";
 const description =
-  "The same MCP server was connected to five coding agents and the model-bound traffic was measured. Each harness shows the model something different: full definitions, bare names, or nothing at all.";
+  "The same MCP server, connected to five coding agents, with the model-bound traffic measured. Each harness shows the model something different: full definitions, bare names, or nothing at all.";
 
 // Δ prompt tokens for the 31 per-integration search tools, provider-reported.
 const costs = [
@@ -63,229 +63,141 @@ const max = Math.max(...costs.map((c) => c.delta));
             {title}
           </h1>
           <p class="mt-5 max-w-[62ch] text-[17px] leading-[1.6] text-ink-2 text-pretty">
-            {description} We connected one Executor workspace — 31 integrations — to Claude Code,
-            Cursor's CLI, Codex, and two versions of opencode, twice each: once plain, once with
-            Executor's <code class="mono-inline">?search_tools=true</code> option, which adds one
-            minimal <code class="mono-inline">search_&lt;integration&gt;</code> tool per connected
-            integration. The difference between those two sessions is exactly what 31 extra tool
-            definitions cost, and where they end up.
+            One Executor workspace — 31 integrations — connected to each harness twice: plain, and
+            with <code class="mono-inline">?search_tools=true</code>, which adds one minimal
+            <code class="mono-inline">search_&lt;integration&gt;</code> tool per integration. The
+            difference between the two captured sessions is what 31 tool definitions cost, and
+            where they end up.
           </p>
         </div>
       </section>
 
-      {/* ─── THE THREE REALITIES ─── */}
+      {/* ─── CONTEXT VIEWER ─── */}
       <section class="border-t border-rule px-6 py-14 sm:px-10 sm:py-20">
         <div class="mx-auto max-w-[1100px]">
-          <span class="eyebrow">What each harness shows the model</span>
-          <h2 class="section-title mt-4 max-w-[24ch]">Five harnesses, three different realities</h2>
-          <p class="section-sub mt-4 max-w-[62ch]">
-            "The model sees your tools" hides three different mechanisms. Every card below is one
-            harness's view of the same server, drawn from the captured request that actually went
-            to the model. Solid blocks are in the context window on every turn; dashed blocks are
-            fetched on demand; crossed-out blocks never reach the model at all.
-          </p>
+          <span class="eyebrow">The model's context window, per harness</span>
+          <h2 class="section-title mt-4 max-w-[26ch]">Same server, four context windows</h2>
 
-          <div class="mt-10 grid gap-6">
-            {/* Inliners */}
-            <div class="persp surface-card">
-              <div class="persp-bar">
-                <span class="persp-dot"></span><span class="persp-dot"></span><span class="persp-dot"></span>
-                <span class="persp-icons">
-                  <img src={claudeLogo} alt="Claude" width="18" height="18" />
-                  <img src={opencodeLogo} alt="opencode" width="18" height="18" />
-                </span>
-                <span class="persp-name">Claude Code · opencode</span>
-                <span class="persp-ver">2.1.247 · 1.18.15</span>
-                <span class="persp-cost">+3,399–3,464 tokens</span>
-              </div>
-              <p class="persp-lede">
-                Every definition is pasted into the prompt, every turn — name, description, and
-                schema for all 38 tools.
-              </p>
-              <div class="persp-body">
-                <div class="ctx">
-                  <div class="ctx-label">the model's context window</div>
-                  <div class="ctx-block ctx-quiet">system prompt</div>
-                  <div class="ctx-block ctx-loud">
-                    <b>38 tool definitions — full JSON schema each</b>
-                    <span>name + description + parameters for every tool, inlined as API function tools</span>
-                  </div>
-                  <div class="ctx-block ctx-quiet">conversation</div>
-                </div>
-                <div class="persp-detail">
-                  <div class="code-window">
-                    <div class="code-titlebar">
-                      <span class="code-dot"></span><span class="code-dot"></span><span class="code-dot"></span>
-                      <span class="code-filename">tools[7] of 38 — as sent to the model</span>
-                    </div>
-                    <pre
-                      class="code-body">{`{
-  "name": "mcp__executor__search_mcp_linear_app",
-  "description": "Search this integration's tools;
-    empty query lists all. Run results with execute.",
-  "input_schema": {
-    "type": "object",
-    "properties": { "query": { "type": "string" } }
-  }
-}`}</pre>
-                  </div>
-                  <p class="persp-path">
-                    <span class="persp-path-label">To search Linear’s tools</span>
-                    one call — <code class="mono-inline">search_mcp_linear_app({"{ query }"})</code>,
-                    the definition is already in context.
-                  </p>
-                </div>
-              </div>
+          <div class="viewer surface-card mt-10">
+            <div class="viewer-tabs" role="tablist" aria-label="Harness">
+              <button class="vtab is-active" data-tab="claude" role="tab" aria-selected="true">
+                <img src={claudeLogo} alt="" width="16" height="16" /> Claude Code
+              </button>
+              <button class="vtab" data-tab="opencode" role="tab" aria-selected="false">
+                <img src={opencodeLogo} alt="" width="16" height="16" /> opencode
+              </button>
+              <button class="vtab" data-tab="cursor" role="tab" aria-selected="false">
+                <img src={cursorLogo} alt="" width="16" height="16" /> Cursor CLI
+              </button>
+              <button class="vtab" data-tab="codex" role="tab" aria-selected="false">
+                <img src={codexLogo} alt="" width="16" height="16" /> Codex CLI
+              </button>
             </div>
 
-            {/* opencode code mode */}
-            <div class="persp surface-card">
-              <div class="persp-bar">
-                <span class="persp-dot"></span><span class="persp-dot"></span><span class="persp-dot"></span>
-                <span class="persp-icons">
-                  <img src={opencodeLogo} alt="opencode" width="18" height="18" />
-                </span>
-                <span class="persp-name">opencode · code mode</span>
-                <span class="persp-ver">OPENCODE_EXPERIMENTAL_CODE_MODE</span>
-                <span class="persp-cost">+1,280 tokens</span>
+            <div class="viewer-sub">
+              <span class="viewer-meta" data-meta="claude">v2.1.247</span>
+              <span class="viewer-meta" data-meta="opencode" hidden>v1.18.15 — beta behaves identically</span>
+              <span class="viewer-meta" data-meta="cursor" hidden>v2026.07.23</span>
+              <span class="viewer-meta" data-meta="codex" hidden>v0.147.0 — with or without the defer flag</span>
+              <div class="seg" data-seg="opencode" hidden>
+                <span class="seg-label">code mode</span>
+                <button class="seg-btn is-active" data-cm="off">Off</button>
+                <button class="seg-btn" data-cm="on">On</button>
               </div>
-              <p class="persp-lede">
-                Your tools collapse into one <code class="mono-inline">execute</code> tool and
-                reappear inside its description as typed signatures — still readable, 2.7× denser.
-              </p>
-              <div class="persp-body">
-                <div class="ctx">
-                  <div class="ctx-label">the model's context window</div>
-                  <div class="ctx-block ctx-quiet">system prompt</div>
-                  <div class="ctx-block ctx-quiet">13 built-in tools</div>
-                  <div class="ctx-block ctx-loud">
-                    <b>one <code class="mono-inline">execute</code> tool</b>
-                    <span>its description lists every MCP tool as a TypeScript signature — 2.7× denser than JSON definitions</span>
-                  </div>
-                  <div class="ctx-block ctx-quiet">conversation</div>
-                </div>
-                <div class="persp-detail">
-                  <div class="code-window">
-                    <div class="code-titlebar">
-                      <span class="code-dot"></span><span class="code-dot"></span><span class="code-dot"></span>
-                      <span class="code-filename">inside execute's description</span>
-                    </div>
-                    <pre
-                      class="code-body">{`- tools.executor.search_google_gmail(input: {
+              <span class="viewer-cost" data-cost>+3,464 tokens for the 31 tools</span>
+            </div>
+
+            {/* Claude Code */}
+            <div class="pane" data-pane="claude">
+              <div class="blk blk-quiet"><span class="blk-tag">system prompt</span></div>
+              <div class="blk blk-quiet"><span class="blk-tag">built-in tools</span> 12 — Bash, Read, Edit, …</div>
+              <div class="blk blk-loud">
+                <span class="blk-tag">your MCP tools · 38 of 38 in context</span>
+                <pre>{`{
+  "name": "mcp__executor__search_mcp_linear_app",
+  "description": "Search this integration's tools; empty query lists all.
+    Run results with execute.",
+  "input_schema": { "type": "object",
+    "properties": { "query": { "type": "string" } } }
+}`}</pre>
+                <span class="blk-note">full name + description + schema, × 38, resent every turn</span>
+              </div>
+              <div class="blk blk-quiet"><span class="blk-tag">conversation</span></div>
+              <div class="pane-measure">prompt 36,013 → 39,477 tokens · Δ +3,464</div>
+            </div>
+
+            {/* opencode, code mode off */}
+            <div class="pane" data-pane="opencode-off" hidden>
+              <div class="blk blk-quiet"><span class="blk-tag">system prompt</span></div>
+              <div class="blk blk-quiet"><span class="blk-tag">built-in tools</span> 13</div>
+              <div class="blk blk-loud">
+                <span class="blk-tag">your MCP tools · 38 of 38 in context</span>
+                <pre>{`{
+  "name": "executor_search_mcp_linear_app",
+  "description": "Search this integration's tools; empty query lists all.
+    Run results with execute.",
+  "inputSchema": { "type": "object",
+    "properties": { "query": { "type": "string" } } }
+}`}</pre>
+                <span class="blk-note">full name + description + schema, × 38, resent every turn</span>
+              </div>
+              <div class="blk blk-quiet"><span class="blk-tag">conversation</span></div>
+              <div class="pane-measure">prompt 17,458 → 20,857 tokens · Δ +3,399</div>
+            </div>
+
+            {/* opencode, code mode on */}
+            <div class="pane" data-pane="opencode-on" hidden>
+              <div class="blk blk-quiet"><span class="blk-tag">system prompt</span></div>
+              <div class="blk blk-quiet"><span class="blk-tag">built-in tools</span> 13</div>
+              <div class="blk blk-loud">
+                <span class="blk-tag">one execute tool — your 38 MCP tools inside its description</span>
+                <pre>{`- tools.executor.search_mcp_linear_app(input: {
     query?: string,
-  }): Promise<unknown> // Search this integration's
-    tools; empty query lists all. Run results
-    with execute.`}</pre>
-                  </div>
-                  <p class="persp-path">
-                    <span class="persp-path-label">To search Linear’s tools</span>
-                    one call through code —
-                    <code class="mono-inline">execute("await tools.executor.search_mcp_linear_app(…)")</code>.
-                  </p>
-                </div>
+  }): Promise<unknown> // Search this integration's tools;
+    empty query lists all. Run results with execute.`}</pre>
+                <span class="blk-note">TypeScript signatures — 2.7× denser than JSON definitions</span>
               </div>
+              <div class="blk blk-quiet"><span class="blk-tag">conversation</span></div>
+              <div class="pane-measure">prompt 16,126 → 17,406 tokens · Δ +1,280</div>
             </div>
 
             {/* Cursor */}
-            <div class="persp surface-card">
-              <div class="persp-bar">
-                <span class="persp-dot"></span><span class="persp-dot"></span><span class="persp-dot"></span>
-                <span class="persp-icons">
-                  <img src={cursorLogo} alt="Cursor" width="18" height="18" />
-                </span>
-                <span class="persp-name">Cursor CLI</span>
-                <span class="persp-ver">2026.07.23</span>
-                <span class="persp-cost">+170 tokens</span>
+            <div class="pane" data-pane="cursor" hidden>
+              <div class="blk blk-quiet"><span class="blk-tag">system prompt</span></div>
+              <div class="blk blk-quiet">
+                <span class="blk-tag">built-in tools</span> 19 — incl. <code class="mono-inline">GetDynamicTools</code> / <code class="mono-inline">CallDynamicTool</code>
               </div>
-              <p class="persp-lede">
-                The model gets a names-only catalog. Descriptions and schemas exist on Cursor's
-                side, but the model has to ask for them.
-              </p>
-              <div class="persp-body">
-                <div class="ctx">
-                  <div class="ctx-label">the model's context window</div>
-                  <div class="ctx-block ctx-quiet">system prompt</div>
-                  <div class="ctx-block ctx-quiet">19 first-party tools, incl. <code class="mono-inline">GetDynamicTools</code> / <code class="mono-inline">CallDynamicTool</code></div>
-                  <div class="ctx-block ctx-loud">
-                    <b>catalog: bare tool names, grouped by server</b>
-                    <span>≈5.5 tokens per tool — the name is all the model gets</span>
-                  </div>
-                  <div class="ctx-block ctx-dashed">
-                    descriptions &amp; schemas — fetched on demand via <code class="mono-inline">GetDynamicTools</code>
-                  </div>
-                  <div class="ctx-block ctx-quiet">conversation</div>
-                </div>
-                <div class="persp-detail">
-                  <div class="code-window">
-                    <div class="code-titlebar">
-                      <span class="code-dot"></span><span class="code-dot"></span><span class="code-dot"></span>
-                      <span class="code-filename">the model's catalog view</span>
-                    </div>
-                    <pre
-                      class="code-body">{`executor: execute · skills · resume ·
-  search_axiom_mcp · search_github_rest ·
-  search_google_gmail · search_mcp_linear_app · …
-
-(full definition available via GetDynamicTools —
- not fetched unless the model asks)`}</pre>
-                  </div>
-                  <p class="persp-path">
-                    <span class="persp-path-label">To search Linear’s tools</span>
-                    the name is visible; call it through
-                    <code class="mono-inline">CallDynamicTool("search_mcp_linear_app", …)</code>,
-                    optionally fetching the schema first.
-                  </p>
-                </div>
+              <div class="blk blk-loud">
+                <span class="blk-tag">your MCP tools · names only</span>
+                <pre>{`executor: execute · skills · resume ·
+  search_axiom_mcp · search_github_rest · search_google_gmail ·
+  search_mcp_linear_app · …`}</pre>
+                <span class="blk-note">≈5.5 tokens per tool</span>
               </div>
+              <div class="blk blk-dashed">
+                descriptions &amp; schemas — sent only when the model calls
+                <code class="mono-inline">GetDynamicTools</code>
+              </div>
+              <div class="blk blk-quiet"><span class="blk-tag">conversation</span></div>
+              <div class="pane-measure">prompt 16,140 → 16,310 tokens · Δ +170 (Cursor's usage meter)</div>
             </div>
 
             {/* Codex */}
-            <div class="persp surface-card">
-              <div class="persp-bar">
-                <span class="persp-dot"></span><span class="persp-dot"></span><span class="persp-dot"></span>
-                <span class="persp-icons">
-                  <img src={codexLogo} alt="Codex" width="18" height="18" />
-                </span>
-                <span class="persp-name">Codex CLI</span>
-                <span class="persp-ver">0.147.0</span>
-                <span class="persp-cost">+0 tokens</span>
+            <div class="pane" data-pane="codex" hidden>
+              <div class="blk blk-quiet"><span class="blk-tag">system prompt</span></div>
+              <div class="blk blk-quiet">
+                <span class="blk-tag">native tools</span> 9 — <code class="mono-inline">exec</code>, collaboration, …
               </div>
-              <p class="persp-lede">
-                Nothing about your tools reaches the prompt. They exist only as callables inside
-                Codex's code sandbox — the model discovers them by writing code.
-              </p>
-              <div class="persp-body">
-                <div class="ctx">
-                  <div class="ctx-label">the model's context window</div>
-                  <div class="ctx-block ctx-quiet">system prompt</div>
-                  <div class="ctx-block ctx-quiet">9 native tools — <code class="mono-inline">exec</code>, collaboration, …</div>
-                  <div class="ctx-block ctx-never">
-                    <b>your MCP tools</b>
-                    <span>carried only in request metadata the model never reads; prompts were byte-identical with 7 vs 38 tools</span>
-                  </div>
-                  <div class="ctx-block ctx-quiet">conversation</div>
-                </div>
-                <div class="persp-detail">
-                  <div class="code-window">
-                    <div class="code-titlebar">
-                      <span class="code-dot"></span><span class="code-dot"></span><span class="code-dot"></span>
-                      <span class="code-filename">request metadata — not model-visible</span>
-                    </div>
-                    <pre
-                      class="code-body">{`"code_mode_tool_names": {
-  "search_google_gmail":
-    { "namespace": "mcp__executor" },
+              <div class="blk blk-never">
+                <span class="blk-tag"><s>your MCP tools</s></span>
+                <pre>{`"code_mode_tool_names": {
+  "search_mcp_linear_app": { "namespace": "mcp__executor" },
   … 37 more
 }`}</pre>
-                  </div>
-                  <p class="persp-path">
-                    <span class="persp-path-label">To search Linear’s tools</span>
-                    the model must call <code class="mono-inline">exec</code> and write code —
-                    <code class="mono-inline">await tools.mcp__executor__search_mcp_linear_app(…)</code> —
-                    discovering what exists only from inside the sandbox.
-                  </p>
-                </div>
+                <span class="blk-note">request metadata — never rendered into the prompt; callable only from code inside <code class="mono-inline">exec</code></span>
               </div>
+              <div class="blk blk-quiet"><span class="blk-tag">conversation</span></div>
+              <div class="pane-measure">prompt 15,776 → 15,776 tokens · Δ 0, byte-identical</div>
             </div>
           </div>
         </div>
@@ -410,6 +322,57 @@ const max = Math.max(...costs.map((c) => c.delta));
   </main>
 </Layout>
 
+<script>
+  const viewer = document.querySelector(".viewer");
+  if (viewer) {
+    const tabs = [...viewer.querySelectorAll(".vtab")];
+    const panes = [...viewer.querySelectorAll(".pane")];
+    const metas = [...viewer.querySelectorAll(".viewer-meta")];
+    const seg = viewer.querySelector("[data-seg='opencode']");
+    const segBtns = [...viewer.querySelectorAll(".seg-btn")];
+    const cost = viewer.querySelector("[data-cost]");
+
+    const COSTS = {
+      claude: "+3,464 tokens for the 31 tools",
+      "opencode-off": "+3,399 tokens for the 31 tools",
+      "opencode-on": "+1,280 tokens for the 31 tools",
+      cursor: "+170 tokens for the 31 tools",
+      codex: "0 tokens — not in the prompt",
+    };
+
+    let tab = "claude";
+    let codemode = false;
+
+    const paneKey = () => (tab === "opencode" ? (codemode ? "opencode-on" : "opencode-off") : tab);
+
+    const update = () => {
+      const key = paneKey();
+      for (const t of tabs) {
+        const active = t.dataset.tab === tab;
+        t.classList.toggle("is-active", active);
+        t.setAttribute("aria-selected", String(active));
+      }
+      for (const p of panes) p.hidden = p.dataset.pane !== key;
+      for (const m of metas) m.hidden = m.dataset.meta !== tab;
+      if (seg) seg.hidden = tab !== "opencode";
+      for (const b of segBtns) b.classList.toggle("is-active", (b.dataset.cm === "on") === codemode);
+      if (cost) cost.textContent = COSTS[key];
+    };
+
+    for (const t of tabs)
+      t.addEventListener("click", () => {
+        tab = t.dataset.tab ?? "claude";
+        update();
+      });
+    for (const b of segBtns)
+      b.addEventListener("click", () => {
+        codemode = b.dataset.cm === "on";
+        update();
+      });
+    update();
+  }
+</script>
+
 <style>
   .mono-inline {
     font-family: var(--font-mono);
@@ -421,192 +384,175 @@ const max = Math.max(...costs.map((c) => c.delta));
     white-space: nowrap;
   }
 
-  /* ── perspective cards ── */
-  .persp {
+  /* ── viewer ── */
+  .viewer {
     padding: 0;
     overflow: hidden;
   }
-  /* window titlebar — the card IS the harness's window */
-  .persp-bar {
+  .viewer-tabs {
+    display: flex;
+    align-items: stretch;
+    border-bottom: 1px solid var(--color-rule);
+    overflow-x: auto;
+  }
+  .vtab {
     display: flex;
     align-items: center;
-    gap: 10px;
-    padding: 12px 18px;
+    gap: 8px;
+    padding: 13px 18px;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--color-ink-2);
+    border: 0;
+    border-bottom: 2px solid transparent;
+    background: none;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: color 0.15s;
+  }
+  .vtab img {
+    display: block;
+    height: 16px;
+    width: 16px;
+    opacity: 0.75;
+  }
+  .vtab:hover {
+    color: var(--color-ink);
+  }
+  .vtab.is-active {
+    color: var(--color-ink);
+    border-bottom-color: var(--color-ink);
+  }
+  .vtab.is-active img {
+    opacity: 1;
+  }
+
+  .viewer-sub {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 10px 18px;
     border-bottom: 1px solid var(--color-rule);
     background: var(--color-surface-2);
   }
-  .persp-dot {
-    width: 9px;
-    height: 9px;
-    border-radius: 9999px;
-    background: var(--color-rule-strong);
-    flex-shrink: 0;
-  }
-  .persp-dot + .persp-dot {
-    margin-left: -3px;
-  }
-  .persp-icons {
-    display: flex;
-    align-items: center;
-    gap: 7px;
-    flex-shrink: 0;
-    margin-left: 8px;
-  }
-  .persp-icons img {
-    display: block;
-    height: 18px;
-    width: 18px;
-  }
-  .persp-name {
-    font-weight: 600;
-    font-size: 15px;
-    letter-spacing: -0.01em;
-    color: var(--color-ink);
-    white-space: nowrap;
-  }
-  .persp-ver {
+  .viewer-meta {
     font-family: var(--font-mono);
-    font-size: 11px;
+    font-size: 11.5px;
     color: var(--color-ink-3);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    min-width: 0;
   }
-  .persp-cost {
+  .viewer-cost {
+    margin-left: auto;
     font-family: var(--font-mono);
-    font-size: 12.5px;
+    font-size: 12px;
     color: var(--color-ink);
     white-space: nowrap;
-    margin-left: auto;
   }
-  @media (max-width: 640px) {
-    .persp-ver {
-      display: none;
-    }
-  }
-  .persp-lede {
-    padding: 16px 24px 0;
-    font-size: 14.5px;
-    line-height: 1.6;
-    color: var(--color-ink-2);
-    max-width: 72ch;
-  }
-  /* one window chrome per card: inner excerpts keep a filename bar, no dots */
-  .persp-detail .code-dot {
-    display: none;
-  }
-  .persp-body {
-    display: grid;
-    grid-template-columns: 340px 1fr;
-    gap: 0;
-  }
-  @media (max-width: 820px) {
-    .persp-body {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  /* context-window schematic */
-  .ctx {
-    padding: 20px 24px;
-    border-right: 1px solid var(--color-rule);
+  .seg {
     display: flex;
-    flex-direction: column;
-    gap: 6px;
+    align-items: center;
+    gap: 4px;
   }
-  @media (max-width: 820px) {
-    .ctx {
-      border-right: 0;
-      border-bottom: 1px solid var(--color-rule);
-    }
-  }
-  .ctx-label {
+  .seg-label {
     font-family: var(--font-mono);
-    font-size: 10.5px;
+    font-size: 11px;
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--color-ink-3);
-    margin-bottom: 4px;
+    margin-right: 4px;
   }
-  .ctx-block {
+  .seg-btn {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    padding: 3px 10px;
+    border: 1px solid var(--color-rule-strong);
+    background: var(--color-surface);
+    color: var(--color-ink-2);
+    cursor: pointer;
+  }
+  .seg-btn:first-of-type {
+    border-radius: 5px 0 0 5px;
+  }
+  .seg-btn:last-of-type {
+    border-radius: 0 5px 5px 0;
+    margin-left: -1px;
+  }
+  .seg-btn.is-active {
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+    color: var(--color-surface);
+  }
+
+  .pane {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 20px;
+  }
+  .blk {
     border-radius: 6px;
-    padding: 9px 12px;
-    font-size: 12.5px;
-    line-height: 1.45;
-  }
-  .ctx-quiet {
-    border: 1px solid var(--color-rule);
-    background: var(--color-surface-2);
+    padding: 10px 14px;
+    font-size: 13px;
+    line-height: 1.5;
     color: var(--color-ink-2);
   }
-  .ctx-loud {
+  .blk-tag {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-ink-3);
+    margin-right: 8px;
+  }
+  .blk-quiet {
+    border: 1px solid var(--color-rule);
+    background: var(--color-surface-2);
+  }
+  .blk-loud {
     border: 1px solid var(--color-rule-strong);
     background: var(--color-surface);
     color: var(--color-ink);
   }
-  .ctx-loud b {
-    display: block;
-    font-weight: 600;
-    font-size: 13px;
+  .blk-loud .blk-tag {
+    color: var(--color-ink);
   }
-  .ctx-loud span {
-    display: block;
-    margin-top: 2px;
-    color: var(--color-ink-2);
-    font-size: 12px;
-  }
-  .ctx-dashed {
+  .blk-dashed {
     border: 1px dashed var(--color-rule-strong);
     color: var(--color-ink-3);
-    background: transparent;
   }
-  .ctx-never {
+  .blk-never {
     border: 1px dashed var(--color-rule);
-    background: transparent;
     color: var(--color-ink-3);
   }
-  .ctx-never b {
-    display: block;
-    font-weight: 500;
-    font-size: 13px;
-    text-decoration: line-through;
-    color: var(--color-ink-3);
-  }
-  .ctx-never span {
-    display: block;
-    margin-top: 2px;
+  .blk pre {
+    margin: 10px 0 6px;
+    font-family: var(--font-mono);
     font-size: 12px;
-  }
-
-  .persp-detail {
-    padding: 20px 24px;
-    display: flex;
-    flex-direction: column;
-    gap: 14px;
-    min-width: 0;
-  }
-  .persp-detail .code-window {
-    margin: 0;
-  }
-  .persp-detail .code-body {
-    font-size: 12px;
-    line-height: 1.6;
-    overflow-x: auto;
-  }
-  .persp-path {
-    font-size: 13.5px;
     line-height: 1.6;
     color: var(--color-ink-2);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-rule);
+    border-radius: 6px;
+    padding: 12px 14px;
+    overflow-x: auto;
+    white-space: pre;
   }
-  .persp-path-label {
+  .blk-never pre {
+    background: transparent;
+  }
+  .blk-note {
     display: block;
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
+    font-size: 12px;
     color: var(--color-ink-3);
-    margin-bottom: 3px;
+  }
+  .pane-measure {
+    margin-top: 8px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--color-ink-3);
+    text-align: right;
   }
 
   /* ── cost chart ── */


### PR DESCRIPTION
New public marketing page at /research/mcp-tool-visibility.

Presents the measured study of how five harnesses (Claude Code, Cursor CLI, Codex CLI, opencode stable/beta incl. code mode) present MCP tools to the model: per-harness context-window anatomy cards with real captured excerpts, provider-reported token costs for 31 per-integration search tools, and takeaways for MCP server authors.

Light-only, design.md tokens and existing marketing classes (eyebrow/section-title/surface-card/cap-grid/code-window). No new deps, no dynamic code beyond static Astro. Verified with astro build plus desktop and mobile screenshots on the dev server.