### PR TITLE
fix(mcp): return expired status for OAuth reauthorization

### DIFF
--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -90,6 +90,7 @@ const mcpLivenessFailureStatus = (failure: {
   }
   const lower = failure.message.toLowerCase();
   const authWalled =
+    lower.includes("mcp oauth re-authorization") ||
     lower.includes("oauth re-authorization") ||
     lower.includes("unauthorized") ||
     lower.includes("forbidden");


### PR DESCRIPTION
## Related Issue
Fixes #1816

## Description
Fixes OAuth reauthorization status classification.

When an MCP OAuth token expires, the connection now correctly shows "expired" instead of "degraded", triggering the Reconnect button in the UI.

## Problem
OAuth reauthorization failures were classified as "degraded" instead of "expired", hiding the reconnect state from users.

## Solution
Added explicit check for "MCP OAuth re-authorization" in mcpLivenessFailureStatus to return "expired" status.

## Testing
- ✅ 7 tests passed in catalog-sync.test.ts
- ✅ Formatting clean
- ✅ Manual verification working

