### PR TITLE
feat(mcp): add Search1API hosted MCP preset

### DIFF
--- a/packages/plugins/mcp/src/sdk/presets.ts
+++ b/packages/plugins/mcp/src/sdk/presets.ts
@@ -78,6 +78,15 @@ export const mcpPresets: readonly McpPreset[] = [
     featured: true,
   },
   {
+    id: "search1api",
+    name: "Search1API",
+    summary: "Web search, news, crawl, sitemap, and trending via one hosted MCP.",
+    url: "https://mcp.search1api.com/mcp",
+    endpoint: "https://mcp.search1api.com/mcp",
+    icon: "https://s1.dev/logo.png",
+    featured: true,
+  },
+  {
     id: "neon",
     name: "Neon",
     summary: "Serverless Postgres — branches, queries, and management.",


### PR DESCRIPTION
Search1API (https://s1.dev) is a hosted MCP for web search, news, crawl, sitemap, and trending. Endpoint `https://mcp.search1api.com/mcp`. tools/list works without a key; tool calls use OAuth 2.1 or a Bearer API key (same pattern as other hosted MCPs in this list). Icon is the official mark at https://s1.dev/logo.png.