### PR TITLE
Move Team to per-member pricing with unlimited executions

### DIFF
--- a/.changeset/seat-based-team-pricing.md
+++ b/.changeset/seat-based-team-pricing.md
@@ -1,0 +1,22 @@
+---
+"@executor-js/cloud": patch
+---
+
+**Team pricing is per member with unlimited executions**
+
+The Team plan moves from $150 per organization with a 250,000-execution
+allowance to $15 per member per month with unlimited executions. The
+`members` feature is unarchived in `autumn.config.ts` and billed in arrears
+on the seat count the app reports; Free keeps its 3-member, 100,000-execution
+shape and Enterprise stays custom with seat usage tracked for visibility.
+
+Seat counts reconcile from a full WorkOS recount (active members only —
+pending invites hold a seat for the plan gate but are not billed) after
+member removal, invitation acceptance, organization creation, and on every
+login callback, which also picks up joins the app never sees a mutation for
+(SSO JIT provisioning, join by domain, dashboard edits). Plans that predate
+seat pricing have no members balance and are skipped, so existing
+subscriptions keep billing exactly as before on their current plan version.
+
+The plans page, billing page, and marketing pricing cards now show the
+per-member price.

--- a/apps/cloud/src/account/org-api-key-revoke.node.test.ts
+++ b/apps/cloud/src/account/org-api-key-revoke.node.test.ts
@@ -111,6 +111,7 @@ const stubAutumn = Layer.succeed(AutumnService)({
   ensureCustomer: () => Effect.die("revoke does not touch billing"),
   checkExecutionBalance: () => Effect.die("revoke does not touch billing"),
   trackExecution: () => Effect.void,
+  setMemberSeats: () => Effect.void,
 });
 
 /**

--- a/apps/cloud/src/account/workos-account-service.ts
+++ b/apps/cloud/src/account/workos-account-service.ts
@@ -14,6 +14,7 @@ import type { Session } from "../auth/middleware";
 import { WorkOSClient } from "../auth/workos";
 import { ORG_SELECTOR_HEADER, authorizeOrganizationSelector } from "../auth/organization";
 import { AutumnService } from "../extensions/billing/service";
+import { forkReportMemberSeats } from "../extensions/billing/member-seats";
 import {
   countSeatsUsed,
   getMemberLimitForPlan,
@@ -82,7 +83,7 @@ export const workosAccountProvider: Layer.Layer<
     // call `authorizeOrganization` (yields `WorkOSClient` + `UserStoreService`) —
     // can be erased to `R = never`, as the neutral AccountProvider shape
     // requires. Provided per method below.
-    const ctx = yield* Effect.context<WorkOSClient | UserStoreService>();
+    const ctx = yield* Effect.context<WorkOSClient | UserStoreService | AutumnService>();
 
     // Unauthenticated (missing/invalid session) => AccountUnauthorized, exactly
     // as the old inline `requireSession` did.
@@ -364,6 +365,7 @@ export const workosAccountProvider: Layer.Layer<
           yield* workos
             .deleteOrgMembership(membershipId)
             .pipe(Effect.catchTag("WorkOSError", toAccountError));
+          yield* forkReportMemberSeats(org.id).pipe(Effect.provideContext(ctx));
           return { success: true };
         }),
 

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -22,6 +22,7 @@ import { env } from "cloudflare:workers";
 import { WorkOSError } from "./errors";
 import { WorkOSClient } from "./workos";
 import { AutumnService } from "../extensions/billing/service";
+import { forkReportMemberSeats } from "../extensions/billing/member-seats";
 import { captureCauseEffect } from "../observability";
 import {
   hasPaidOrganizationSubscription,
@@ -245,6 +246,15 @@ export const CloudAuthPublicHandlers = HttpApiBuilder.group(
             targetOrganizationId = existingActive?.organizationId ?? null;
           }
 
+          // Seat changes the app never sees a mutation for (invitation
+          // acceptance in AuthKit, SSO JIT provisioning, join by domain,
+          // WorkOS dashboard edits) all end in a sign-in, so every login
+          // reconciles the landed org's billed seat count. Forked: billing
+          // must not delay the login.
+          if (targetOrganizationId) {
+            yield* forkReportMemberSeats(targetOrganizationId);
+          }
+
           if (
             targetOrganizationId &&
             targetOrganizationId !== result.organizationId &&
@@ -451,6 +461,8 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
               }),
             ),
           );
+          // Seed the new org's billed seat count (the creator's seat).
+          yield* forkReportMemberSeats(org.id);
 
           // Try to attach the new org to the current session. This can fail
           // (or silently return a session still scoped to the old org) when
@@ -626,6 +638,11 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
           const mirrored = yield* users.use("upsertOrganization", (s) =>
             s.upsertOrganization({ id: org.id, name: org.name }),
           );
+
+          // The membership is active in WorkOS from this point even if
+          // attaching the session below fails, so reconcile the org's billed
+          // seat count now.
+          yield* forkReportMemberSeats(org.id);
 
           // Attach the just-accepted org to the current session. Same shape
           // as createOrganization: refresh + verify; if we can't pin the

--- a/apps/cloud/src/extensions/billing/member-seats.ts
+++ b/apps/cloud/src/extensions/billing/member-seats.ts
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------------------
+// Seat-count reporting — the WorkOS → Autumn reconciliation for seat billing
+// ---------------------------------------------------------------------------
+
+import { Effect } from "effect";
+
+import { WorkOSClient } from "../../auth/workos";
+import { AutumnService } from "./service";
+
+/**
+ * Report the organization's billable seat count to Autumn: active members
+ * only — a pending invite occupies a seat for the plan gate but is not
+ * billed until the person joins.
+ *
+ * Seats change through paths the app never sees a mutation for (invitation
+ * acceptance in AuthKit, SSO JIT provisioning, join by domain, WorkOS
+ * dashboard edits), so this reconciles from a full recount rather than
+ * tracking deltas. It runs after in-app membership mutations AND on every
+ * login callback, so drift from out-of-band changes heals on the next
+ * sign-in. Fire-and-forget-safe: errors are logged, never surfaced.
+ */
+export const reportMemberSeats = (
+  organizationId: string,
+): Effect.Effect<void, never, WorkOSClient | AutumnService> =>
+  Effect.gen(function* () {
+    const workos = yield* WorkOSClient;
+    const autumn = yield* AutumnService;
+    const memberships = yield* workos.listOrgMembers(organizationId);
+    const seats = memberships.data.filter((m) => m.status === "active").length;
+    yield* autumn.setMemberSeats(organizationId, seats);
+  }).pipe(
+    Effect.catch((error) =>
+      Effect.logWarning("reportMemberSeats: seat recount failed", { organizationId, error }),
+    ),
+    Effect.withSpan("billing.reportMemberSeats"),
+  );
+
+/**
+ * Fork `reportMemberSeats` off the calling request, mirroring how execution
+ * tracking is forked: billing must never stall or fail a user-facing
+ * request. Only boot-scoped services are captured (WorkOS + Autumn — no
+ * request-scoped resources), so the forked fiber cannot outlive anything it
+ * depends on.
+ */
+export const forkReportMemberSeats = (
+  organizationId: string,
+): Effect.Effect<void, never, WorkOSClient | AutumnService> =>
+  Effect.gen(function* () {
+    const ctx = yield* Effect.context<WorkOSClient | AutumnService>();
+    yield* Effect.sync(() => {
+      Effect.runForkWith(ctx)(reportMemberSeats(organizationId));
+    });
+  });

