### PR TITLE
Add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,100 @@
+name: Bug report
+description: Something in Executor does not work as expected.
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please update to the latest version first — the bug may already be fixed.
+        If the desktop app crashes, will not start, or shows a blank window, use the
+        **[Desktop app crash](?template=desktop-crash.yml)** template instead.
+  - type: input
+    id: version
+    attributes:
+      label: Executor version
+      description: Run `executor --version`, or open the About menu in the desktop app.
+      placeholder: "1.5.4"
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: How do you run Executor?
+      options:
+        - Executor Cloud
+        - CLI
+        - Desktop app
+        - Self-host (Docker)
+        - Self-host (Cloudflare)
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      description: For Executor Cloud, select the system you browse from.
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Windows
+        - Linux
+    validations:
+      required: true
+  - type: input
+    id: integration
+    attributes:
+      label: Integration involved
+      description: The integration or source type, if the bug is specific to one.
+      placeholder: "MCP server, OpenAPI spec, GraphQL API, …"
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: Describe the behaviour you saw.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      description: Describe the behaviour you wanted instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The smallest sequence that shows the bug. Include the commands you ran.
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Diagnostics / logs
+      description: |
+        In the desktop app, open the **Executor** menu → **Export Diagnostics…** and attach
+        the zip — it has everything we need and no secrets.
+
+        Otherwise attach the relevant log:
+        - CLI / self-host: `~/.executor/logs/` (run `executor service status` for the exact path)
+        - macOS desktop: `~/Library/Logs/Executor/main.log`
+        - Windows desktop: `%APPDATA%\Executor\logs\main.log`
+        - Linux desktop: `~/.config/Executor/logs/main.log`
+
+        (Please don't attach anything else from `~/.executor` — that's where your data and
+        secrets live. Remove API keys and tokens from anything you paste.)
+      placeholder: Drag the diagnostics zip or log file here.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you submit
+      options:
+        - label: I searched the open issues for a duplicate.
+          required: true
+        - label: I removed all keys, tokens, and credentials from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature request
+description: Suggest a capability or an improvement for Executor.
+title: "[feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Tell us the task you want to do and why Executor cannot do it today.
+        A concrete example helps more than a general proposal.
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What are you trying to do, and where does Executor stop you?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed shape
+      description: |
+        The change you want, as concretely as you can describe it. Name the command,
+        the setting, or the screen where it would live.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: Workarounds you tried, and why they are not sufficient.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where it belongs
+      description: Select every form of Executor this applies to.
+      options:
+        - Executor Cloud
+        - CLI
+        - Desktop app
+        - Self-host (Docker)
+        - Self-host (Cloudflare)
+        - Not sure
+      multiple: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you submit
+      options:
+        - label: I searched the open issues for a duplicate.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!-- Keep this short and plain. Delete the sections that do not apply. -->
+
+## Summary
+
+<!-- What does this change do, and why? One or two sentences. -->
+
+## Linked issue
+
+Fixes #
+
+## Verification
+
+<!--
+Say what you ran and what it showed. File paths alone are not evidence.
+User-visible work needs a specific e2e run or a browsable dev instance, plus
+the recording or trace that shows what to inspect. Add an e2e scenario when
+none covers the changed behaviour.
+-->
+
+- [ ] `bun run format:check`
+- [ ] `bun run lint`
+- [ ] `bun run typecheck`
+- [ ] `bun run test`
+- [ ] e2e — name the scenario, and link the recording or trace:
+
+## Checklist
+
+- [ ] Added a changeset (`bun run changeset`), or this change needs none.
+- [ ] Added or updated tests for the new behaviour.
+- [ ] No secrets, credentials, or private data in the diff.


### PR DESCRIPTION
Fixes #1225

The repo only had a desktop-crash issue template, so every other report started from an empty box. This adds a general bug report form, a feature request form, and a pull request template.

The bug form asks for the version, the form of Executor in use (Cloud, CLI, desktop, self-host), the operating system, what happened, what was expected, and the steps to reproduce. It repeats the diagnostics and secret-handling guidance from the desktop-crash template. The pull request template asks for a summary, the linked issue, and the verification that was run, and it states the e2e evidence rule from AGENTS.md. No changeset: no package changes.