### PR TITLE
Wait for OAuth connect actionability instead of reading the first paint

### DIFF
--- a/e2e/cloud/connection-modal-oauth-abandon.test.ts
+++ b/e2e/cloud/connection-modal-oauth-abandon.test.ts
@@ -102,8 +102,12 @@ scenario(
           await visit(page, `/integrations/${integration}`);
           await addConnection.click();
           // The registered app is auto-selected, so the OAuth connect button is
-          // present and enabled.
+          // present and enabled. Auto-selection resolves asynchronously after
+          // the modal opens, so the button legitimately renders disabled for a
+          // beat first — wait for actionability (trial click waits for
+          // enabled + stable) rather than reading that transient first paint.
           await connectWithOAuth.waitFor({ state: "visible", timeout: 15_000 });
+          await connectWithOAuth.click({ trial: true, timeout: 15_000 });
           expect(
             await connectWithOAuth.isDisabled(),
             "the auto-selected app makes Connect with OAuth actionable",


### PR DESCRIPTION
Fixes a new e2e flake: `connection-modal-oauth-abandon` failed twice within an hour on unrelated bases (runs 33153832122 on changeset-release, 33156980537) with the same assertion — "the auto-selected app makes Connect with OAuth actionable: expected true to be false".

The test waited for the button to be visible, then read `isDisabled()` once. The app picker's auto-selection resolves asynchronously after the modal opens, so the button legitimately renders disabled for a beat before enabling; the one-shot read raced that. It now waits for actionability (a trial click waits for enabled + stable) before the assertion. A genuine regression where the button never enables still fails, via the trial-click timeout.

Checks: lint, typecheck, focused `cloud/connection-modal-oauth-abandon.test.ts` run.