--- a/apps/cloud/src/extensions/billing/service.ts
+++ b/apps/cloud/src/extensions/billing/service.ts
@@ -79,6 +79,16 @@ export type IAutumnService = Readonly<{
    * user-facing request.
    */
   trackExecution: (organizationId: string) => Effect.Effect<void, never, never>;
+  /**
+   * Set the organization's billed seat count to an absolute value. Seats are
+   * a continuous-use feature, so callers recount from the membership source
+   * of truth and this SETS the usage rather than incrementing it — deltas
+   * would drift against seat changes the app never sees. Orgs whose plan
+   * version carries no `members` item (every plan predating seat pricing)
+   * are skipped. Fire-and-forget-safe: errors are caught and logged; the
+   * returned Effect never fails.
+   */
+  setMemberSeats: (organizationId: string, seats: number) => Effect.Effect<void, never, never>;
 }>;
 
 // ---------------------------------------------------------------------------
@@ -97,6 +107,7 @@ const make = Effect.sync(() => {
       ensureCustomer: () => notConfigured,
       checkExecutionBalance: () => notConfigured,
       trackExecution: () => Effect.void,
+      setMemberSeats: () => Effect.void,
     } satisfies IAutumnService;
   }
 
@@ -169,6 +180,41 @@ const make = Effect.sync(() => {
       );
     }).pipe(Effect.withSpan("autumn.trackExecution"));
 
