### PR TITLE
Drop the ignored package from the pre-initialize changeset

### DIFF
--- a/.changeset/mcp-pre-initialize-method-not-found.md
+++ b/.changeset/mcp-pre-initialize-method-not-found.md
@@ -1,5 +1,4 @@
 ---
-"@executor-js/host-mcp": patch
 "@executor-js/local": patch
 ---
 


### PR DESCRIPTION
The changeset from #1458 listed both @executor-js/host-mcp (on the changesets ignore list) and @executor-js/local. Mixed changesets fail release-plan assembly, which is failing the Release workflow on main. host-mcp is deliberately unversioned; local alone carries the bump. Same failure class as #1651.