### PR TITLE
Document connections.list result shape in skills.ts

### DIFF
--- a/packages/core/execution/src/skills.test.ts
+++ b/packages/core/execution/src/skills.test.ts
@@ -13,6 +13,7 @@ describe("skills registry", () => {
     expect(EXECUTE_SKILL.body).toContain(
       "Do not use `fetch` — all API calls go through `tools.*`.",
     );
+    expect(EXECUTE_SKILL.body).toContain("read `result.data.connections`");
   });
 
   it("finds a skill by exact name and misses unknown names", () => {

--- a/packages/core/execution/src/skills.ts
+++ b/packages/core/execution/src/skills.ts
@@ -36,7 +36,7 @@ const EXECUTE_SKILL_BODY = [
   '2. `const path = matches[0]?.path; if (!path) return "No matching tools found.";`',
   "3. `const details = await tools.describe.tool({ path });`",
   "4. Use `details.inputTypeScript` / `details.outputTypeScript` and `details.typeScriptDefinitions` for compact shapes.",
-  "5. Use `tools.executor.coreTools.connections.list({})` when you need live saved-connection inventory.",
+  "5. For live saved-connection inventory, call `tools.executor.coreTools.connections.list({})`; after checking `result.ok`, read `result.data.connections`.",
   "6. Call the tool: `const result = await tools.<path>(input);`",
   "",
   "## Rules",


### PR DESCRIPTION
## issue

when agents call `tools.executor.coreTools.connections.list({})` the actual output is 

```
{
  ok: true,
  data: {
    connections: [connection objects],
  }
}
```


while `execute` skill doesn't explicitly say where the connection array is inside the `{ok , data}` envelope.

i have observed that agents **almost always** tend to write code like:

```ts
const result = await tools.executor.coreTools.connections.list({});
for (const conn of result) {
  const slug = conn.integration;
  // something else, e.g., search a tool with name 
}
```

which gives an error, as `conn.integration` is invalid.

## fix 

i've added instructions in skills to document how to deal with results from `tools.executor.coreTools.connections.list({})`. been running this local build for a week now, have seen significant improvements on this, no mistake at all across 50+ calls! hence im opening this PR 