+  const setMemberSeats = (organizationId: string, seats: number) =>
+    Effect.gen(function* () {
+      yield* Effect.annotateCurrentSpan({
+        "autumn.customer.id": organizationId,
+        "autumn.members.seats": seats,
+      });
+      // getOrCreate rather than get: reuses the provisioning repair, so an
+      // org Autumn has never seen gets its customer minted here instead of
+      // 404ing forever.
+      const customer = yield* use((c) => c.customers.getOrCreate({ customerId: organizationId }));
+      // Plans that predate seat pricing have no members balance to set.
+      // Existing subscribers stay on those versions deliberately, so this is
+      // a steady state, not an error.
+      if (customer.balances["members"] == null) {
+        yield* Effect.annotateCurrentSpan({ "autumn.members.skipped": true });
+        return;
+      }
+      yield* use((c) =>
+        c.balances.update({ customerId: organizationId, featureId: "members", usage: seats }),
+      );
+    }).pipe(
+      Effect.catch((error) =>
+        Effect.gen(function* () {
+          // Silent seat drift means wrong invoices, so failures page just
+          // like a lost execution track.
+          yield* Effect.sync(() => {
+            console.error("[billing] seat sync failed:", error);
+          });
+          yield* captureCauseEffect(error);
+          yield* Effect.annotateCurrentSpan({ "autumn.members.failed": true });
+        }),
+      ),
+      Effect.withSpan("autumn.setMemberSeats"),
+    );
+
   const checkExecutionBalance = (organizationId: string) =>
     Effect.gen(function* () {
       yield* Effect.annotateCurrentSpan({ "autumn.customer.id": organizationId });
@@ -179,7 +225,13 @@ const make = Effect.sync(() => {
       return { allowed: check.allowed };
     }).pipe(Effect.withSpan("autumn.checkExecutionBalance"));
 
-  return { use, ensureCustomer, checkExecutionBalance, trackExecution } satisfies IAutumnService;
+  return {
+    use,
+    ensureCustomer,
+    checkExecutionBalance,
+    trackExecution,
+    setMemberSeats,
+  } satisfies IAutumnService;
 });
 
 export class AutumnService extends Context.Service<AutumnService, IAutumnService>()(

--- a/apps/cloud/src/routes/app/billing.tsx
+++ b/apps/cloud/src/routes/app/billing.tsx
@@ -13,7 +13,7 @@ export const Route = createFileRoute("/{-$orgSlug}/billing")({
 
 const PLAN_TAGLINES: Record<string, string> = {
   free: "Free for up to 3 members",
-  team: "$150 per organization",
+  team: "$15 per member per month",
   enterprise: "Custom enterprise agreement",
 };
 

--- a/apps/cloud/src/routes/app/billing_.plans.tsx
+++ b/apps/cloud/src/routes/app/billing_.plans.tsx
@@ -117,29 +117,32 @@ const ENTERPRISE_FEATURES = [
   "Security reviews, DPA & SOC 2 on request",
 ];
 
-const PLAN_META: Record<string, { tagline: string; inherits?: string; features: string[] }> = {
+// Price display is hardcoded alongside the feature copy: Team's price lives
+// on its per-seat `members` item in Autumn, not the plan-level `price` the
+// SDK surfaces, so there is no live field to render it from.
+const PLAN_META: Record<
+  string,
+  {
+    tagline: string;
+    inherits?: string;
+    features: string[];
+    price: { label: string; suffix?: string };
+  }
+> = {
   free: {
     tagline: "For small teams getting started",
-    features: [
-      "Up to 3 members",
-      "100,000 included executions per month",
-      "$0.20 per 1,000 additional executions",
-      "Unlimited sources",
-    ],
+    price: { label: "$0", suffix: "USD / month" },
+    features: ["Up to 3 members", "100,000 executions per month", "Unlimited sources"],
   },
   team: {
     tagline: "For growing organizations",
-    features: [
-      "Unlimited members",
-      "250,000 included executions per month",
-      "5 minute execution timeout",
-      "Join by team domain",
-      "$0.20 per 1,000 additional executions",
-    ],
+    price: { label: "$15", suffix: "USD / member / month" },
+    features: ["Unlimited executions", "Verified domains & join by team domain"],
   },
   enterprise: {
     tagline: "For orgs with custom needs",
     inherits: "Team",
+    price: { label: "Custom" },
     features: ENTERPRISE_FEATURES,
   },
 };
@@ -278,15 +281,10 @@ function PlansPage() {
 
                   <div className="mt-4 flex items-baseline gap-1.5">
                     <span className="text-2xl font-semibold text-foreground tabular-nums">
-                      {plan.id === "enterprise" ? "Custom" : `$${plan.price?.amount ?? 0}`}
+                      {meta.price.label}
                     </span>
-                    {plan.id !== "enterprise" && plan.price?.interval && (
-                      <span className="text-sm text-muted-foreground">
-                        USD / org / {plan.price.interval}
-                      </span>
-                    )}
-                    {plan.id !== "enterprise" && !plan.price?.interval && (
-                      <span className="text-sm text-muted-foreground">USD</span>
+                    {meta.price.suffix && (
+                      <span className="text-sm text-muted-foreground">{meta.price.suffix}</span>
                     )}
                   </div>
 

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -591,7 +591,7 @@ Source (and the place to start if something breaks): https://github.com/UsefulSo
           <div class="mb-14 mx-auto text-center max-w-2xl">
             <div class="eyebrow mb-4">Pricing</div>
             <h2 class="section-title mx-auto max-w-[20ch]">
-              Start free, pay as you <span class="serif-italic">run</span>.
+              Start free, pay per <span class="serif-italic">member</span>.
             </h2>
           </div>
 
@@ -618,8 +618,7 @@ Source (and the place to start if something breaks): https://github.com/UsefulSo
               <ul class="check-list">
                 {[
                   "Up to 3 members",
-                  "100,000 included executions per month",
-                  "$0.20 per 1,000 additional executions",
+                  "100,000 executions per month",
                   "Unlimited integrations",
                 ].map((f) => (
                   <li>
@@ -650,21 +649,18 @@ Source (and the place to start if something breaks): https://github.com/UsefulSo
               <div class="flex items-baseline gap-1.5 mb-6">
                 <span
                   class="text-[40px] leading-none font-semibold tracking-[-0.02em] text-ink tabular-nums"
-                  >$150</span
+                  >$15</span
                 >
-                <span class="text-[13.5px] text-ink-3">/ org / month</span>
+                <span class="text-[13.5px] text-ink-3">/ member / month</span>
               </div>
               <a href="/cloud" class="btn-primary self-start mb-7"
                 >Start free trial →</a
               >
               <ul class="check-list">
                 {[
-                  "14-day free trial, then $150 / month",
-                  "Unlimited members",
-                  "250,000 included executions per month",
-                  "5 minute execution timeout",
-                  "Join by team domain",
-                  "$0.20 per 1,000 additional executions",
+                  "14-day free trial, then $15 / member / month",
+                  "Unlimited executions",
+                  "Verified domains & join by team domain",
                 ].map((f) => (
                   <li>
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"

--- a/autumn.config.ts
+++ b/autumn.config.ts
@@ -19,7 +19,6 @@ export const members = feature({
   name: "Members",
   type: "metered",
   consumable: false,
-  archived: true,
 });
 
 // Plans
@@ -29,6 +28,10 @@ export const free = plan({
   addOn: false,
   autoEnable: true,
   items: [
+    item({
+      featureId: members.id,
+      included: 3,
+    }),
     item({
       featureId: executions.id,
       included: 100000,
@@ -63,23 +66,28 @@ export const team = plan({
   name: "Team",
   addOn: false,
   autoEnable: false,
-  price: {
-    amount: 150,
-    interval: "month",
-  },
   freeTrial: {
     durationLength: 14,
     durationType: "day",
     cardRequired: true,
   },
   items: [
+    // Billed in arrears on the seat count the app reports (active members
+    // only — see apps/cloud/src/extensions/billing/member-seats.ts).
+    item({
+      featureId: members.id,
+      included: 0,
+      price: {
+        amount: 15,
+        billingUnits: 1,
+        billingMethod: "usage_based",
+        interval: "month",
+      },
+    }),
     item({
       featureId: executions.id,
-      included: 250000,
-      price: {
-        amount: 0.2,
-        billingUnits: 1000,
-        billingMethod: "usage_based",
+      unlimited: true,
+      reset: {
         interval: "month",
       },
     }),
@@ -95,6 +103,12 @@ export const enterprise = plan({
   addOn: false,
   autoEnable: false,
   items: [
+    // Seat usage is tracked for visibility; pricing is set per contract at
+    // attach time, so the plan itself carries no price.
+    item({
+      featureId: members.id,
+      unlimited: true,
+    }),
     item({
       featureId: executions.id,
       unlimited: true,

--- a/bun.lock
+++ b/bun.lock
@@ -355,7 +355,7 @@
       "version": "0.0.41",
       "dependencies": {
         "@executor-js/api": "workspace:*",
-        "@executor-js/emulate": "^0.14.0",
+        "@executor-js/emulate": "^0.14.1",
         "@executor-js/mcporter": "^0.11.4",
         "@executor-js/plugin-graphql": "workspace:*",
         "@executor-js/plugin-mcp": "workspace:*",
@@ -1774,7 +1774,7 @@
 
     "@executor-js/e2e": ["@executor-js/e2e@workspace:e2e"],
 
-    "@executor-js/emulate": ["@executor-js/emulate@0.14.0", "", { "dependencies": { "@aws-sdk/client-s3": "^3.1031.0", "@aws-sdk/client-sqs": "^3.1075.0", "@azure/msal-node": "^5.3.0", "@clerk/backend": "^3.8.4", "@octokit/rest": "^22.0.1", "@okta/okta-auth-js": "^8.0.1", "@slack/web-api": "^7.16.0", "@vercel/sdk": "^1.28.4", "@workos-inc/node": "^8.13.0", "atlas-api-client": "^0.3.0", "autumn-js": "^1.2.8", "commander": "^14", "googleapis": "^173.0.0", "graphql": "^16.9.0", "graphql-request": "^7.4.0", "openid-client": "^6.8.4", "picocolors": "^1.1.1", "resend": "^6.16.0", "spotify-web-api-node": "^5.0.2", "stripe": "^22.3.0", "twitter-api-v2": "^1.29.0", "yaml": "^2" }, "bin": { "emulate": "dist/index.js" } }, "sha512-SqxMifp1E3FFQ+A8Q/xVTuOxPd75Z/kWAwYgqS/9W+WnVspoAs1ZYAnTfLxsaEkwsURmngqAkc83Z+oySDjYdA=="],
+    "@executor-js/emulate": ["@executor-js/emulate@0.14.1", "", { "dependencies": { "@aws-sdk/client-s3": "^3.1031.0", "@aws-sdk/client-sqs": "^3.1075.0", "@azure/msal-node": "^5.3.0", "@clerk/backend": "^3.8.4", "@octokit/rest": "^22.0.1", "@okta/okta-auth-js": "^8.0.1", "@slack/web-api": "^7.16.0", "@vercel/sdk": "^1.28.4", "@workos-inc/node": "^8.13.0", "atlas-api-client": "^0.3.0", "autumn-js": "^1.2.8", "commander": "^14", "googleapis": "^173.0.0", "graphql": "^16.9.0", "graphql-request": "^7.4.0", "openid-client": "^6.8.4", "picocolors": "^1.1.1", "resend": "^6.16.0", "spotify-web-api-node": "^5.0.2", "stripe": "^22.3.0", "twitter-api-v2": "^1.29.0", "yaml": "^2" }, "bin": { "emulate": "dist/index.js" } }, "sha512-MO72WgLgjyOJnWEiL8DrT6jAVs8C2VDz9oGUFkZ/x2GciEkiOkYG67u5/o+nqtPoxJTR06cqpkHjfrzCm1dqww=="],
 
     "@executor-js/example-all-plugins": ["@executor-js/example-all-plugins@workspace:examples/all-plugins"],
 

--- a/e2e/cloud/member-seat-billing-sync.test.ts
+++ b/e2e/cloud/member-seat-billing-sync.test.ts
@@ -1,0 +1,107 @@
+// Cloud-only (billing): seat-based pricing bills the seat count Autumn holds,
+// so that count must actually REACH Autumn. Seats change through paths the
+// app never sees a mutation for (invitation acceptance in AuthKit, SSO JIT
+// provisioning, join by domain), so the app reconciles instead of tracking
+// deltas: it recounts active members from WorkOS and SETS the members balance
+// (`balances.update`), forked off org creation, login, invitation acceptance,
+// and member removal.
+//
+// Three guarantees are pinned here, all read from Autumn's own state (the
+// mutating responses can never show them):
+//
+//   1. creating an organization lands its creator's seat on the members
+//      balance,
+//   2. a pending invite occupies a plan-gate seat but is NOT billed — active
+//      members only, and
+//   3. a later membership mutation reconciles rather than increments: the
+//      recount after removing the pending membership still reports exactly
+//      the active seats.
+import { expect } from "@effect/vitest";
+import { Effect, Schedule } from "effect";
+import { AccountHttpApi } from "@executor-js/api";
+
+import { scenario } from "../src/scenario";
+import { Api, Autumn, Billing, Mcp, Target } from "../src/services";
+import type { Identity } from "../src/target";
+
+// apps/cloud/src/extensions/billing/plans.ts → MEMBER_LIMITS.free, mirrored by
+// the free plan's members item in autumn.config.ts.
+const FREE_MEMBER_SEATS = 3;
+
+const emailOf = (identity: Identity): string => identity.credentials?.email ?? identity.label;
+
+/** The org the bearer is scoped to — the Autumn customer id every billing call
+ *  is made against — read from the JWT's public claims. */
+const orgIdOf = (bearer: string): string => {
+  const claims = JSON.parse(Buffer.from(bearer.split(".")[1] ?? "", "base64url").toString()) as {
+    readonly org_id?: string;
+  };
+  if (!claims.org_id) throw new Error("orgIdOf: bearer carries no org_id claim");
+  return claims.org_id;
+};
+
+scenario(
+  "Billing · the billed seat count reaches Autumn: active members only, reconciled not incremented",
+  { timeout: 180_000 },
+  Effect.gen(function* () {
+    yield* Billing;
+    const autumn = yield* Autumn;
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const { client: apiClient } = yield* Api;
+
+    // A fresh user who owns a brand-new free org. Creating the org forks the
+    // first seat recount, so the creator's seat is on the meter before anyone
+    // is invited.
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+    const customerId = orgIdOf(bearer);
+    const client = yield* apiClient(AccountHttpApi, identity);
+
+    const seats = yield* autumn.expectMemberSeats(customerId, 1);
+    expect(seats.granted, "the free plan's members item grants the advertised seats").toBe(
+      FREE_MEMBER_SEATS,
+    );
+    expect(seats.unlimited, "free-plan seats are capped, not unlimited").toBe(false);
+
+    // An outstanding invite: the plan gate charges it a seat (so the org
+    // cannot invite past the cap), but billing counts active members only —
+    // nobody pays for a person who has not joined.
+    yield* client.account.inviteMember({ payload: { email: "invited@example.com" } });
+    const { members, seats: gateSeats } = yield* client.account.listMembers();
+    expect(gateSeats?.used, "the plan gate counts the pending invite as a seat").toBe(2);
+    const billedWithPendingInvite = yield* autumn.memberSeats(customerId);
+    expect(billedWithPendingInvite?.usage, "the pending invite is not billed").toBe(1);
+
+    // Removing the pending membership forks another recount. Its ledger entry
+    // is the barrier that separates "not billed yet" from "never billed": once
+    // the second reconciliation has landed, the balance is the recount's
+    // answer, not a stale read.
+    const pending = members.find((member) => member.status === "pending");
+    expect(pending, "the invited person appears as a pending membership").toBeTruthy();
+    yield* client.account.removeMember({ params: { membershipId: pending!.id } });
+
+    yield* autumn.ledgerFor("balances.update").pipe(
+      Effect.map((entries) => entries.filter((entry) => entry.customerId === customerId)),
+      Effect.filterOrFail(
+        (entries) => entries.length >= 2,
+        (entries) => `only ${entries.length}/2 seat reconciliations reached Autumn`,
+      ),
+      Effect.retry(Schedule.both(Schedule.spaced("500 millis"), Schedule.recurs(40))),
+    );
+
+    const reconciled = yield* autumn.memberSeats(customerId);
+    expect(
+      reconciled?.usage,
+      "the recount reconciles to the active seats — it never counted the invite, so it has nothing to walk back",
+    ).toBe(1);
+
+    // The balance moved by reconciliation events, not blind increments: one
+    // adjustment for the creator's seat, and none for the no-op recount.
+    const events = yield* autumn.usageEvents({ customerId, featureId: "members" });
+    expect(
+      events.map((event) => event.value),
+      "one +1 adjustment for the creator; the no-op recount writes no event",
+    ).toEqual([1]);
+  }),
+);

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@executor-js/api": "workspace:*",
-    "@executor-js/emulate": "^0.14.0",
+    "@executor-js/emulate": "^0.14.1",
     "@executor-js/mcporter": "^0.11.4",
     "@executor-js/plugin-graphql": "workspace:*",
     "@executor-js/plugin-mcp": "workspace:*",

--- a/e2e/src/surfaces/autumn.ts
+++ b/e2e/src/surfaces/autumn.ts
@@ -100,6 +100,19 @@ export interface AutumnSurface {
   /** Read the emulator's request ledger, filtered to one operation — used to
    *  prove a faulted `balances.check` was actually attempted (fail-open proof). */
   readonly ledgerFor: (operationId: string) => Effect.Effect<readonly LedgerEntry[], unknown>;
+  /** The customer's `members` balance as Autumn holds it — the seat count the
+   *  org is billed on — or null when the customer's plan carries no members
+   *  item. */
+  readonly memberSeats: (
+    customerId: string,
+  ) => Effect.Effect<{ usage: number; granted: number; unlimited: boolean } | null, unknown>;
+  /** Poll until the billed seat count reaches `usage`. Seat reporting is
+   *  forked off the mutating request (like usage tracking), so arrival is
+   *  eventually-consistent — polling IS the contract. */
+  readonly expectMemberSeats: (
+    customerId: string,
+    usage: number,
+  ) => Effect.Effect<{ usage: number; granted: number; unlimited: boolean }, unknown>;
 }
 
 export const makeAutumnSurface = (autumnUrl: string): AutumnSurface => {
@@ -218,6 +231,36 @@ export const makeAutumnSurface = (autumnUrl: string): AutumnSurface => {
       }
     });
 
+  const memberSeats = (customerId: string) =>
+    Effect.gen(function* () {
+      const response = yield* Effect.promise(() =>
+        fetch(`${autumnUrl}/v1/customers.get_or_create`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ customer_id: customerId }),
+        }),
+      );
+      if (!response.ok) {
+        return yield* Effect.fail(
+          `autumn customers.get_or_create responded ${response.status}: ${yield* Effect.promise(() => response.text())}`,
+        );
+      }
+      const body = (yield* Effect.promise(() => response.json())) as {
+        readonly balances?: Record<
+          string,
+          { readonly usage?: number; readonly granted?: number; readonly unlimited?: boolean }
+        >;
+      };
+      const balance = body.balances?.["members"];
+      return balance
+        ? {
+            usage: balance.usage ?? 0,
+            granted: balance.granted ?? 0,
+            unlimited: balance.unlimited === true,
+          }
+        : null;
+    });
+
   const armFault = (input: FaultInput) =>
     Effect.gen(function* () {
       const response = yield* Effect.promise(() =>
@@ -290,6 +333,19 @@ export const makeAutumnSurface = (autumnUrl: string): AutumnSurface => {
     armFault,
     clearFaults,
     ledgerFor,
+    memberSeats,
+    expectMemberSeats: (customerId, usage) =>
+      memberSeats(customerId).pipe(
+        Effect.filterOrFail(
+          (balance): balance is { usage: number; granted: number; unlimited: boolean } =>
+            balance !== null && balance.usage === usage,
+          (balance) =>
+            `members balance for ${customerId} is ${balance ? balance.usage : "absent"}, expected ${usage}`,
+        ),
+        // Same ceiling as expectUsage: the forked seat sync drains on the
+        // worker's waitUntil shortly after the mutating request returns.
+        Effect.retry(Schedule.both(Schedule.spaced("500 millis"), Schedule.recurs(40))),
+      ),
     expectUsage: (query) =>
       usageEvents(query).pipe(
         Effect.filterOrFail(


### PR DESCRIPTION
## What

New pricing for new customers. Existing subscribers stay on their current plan version and keep billing exactly as before.

| | Free | Team | Enterprise |
|---|---|---|---|
| Price | $0 | $15 / member / month | custom |
| Members | up to 3 | unlimited, billed per seat | unlimited |
| Executions | 100k / month | unlimited | unlimited |

## How

- `autumn.config.ts`: unarchive the `members` feature. Team drops the $150 flat price and the 250k execution allowance; it now bills $15 per member in arrears and has unlimited executions. Free gains a members item (included: 3) for visibility. Enterprise tracks seat usage but stays unpriced (set per contract at attach).
- Autumn versions plans on update, so syncing this config creates new plan versions; current subscribers are untouched.
- Seat reporting: `AutumnService.setMemberSeats` sets the members balance to an absolute usage. `reportMemberSeats` recounts active members from WorkOS (pending invites hold a seat for the gate but are not billed) and is forked after member removal, invitation acceptance, org creation, and on every login callback — the callback pass picks up joins the app never sees (SSO JIT, join by domain, dashboard edits). Orgs on plan versions without a members item are skipped, so legacy plans never error.
- Copy: plans page, billing page tagline, and the marketing pricing cards now show the per-member price. The plans page price is hardcoded next to the feature copy because the per-seat price lives on the plan item, not the plan-level `price` the SDK surfaces.

## Verification

- `apps/cloud`: typecheck, lint, full unit suite (344 passing).
- e2e, all on the Autumn emulator seeded from the new config:
  - `member-seat-billing-sync` (new): the creator seat lands on the members balance, a pending invite is gate-counted but not billed, and the removal-triggered recount reconciles — one adjustment event total.
  - `billing-trial-checkout-stale` (Team trial checkout), `member-invite-seat-limit` (free 3-seat gate), and the four `billing-customer-provisioning` scenarios all pass.
- The seat-sync assertions needed `balances.update` in the Autumn emulator; added in emulate v0.14.1 and consumed here.

## Notes

- The member seat GATE is unchanged (free: 3, paid: unlimited) — no product behavior changes, pricing only.
- After deploy, the config must be synced to Autumn via atmn for the new versions to exist.