### PR TITLE
Support multiple 1Password vaults

### DIFF
--- a/.changeset/defer-irreversible-cleanup.md
+++ b/.changeset/defer-irreversible-cleanup.md
@@ -1,5 +1,5 @@
 ---
-"executor": minor
+"executor": patch
 ---
 
 **Irreversible cleanup now waits for the transaction to commit, and plugins can do the same**

--- a/.changeset/onepassword-multiple-vaults.md
+++ b/.changeset/onepassword-multiple-vaults.md
@@ -6,4 +6,6 @@
 
 The provider previously bound exactly one vault. The configuration now holds a set of vaults selected with checkboxes, and every reference is explicit about which vault it means: the item picker is a searchable list that shows each item's vault and stores a vault-qualified `op://` reference, so identically-titled items in different vaults can never collide. A bare item name is accepted only when it matches exactly one item across the selected vaults — a name that exists in more than one place fails with an error naming the matching vaults instead of silently picking one.
 
+Reopening the vault or item pickers no longer flashes a loading state: listings are retained and re-validated in the background, so the last-known list renders instantly.
+
 Configurations saved before this change keep working: the stored single-vault shape is read as a one-vault list and upgrades to the new shape the next time it is saved. The `status` tool reports `vaultNames` for all configured vaults and flags any configured vault the account can no longer see. Provider entries also gained an optional `group` label, which pickers use to show where an item lives.

--- a/.changeset/onepassword-multiple-vaults.md
+++ b/.changeset/onepassword-multiple-vaults.md
@@ -2,8 +2,8 @@
 "executor": minor
 ---
 
-**The 1Password provider can now be scoped to several vaults at once**
+**The 1Password provider can now be scoped to several vaults, with explicit per-vault addressing**
 
-The provider previously bound exactly one vault. The configuration now holds an ordered list of vaults: the settings dialog offers a checkbox per vault, item listings aggregate across every selected vault (suffixing the vault name when more than one is selected), and a bare item id is resolved by trying each vault in order with the first match winning. A fully-qualified `op://` URI resolves when its vault segment names any configured vault, by id or by name.
+The provider previously bound exactly one vault. The configuration now holds a set of vaults selected with checkboxes, and every reference is explicit about which vault it means: the item picker is a searchable list that shows each item's vault and stores a vault-qualified `op://` reference, so identically-titled items in different vaults can never collide. A bare item name is accepted only when it matches exactly one item across the selected vaults — a name that exists in more than one place fails with an error naming the matching vaults instead of silently picking one.
 
-Configurations saved before this change keep working: the stored single-vault shape is read as a one-vault list and upgrades to the new shape the next time it is saved. The `status` tool now reports `vaultNames` for all configured vaults and flags any configured vault the account can no longer see.
+Configurations saved before this change keep working: the stored single-vault shape is read as a one-vault list and upgrades to the new shape the next time it is saved. The `status` tool reports `vaultNames` for all configured vaults and flags any configured vault the account can no longer see. Provider entries also gained an optional `group` label, which pickers use to show where an item lives.

--- a/.changeset/onepassword-multiple-vaults.md
+++ b/.changeset/onepassword-multiple-vaults.md
@@ -1,0 +1,9 @@
+---
+"executor": minor
+---
+
+**The 1Password provider can now be scoped to several vaults at once**
+
+The provider previously bound exactly one vault. The configuration now holds an ordered list of vaults: the settings dialog offers a checkbox per vault, item listings aggregate across every selected vault (suffixing the vault name when more than one is selected), and a bare item id is resolved by trying each vault in order with the first match winning. A fully-qualified `op://` URI resolves when its vault segment names any configured vault, by id or by name.
+
+Configurations saved before this change keep working: the stored single-vault shape is read as a one-vault list and upgrades to the new shape the next time it is saved. The `status` tool now reports `vaultNames` for all configured vaults and flags any configured vault the account can no longer see.

--- a/.changeset/onepassword-multiple-vaults.md
+++ b/.changeset/onepassword-multiple-vaults.md
@@ -1,5 +1,5 @@
 ---
-"executor": minor
+"executor": patch
 ---
 
 **The 1Password provider can now be scoped to several vaults, with explicit per-vault addressing**

--- a/packages/core/api/src/handlers/providers.ts
+++ b/packages/core/api/src/handlers/providers.ts
@@ -21,7 +21,11 @@ export const ProvidersHandlers = HttpApiBuilder.group(ExecutorApi, "providers", 
         Effect.gen(function* () {
           const executor = yield* ExecutorService;
           const entries = yield* executor.providers.items(path.key);
-          return entries.map((entry) => ({ id: entry.id, name: entry.name }));
+          return entries.map((entry) => ({
+            id: entry.id,
+            name: entry.name,
+            ...(entry.group !== undefined ? { group: entry.group } : {}),
+          }));
         }),
       ),
     ),

--- a/packages/core/api/src/providers/api.ts
+++ b/packages/core/api/src/providers/api.ts
@@ -26,6 +26,7 @@ const ProviderParams = { key: ProviderKey };
 const ProviderEntryResponse = Schema.Struct({
   id: ProviderItemId,
   name: Schema.String,
+  group: Schema.optional(Schema.String),
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/sdk/src/provider.ts
+++ b/packages/core/sdk/src/provider.ts
@@ -16,6 +16,9 @@ export interface ProviderEntry {
    *  a connection can reference it without core knowing its internal shape. */
   readonly id: ProviderItemId;
   readonly name: string;
+  /** Optional provenance label for pickers when a provider spans several
+   *  containers (a 1Password vault name). Purely presentational. */
+  readonly group?: string;
 }
 
 export interface CredentialProvider {

--- a/packages/plugins/onepassword/src/react/OnePasswordSettings.tsx
+++ b/packages/plugins/onepassword/src/react/OnePasswordSettings.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import { useEffect, useRef, useState } from "react";
+import { useAtomRefresh, useAtomSet, useAtomValue } from "@effect/atom-react";
 import * as Exit from "effect/Exit";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { Button } from "@executor-js/react/components/button";
@@ -57,7 +57,20 @@ function VaultPicker(props: {
   onSelectedChange: (vaults: ReadonlyArray<Vault>) => void;
 }) {
   const account = props.accountName.trim();
-  const vaultsResult = useAtomValue(onepasswordVaultsAtom(props.authKind, account));
+  const vaultsAtom = onepasswordVaultsAtom(props.authKind, account);
+  const vaultsResult = useAtomValue(vaultsAtom);
+  const refreshVaults = useAtomRefresh(vaultsAtom);
+
+  // Stale-while-revalidate: with a retained value the vault list renders
+  // instantly and one background refresh per atom key picks up changes
+  // (refreshing keeps the previous value, so nothing flashes). A cold key is
+  // already fetching — refreshing it would only restart the request. The ref
+  // carries the latest cached-ness into the effect without re-running it.
+  const isCachedRef = useRef(false);
+  isCachedRef.current = AsyncResult.isSuccess(vaultsResult);
+  useEffect(() => {
+    if (isCachedRef.current) refreshVaults();
+  }, [refreshVaults]);
 
   const { vaults, isLoading, error } = AsyncResult.matchWithError(
     vaultsResult as AsyncResult.AsyncResult<

--- a/packages/plugins/onepassword/src/react/OnePasswordSettings.tsx
+++ b/packages/plugins/onepassword/src/react/OnePasswordSettings.tsx
@@ -3,6 +3,7 @@ import { useAtomSet, useAtomValue } from "@effect/atom-react";
 import * as Exit from "effect/Exit";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { Button } from "@executor-js/react/components/button";
+import { Checkbox } from "@executor-js/react/components/checkbox";
 import { Input } from "@executor-js/react/components/input";
 import { Label } from "@executor-js/react/components/label";
 import {
@@ -35,10 +36,10 @@ import {
   removeOnePasswordConfig,
   onepasswordWriteKeys,
 } from "./atoms";
-import type { RedactedOnePasswordConfig } from "../sdk/types";
+import type { RedactedOnePasswordConfig, Vault } from "../sdk/types";
 
 // ---------------------------------------------------------------------------
-// Vault picker
+// Vault picker — multi-select
 // ---------------------------------------------------------------------------
 
 const VAULT_LIST_ERROR_FALLBACK = "Failed to list vaults";
@@ -52,8 +53,8 @@ const formatVaultListError = (error: Error): string => {
 function VaultPicker(props: {
   authKind: "desktop-app" | "service-account";
   accountName: string;
-  vaultId: string;
-  onVaultSelect: (id: string, name: string) => void;
+  selected: ReadonlyArray<Vault>;
+  onSelectedChange: (vaults: ReadonlyArray<Vault>) => void;
 }) {
   const account = props.accountName.trim();
   const vaultsResult = useAtomValue(onepasswordVaultsAtom(props.authKind, account));
@@ -81,12 +82,9 @@ function VaultPicker(props: {
       }),
       onSuccess: ({ value }) => {
         const v = value.vaults;
-        const defaultVault = v[0];
-        if (
-          defaultVault &&
-          (!props.vaultId || (v.length === 1 && props.vaultId !== defaultVault.id))
-        ) {
-          queueMicrotask(() => props.onVaultSelect(defaultVault.id, defaultVault.name));
+        const onlyVault = v.length === 1 ? v[0] : undefined;
+        if (onlyVault && props.selected.length === 0) {
+          queueMicrotask(() => props.onSelectedChange([onlyVault]));
         }
         return { vaults: [...v], isLoading: false, error: null };
       },
@@ -101,34 +99,51 @@ function VaultPicker(props: {
     );
   }
 
-  const singleVault = vaults.length === 1 ? vaults[0] : null;
+  // Selected vaults missing from the loaded list (renamed, revoked, or the
+  // list failed to load while editing) stay visible so they can be unchecked.
+  const loadedIds = new Set(vaults.map((v) => v.id));
+  const stale = props.selected.filter((v) => !loadedIds.has(v.id));
+  const rows = [...vaults, ...stale];
+
+  const toggle = (vault: Vault, checked: boolean) => {
+    if (checked) {
+      if (!props.selected.some((v) => v.id === vault.id)) {
+        props.onSelectedChange([...props.selected, vault]);
+      }
+      return;
+    }
+    props.onSelectedChange(props.selected.filter((v) => v.id !== vault.id));
+  };
 
   return (
     <div className="grid gap-2">
-      {singleVault ? (
-        <div className="flex h-9 items-center rounded-md border border-input bg-muted/30 px-3 text-[13px] text-foreground">
-          <span className="truncate">{singleVault.name}</span>
-        </div>
+      {isLoading ? (
+        <p className="text-[11px] text-muted-foreground/50 py-1">Loading vaults…</p>
+      ) : rows.length === 0 ? (
+        <p className="text-[11px] text-muted-foreground/50 py-1">No vaults found.</p>
       ) : (
-        <Select
-          disabled={isLoading || vaults.length === 0}
-          value={props.vaultId}
-          onValueChange={(id) => {
-            const v = vaults.find((vault) => vault.id === id);
-            if (v) props.onVaultSelect(v.id, v.name);
-          }}
-        >
-          <SelectTrigger className="h-9 text-[13px]">
-            <SelectValue placeholder={isLoading ? "Loading…" : "Select a vault"} />
-          </SelectTrigger>
-          <SelectContent>
-            {vaults.map((v) => (
-              <SelectItem key={v.id} value={v.id}>
-                {v.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <div className="grid max-h-44 gap-0.5 overflow-y-auto rounded-md border border-input p-1">
+          {rows.map((vault) => {
+            const checked = props.selected.some((v) => v.id === vault.id);
+            return (
+              <Label
+                key={vault.id}
+                className="flex cursor-pointer items-center gap-2.5 rounded-sm px-2 py-1.5 font-normal hover:bg-muted/40"
+              >
+                <Checkbox
+                  checked={checked}
+                  onCheckedChange={(value) => toggle(vault, value === true)}
+                />
+                <span className="truncate text-[13px] text-foreground">{vault.name}</span>
+                {!loadedIds.has(vault.id) && (
+                  <span className="ml-auto shrink-0 text-[11px] text-muted-foreground/50">
+                    not found
+                  </span>
+                )}
+              </Label>
+            );
+          })}
+        </div>
       )}
       {error && (
         <div className="rounded-md border border-destructive/20 bg-destructive/5 px-2.5 py-1.5">
@@ -151,7 +166,7 @@ function ConfigDialog(props: {
   initial?: {
     authKind: string;
     accountName: string;
-    vaultId: string;
+    vaults: ReadonlyArray<Vault>;
     name: string;
   };
 }) {
@@ -160,8 +175,10 @@ function ConfigDialog(props: {
     (props.initial?.authKind as "desktop-app" | "service-account") ?? "desktop-app",
   );
   const [accountName, setAccountName] = useState(props.initial?.accountName ?? "my.1password.com");
-  const [vaultId, setVaultId] = useState(props.initial?.vaultId ?? "");
-  const [vaultName, setVaultName] = useState(props.initial?.name ?? "");
+  const [selectedVaults, setSelectedVaults] = useState<ReadonlyArray<Vault>>(
+    props.initial?.vaults ?? [],
+  );
+  const [displayName, setDisplayName] = useState(props.initial?.name ?? "");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -171,15 +188,16 @@ function ConfigDialog(props: {
     if (!isEdit) {
       setAuthKind("desktop-app");
       setAccountName("my.1password.com");
-      setVaultId("");
-      setVaultName("");
+      setSelectedVaults([]);
+      setDisplayName("");
     }
     setError(null);
     setSaving(false);
   };
 
   const handleSave = async () => {
-    if (!accountName.trim() || !vaultId.trim()) return;
+    const [firstVault, ...restVaults] = selectedVaults;
+    if (!accountName.trim() || firstVault === undefined) return;
     setSaving(true);
     setError(null);
 
@@ -191,8 +209,8 @@ function ConfigDialog(props: {
     const exit = await doConfigure({
       payload: {
         auth,
-        vaultId: vaultId.trim(),
-        name: vaultName.trim() || "1Password",
+        vaults: [firstVault, ...restVaults],
+        name: displayName.trim() || "1Password",
       },
       reactivityKeys: onepasswordWriteKeys,
     });
@@ -220,7 +238,8 @@ function ConfigDialog(props: {
             {isEdit ? "Edit 1Password" : "Connect 1Password"}
           </DialogTitle>
           <DialogDescription className="text-[13px] leading-relaxed">
-            Link a vault to resolve secrets via the 1Password desktop app or a service account.
+            Link one or more vaults to resolve secrets via the 1Password desktop app or a service
+            account.
           </DialogDescription>
         </DialogHeader>
 
@@ -262,20 +281,22 @@ function ConfigDialog(props: {
             </p>
           </div>
 
-          {/* Vault */}
+          {/* Vaults */}
           <div className="grid gap-1.5">
             <Label className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
-              Vault
+              Vaults
             </Label>
             <VaultPicker
               authKind={authKind}
               accountName={accountName}
-              vaultId={vaultId}
-              onVaultSelect={(id, name) => {
-                setVaultId(id);
-                setVaultName(name);
-              }}
+              selected={selectedVaults}
+              onSelectedChange={setSelectedVaults}
             />
+            {selectedVaults.length > 1 && (
+              <p className="text-[11px] text-muted-foreground/60 leading-relaxed">
+                Items are looked up in the checked vaults in order; the first match wins.
+              </p>
+            )}
           </div>
 
           {/* Display name */}
@@ -285,8 +306,8 @@ function ConfigDialog(props: {
             </Label>
             <Input
               placeholder="1Password"
-              value={vaultName}
-              onChange={(e) => setVaultName((e.target as HTMLInputElement).value)}
+              value={displayName}
+              onChange={(e) => setDisplayName((e.target as HTMLInputElement).value)}
               className="text-[13px] h-9"
             />
           </div>
@@ -307,7 +328,7 @@ function ConfigDialog(props: {
           <Button
             size="sm"
             onClick={handleSave}
-            disabled={!accountName.trim() || !vaultId.trim() || saving}
+            disabled={!accountName.trim() || selectedVaults.length === 0 || saving}
           >
             {saving ? "Saving…" : isEdit ? "Update" : "Connect"}
           </Button>
@@ -371,14 +392,18 @@ export default function OnePasswordSettings() {
               <span className="font-mono text-foreground/80 truncate">
                 {config.auth.kind === "desktop-app" ? config.auth.accountName : "service-account"}
               </span>
-              <span className="text-muted-foreground/60">Vault</span>
+              <span className="text-muted-foreground/60">
+                {config.vaults.length === 1 ? "Vault" : "Vaults"}
+              </span>
               <div className="flex items-center gap-2 min-w-0">
-                <span className="text-foreground/80 truncate">{config.name}</span>
+                <span className="text-foreground/80 truncate">
+                  {config.vaults.map((vault) => vault.name).join(", ")}
+                </span>
               </div>
             </div>
           ) : (
             <CardStackEntryDescription>
-              Resolve secrets from your 1Password vault.
+              Resolve secrets from your 1Password vaults.
             </CardStackEntryDescription>
           )}
         </CardStackEntryContent>
@@ -429,7 +454,7 @@ export default function OnePasswordSettings() {
                   // Service-account tokens are never surfaced (redacted); the
                   // user re-enters the token when editing that auth method.
                   accountName: config.auth.kind === "desktop-app" ? config.auth.accountName : "",
-                  vaultId: config.vaultId,
+                  vaults: config.vaults,
                   name: config.name,
                 }
               : undefined

--- a/packages/plugins/onepassword/src/react/OnePasswordSettings.tsx
+++ b/packages/plugins/onepassword/src/react/OnePasswordSettings.tsx
@@ -292,11 +292,6 @@ function ConfigDialog(props: {
               selected={selectedVaults}
               onSelectedChange={setSelectedVaults}
             />
-            {selectedVaults.length > 1 && (
-              <p className="text-[11px] text-muted-foreground/60 leading-relaxed">
-                Items are looked up in the checked vaults in order; the first match wins.
-              </p>
-            )}
           </div>
 
           {/* Display name */}

--- a/packages/plugins/onepassword/src/react/atoms.ts
+++ b/packages/plugins/onepassword/src/react/atoms.ts
@@ -33,7 +33,10 @@ export const onepasswordVaultsAtom = (
 ) =>
   OnePasswordClient.query("onepassword", "listVaults", {
     query: { authKind, account },
-    timeToLive: "30 seconds",
+    // Long retention on purpose: vault listing goes through the op CLI/SDK and
+    // is slow, so a reopened dialog renders the last-known vaults instantly
+    // and revalidates in the background instead of flashing a loading state.
+    timeToLive: "10 minutes",
     reactivityKeys: [ReactivityKey.providers],
   });
 

--- a/packages/plugins/onepassword/src/sdk/index.ts
+++ b/packages/plugins/onepassword/src/sdk/index.ts
@@ -1,12 +1,16 @@
 export {
   onepasswordPlugin,
   makeOnePasswordStore,
+  candidateSecretUris,
   type OnePasswordExtension,
   type OnePasswordPluginOptions,
   type OnePasswordStore,
 } from "./plugin";
 export {
   OnePasswordConfig,
+  LegacyOnePasswordConfig,
+  StoredOnePasswordConfig,
+  normalizeStoredConfig,
   RedactedOnePasswordConfig,
   RedactedOnePasswordAuth,
   redactConfig,

--- a/packages/plugins/onepassword/src/sdk/index.ts
+++ b/packages/plugins/onepassword/src/sdk/index.ts
@@ -1,7 +1,9 @@
 export {
   onepasswordPlugin,
   makeOnePasswordStore,
-  candidateSecretUris,
+  resolveConfiguredRef,
+  ambiguityMessage,
+  type RefResolution,
   type OnePasswordExtension,
   type OnePasswordPluginOptions,
   type OnePasswordStore,

--- a/packages/plugins/onepassword/src/sdk/plugin.test.ts
+++ b/packages/plugins/onepassword/src/sdk/plugin.test.ts
@@ -5,7 +5,9 @@ import { ProviderKey, ToolAddress, createExecutor } from "@executor-js/sdk";
 import { makeInMemoryBlobStore, pluginBlobStore } from "@executor-js/sdk/core";
 import { makeTestConfig } from "@executor-js/sdk/testing";
 
-import { candidateSecretUris, makeOnePasswordStore, onepasswordPlugin } from "./plugin";
+import { makeOnePasswordStore, onepasswordPlugin, resolveConfiguredRef } from "./plugin";
+import type { OnePasswordService } from "./service";
+import { OnePasswordError } from "./errors";
 import { OnePasswordConfig, DesktopAppAuth } from "./types";
 
 // removed: v1 routed configure/removeConfig through an explicit `ScopeId`
@@ -193,30 +195,130 @@ describe("onepassword store", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Candidate URI fan-out — the order here is the provider's resolution order.
+// Explicit ref resolution — vault-qualified refs resolve directly; bare refs
+// must locate exactly one item, and a multi-vault match is an explicit
+// ambiguity, never a precedence pick.
 // ---------------------------------------------------------------------------
 
-describe("candidateSecretUris", () => {
-  it("fans a bare item id out across the configured vaults in order", () => {
-    expect(candidateSecretUris(twoVaultConfig, "item-abc")).toEqual([
-      "op://vault-123/item-abc/credential",
-      "op://vault-456/item-abc/credential",
-    ]);
-  });
+const fakeService = (
+  itemsByVault: Readonly<Record<string, readonly { id: string; title: string }[]>>,
+  onResolve?: (uri: string) => void,
+): OnePasswordService => ({
+  resolveSecret: (uri) => {
+    onResolve?.(uri);
+    return Effect.succeed(`secret:${uri}`);
+  },
+  listVaults: () => Effect.succeed(Object.keys(itemsByVault).map((id) => ({ id, title: id }))),
+  listItems: (vaultId) => {
+    const items = itemsByVault[vaultId];
+    return items === undefined
+      ? Effect.fail(new OnePasswordError({ operation: "item listing", message: "no such vault" }))
+      : Effect.succeed(items);
+  },
+});
 
-  it("passes through an op:// URI inside a configured vault", () => {
-    expect(candidateSecretUris(twoVaultConfig, "op://vault-456/item-abc/password")).toEqual([
-      "op://vault-456/item-abc/password",
-    ]);
-  });
+describe("resolveConfiguredRef", () => {
+  it.effect("resolves a fully-qualified op:// URI in a configured vault as-is", () =>
+    Effect.gen(function* () {
+      const svc = fakeService({});
+      const result = yield* resolveConfiguredRef(
+        svc,
+        twoVaultConfig,
+        "op://vault-456/item-abc/password",
+      );
+      expect(result).toEqual({
+        kind: "resolved",
+        value: "secret:op://vault-456/item-abc/password",
+      });
+    }),
+  );
 
-  it("accepts an op:// URI addressed by vault name", () => {
-    expect(candidateSecretUris(twoVaultConfig, "op://Work/item-abc/password")).toEqual([
-      "op://Work/item-abc/password",
-    ]);
-  });
+  it.effect("appends the credential field to a picker-shaped op://vault/item ref", () =>
+    Effect.gen(function* () {
+      const svc = fakeService({});
+      const result = yield* resolveConfiguredRef(svc, twoVaultConfig, "op://vault-123/item-abc");
+      expect(result).toEqual({
+        kind: "resolved",
+        value: "secret:op://vault-123/item-abc/credential",
+      });
+    }),
+  );
 
-  it("rejects an op:// URI outside the configured vaults", () => {
-    expect(candidateSecretUris(twoVaultConfig, "op://vault-999/item-abc/password")).toEqual([]);
-  });
+  it.effect("accepts an op:// URI addressed by vault name", () =>
+    Effect.gen(function* () {
+      const svc = fakeService({});
+      const result = yield* resolveConfiguredRef(svc, twoVaultConfig, "op://Work/item/password");
+      expect(result).toEqual({ kind: "resolved", value: "secret:op://Work/item/password" });
+    }),
+  );
+
+  it.effect("reports an op:// URI outside the configured vaults", () =>
+    Effect.gen(function* () {
+      const svc = fakeService({});
+      const result = yield* resolveConfiguredRef(
+        svc,
+        twoVaultConfig,
+        "op://vault-999/item/password",
+      );
+      expect(result).toEqual({ kind: "outside-vaults" });
+    }),
+  );
+
+  it.effect("resolves a bare ref that matches exactly one item across vaults", () =>
+    Effect.gen(function* () {
+      const svc = fakeService({
+        "vault-123": [{ id: "item-1", title: "GitHub Token" }],
+        "vault-456": [{ id: "item-2", title: "Stripe Key" }],
+      });
+      const result = yield* resolveConfiguredRef(svc, twoVaultConfig, "GitHub Token");
+      expect(result).toEqual({
+        kind: "resolved",
+        value: "secret:op://vault-123/item-1/credential",
+      });
+    }),
+  );
+
+  it.effect("fails a bare ref that matches in two vaults with the vaults named", () =>
+    Effect.gen(function* () {
+      const svc = fakeService({
+        "vault-123": [{ id: "item-1", title: "GitHub Token" }],
+        "vault-456": [{ id: "item-2", title: "GitHub Token" }],
+      });
+      const result = yield* resolveConfiguredRef(svc, twoVaultConfig, "GitHub Token");
+      expect(result).toEqual({
+        kind: "ambiguous",
+        matches: [
+          {
+            vaultId: "vault-123",
+            vaultName: "Personal",
+            itemId: "item-1",
+            itemTitle: "GitHub Token",
+          },
+          { vaultId: "vault-456", vaultName: "Work", itemId: "item-2", itemTitle: "GitHub Token" },
+        ],
+      });
+    }),
+  );
+
+  it.effect("treats duplicate titles inside one vault as ambiguous too", () =>
+    Effect.gen(function* () {
+      const svc = fakeService({
+        "vault-123": [
+          { id: "item-1", title: "GitHub Token" },
+          { id: "item-9", title: "GitHub Token" },
+        ],
+        "vault-456": [],
+      });
+      const result = yield* resolveConfiguredRef(svc, twoVaultConfig, "GitHub Token");
+      expect(result.kind).toBe("ambiguous");
+    }),
+  );
+
+  it.effect("reports not-found for a bare ref matching nothing", () =>
+    Effect.gen(function* () {
+      const svc = fakeService({ "vault-123": [], "vault-456": [] });
+      const result = yield* resolveConfiguredRef(svc, twoVaultConfig, "missing");
+      expect(result).toEqual({ kind: "not-found" });
+    }),
+  );
 });

--- a/packages/plugins/onepassword/src/sdk/plugin.test.ts
+++ b/packages/plugins/onepassword/src/sdk/plugin.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { ProviderKey, ToolAddress, createExecutor } from "@executor-js/sdk";
+import { makeInMemoryBlobStore, pluginBlobStore } from "@executor-js/sdk/core";
 import { makeTestConfig } from "@executor-js/sdk/testing";
 
-import { onepasswordPlugin } from "./plugin";
+import { candidateSecretUris, makeOnePasswordStore, onepasswordPlugin } from "./plugin";
 import { OnePasswordConfig, DesktopAppAuth } from "./types";
 
 // removed: v1 routed configure/removeConfig through an explicit `ScopeId`
@@ -15,6 +16,18 @@ import { OnePasswordConfig, DesktopAppAuth } from "./types";
 // providers are discovered through `executor.providers.list()`.
 
 const ONEPASSWORD = ProviderKey.make("onepassword");
+
+const twoVaultConfig = OnePasswordConfig.make({
+  auth: DesktopAppAuth.make({
+    kind: "desktop-app",
+    accountName: "my.1password.com",
+  }),
+  vaults: [
+    { id: "vault-123", name: "Personal" },
+    { id: "vault-456", name: "Work" },
+  ],
+  name: "1Password",
+});
 
 describe("onepassword plugin", () => {
   it.effect("registers onepassword as a credential provider", () =>
@@ -36,20 +49,14 @@ describe("onepassword plugin", () => {
       const initial = yield* executor.onepassword.getConfig();
       expect(initial).toBeNull();
 
-      const config = OnePasswordConfig.make({
-        auth: DesktopAppAuth.make({
-          kind: "desktop-app",
-          accountName: "my.1password.com",
-        }),
-        vaultId: "vault-123",
-        name: "Personal",
-      });
-
-      yield* executor.onepassword.configure(config);
+      yield* executor.onepassword.configure(twoVaultConfig);
 
       const loaded = yield* executor.onepassword.getConfig();
-      expect(loaded?.vaultId).toBe("vault-123");
-      expect(loaded?.name).toBe("Personal");
+      expect(loaded?.vaults).toEqual([
+        { id: "vault-123", name: "Personal" },
+        { id: "vault-456", name: "Work" },
+      ]);
+      expect(loaded?.name).toBe("1Password");
       expect(loaded?.auth.kind).toBe("desktop-app");
 
       yield* executor.onepassword.removeConfig();
@@ -67,7 +74,7 @@ describe("onepassword plugin", () => {
       yield* executor.onepassword.configure(
         OnePasswordConfig.make({
           auth: { kind: "service-account", token: "super-secret-token" },
-          vaultId: "vault-123",
+          vaults: [{ id: "vault-123", name: "CI" }],
           name: "CI",
         }),
       );
@@ -89,8 +96,11 @@ describe("onepassword plugin", () => {
         ToolAddress.make("executor.onepassword.configure"),
         {
           auth: { kind: "desktop-app", accountName: "my.1password.com" },
-          vaultId: "vault-123",
-          name: "Personal",
+          vaults: [
+            { id: "vault-123", name: "Personal" },
+            { id: "vault-456", name: "Work" },
+          ],
+          name: "1Password",
         },
         { onElicitation: "accept-all" },
       );
@@ -100,7 +110,15 @@ describe("onepassword plugin", () => {
         yield* executor.execute(ToolAddress.make("executor.onepassword.getConfig"), {}),
       ).toMatchObject({
         ok: true,
-        data: { config: { vaultId: "vault-123", name: "Personal" } },
+        data: {
+          config: {
+            vaults: [
+              { id: "vault-123", name: "Personal" },
+              { id: "vault-456", name: "Work" },
+            ],
+            name: "1Password",
+          },
+        },
       });
 
       const removed = yield* executor.execute(
@@ -124,4 +142,81 @@ describe("onepassword plugin", () => {
       expect(status.error).toBe("Not configured");
     }),
   );
+});
+
+// ---------------------------------------------------------------------------
+// Stored-config compatibility — blobs written before multi-vault support hold
+// `{ auth, vaultId, name }`. Reads normalize that to a one-element vaults
+// array; the next save writes the current shape.
+// ---------------------------------------------------------------------------
+
+describe("onepassword store", () => {
+  const makeStore = () => {
+    const blobs = pluginBlobStore(
+      makeInMemoryBlobStore(),
+      { org: "org_test", user: null },
+      "onepassword",
+    );
+    return { blobs, store: makeOnePasswordStore(blobs) };
+  };
+
+  it.effect("upgrades a legacy single-vault blob on read", () =>
+    Effect.gen(function* () {
+      const { blobs, store } = makeStore();
+      yield* blobs.put(
+        "config",
+        JSON.stringify({
+          auth: { kind: "desktop-app", accountName: "my.1password.com" },
+          vaultId: "vault-123",
+          name: "Personal",
+        }),
+        { owner: "org" },
+      );
+
+      const config = yield* store.getConfig();
+      expect(config).toEqual({
+        auth: { kind: "desktop-app", accountName: "my.1password.com" },
+        vaults: [{ id: "vault-123", name: "Personal" }],
+        name: "Personal",
+      });
+    }),
+  );
+
+  it.effect("persists and reads back the multi-vault shape", () =>
+    Effect.gen(function* () {
+      const { store } = makeStore();
+      yield* store.saveConfig(twoVaultConfig, "org");
+      const config = yield* store.getConfig();
+      expect(config).toEqual(twoVaultConfig);
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Candidate URI fan-out — the order here is the provider's resolution order.
+// ---------------------------------------------------------------------------
+
+describe("candidateSecretUris", () => {
+  it("fans a bare item id out across the configured vaults in order", () => {
+    expect(candidateSecretUris(twoVaultConfig, "item-abc")).toEqual([
+      "op://vault-123/item-abc/credential",
+      "op://vault-456/item-abc/credential",
+    ]);
+  });
+
+  it("passes through an op:// URI inside a configured vault", () => {
+    expect(candidateSecretUris(twoVaultConfig, "op://vault-456/item-abc/password")).toEqual([
+      "op://vault-456/item-abc/password",
+    ]);
+  });
+
+  it("accepts an op:// URI addressed by vault name", () => {
+    expect(candidateSecretUris(twoVaultConfig, "op://Work/item-abc/password")).toEqual([
+      "op://Work/item-abc/password",
+    ]);
+  });
+
+  it("rejects an op:// URI outside the configured vaults", () => {
+    expect(candidateSecretUris(twoVaultConfig, "op://vault-999/item-abc/password")).toEqual([]);
+  });
 });

--- a/packages/plugins/onepassword/src/sdk/plugin.ts
+++ b/packages/plugins/onepassword/src/sdk/plugin.ts
@@ -178,48 +178,105 @@ const getServiceFromConfig = (
 ): Effect.Effect<OnePasswordService, OnePasswordError> =>
   makeOnePasswordService(resolveAuth(config.auth), { timeoutMs, preferSdk });
 
-/** Candidate `op://` URIs for an item id, in resolution order.
- *
- * A bare item id fans out to one candidate per configured vault (item ids are
- * unique across an account, so at most one resolves). A fully-qualified
- * `op://` URI is a single candidate when its vault segment names a configured
- * vault (by id or by name — 1Password accepts either), and no candidate at
- * all when it points outside the configured set. */
-export const candidateSecretUris = (
-  config: OnePasswordConfig,
-  itemId: string,
-): readonly string[] => {
-  if (!itemId.startsWith("op://")) {
-    return config.vaults.map((vault) => `op://${vault.id}/${itemId}/${CREDENTIAL_FIELD}`);
-  }
-  const match = itemId.match(/^op:\/\/([^/]+)\/.+/);
-  if (!match) return [];
-  const segment = match[1];
-  return config.vaults.some((vault) => vault.id === segment || vault.name === segment)
-    ? [itemId]
-    : [];
-};
+// ---------------------------------------------------------------------------
+// Explicit ref resolution.
+//
+// A ref is one of:
+//   - `op://vault/item/field...` — fully qualified, resolved as-is.
+//   - `op://vault/item`         — picker-shaped; the default credential field
+//                                 is appended. This is the id shape `list()`
+//                                 hands out, so every picked item permanently
+//                                 records which vault it came from.
+//   - a bare item id or title   — located by listing the configured vaults.
+//                                 Exactly one match resolves; several matches
+//                                 are an explicit ambiguity failure naming the
+//                                 vaults — never a silent precedence pick.
+// ---------------------------------------------------------------------------
 
-/** Try candidates in order; the first successful resolution wins. Fails with
- *  the last backend error when every candidate fails. */
-const resolveFirstCandidate = (
+export type RefResolution =
+  | { readonly kind: "resolved"; readonly value: string }
+  | { readonly kind: "not-found" }
+  | { readonly kind: "outside-vaults" }
+  | {
+      readonly kind: "ambiguous";
+      readonly matches: readonly {
+        readonly vaultId: string;
+        readonly vaultName: string;
+        readonly itemId: string;
+        readonly itemTitle: string;
+      }[];
+    };
+
+export const ambiguityMessage = (
+  ref: string,
+  matches: Extract<RefResolution, { kind: "ambiguous" }>["matches"],
+): string =>
+  [
+    `1Password ref "${ref}" is ambiguous: it matches`,
+    matches.map((m) => `"${m.itemTitle}" in vault "${m.vaultName}"`).join(", "),
+    `. Use op://<vaultId>/<itemId> to pick one.`,
+  ].join(" ");
+
+const isConfiguredVaultSegment = (config: OnePasswordConfig, segment: string): boolean =>
+  config.vaults.some((vault) => vault.id === segment || vault.name === segment);
+
+/** Resolve a ref against the configured vaults. Backend failures stay on the
+ *  error channel; every addressing outcome is an explicit `RefResolution`. */
+export const resolveConfiguredRef = (
   svc: OnePasswordService,
-  first: string,
-  rest: readonly string[],
-): Effect.Effect<string, OnePasswordError> =>
-  rest.reduce(
-    (acc, uri) => acc.pipe(Effect.catch(() => svc.resolveSecret(uri))),
-    svc.resolveSecret(first),
-  );
+  config: OnePasswordConfig,
+  ref: string,
+): Effect.Effect<RefResolution, OnePasswordError> => {
+  if (ref.startsWith("op://")) {
+    const segments = ref.slice("op://".length).split("/");
+    const vaultSegment = segments[0];
+    if (segments.length < 2 || vaultSegment === undefined || segments.includes("")) {
+      return Effect.succeed({ kind: "not-found" });
+    }
+    if (!isConfiguredVaultSegment(config, vaultSegment)) {
+      return Effect.succeed({ kind: "outside-vaults" });
+    }
+    const uri = segments.length === 2 ? `${ref}/${CREDENTIAL_FIELD}` : ref;
+    return svc
+      .resolveSecret(uri)
+      .pipe(Effect.map((value): RefResolution => ({ kind: "resolved", value })));
+  }
+
+  return Effect.gen(function* () {
+    const matches = (yield* Effect.forEach(config.vaults, (vault) =>
+      svc.listItems(vault.id).pipe(
+        Effect.map((items) =>
+          items
+            .filter((item) => item.id === ref || item.title === ref)
+            .map((item) => ({
+              vaultId: vault.id,
+              vaultName: vault.name,
+              itemId: item.id,
+              itemTitle: item.title,
+            })),
+        ),
+      ),
+    )).flat();
+
+    const [only, ...extra] = matches;
+    if (only === undefined) return { kind: "not-found" } as const;
+    if (extra.length > 0) return { kind: "ambiguous", matches } as const;
+
+    const value = yield* svc.resolveSecret(
+      `op://${only.vaultId}/${only.itemId}/${CREDENTIAL_FIELD}`,
+    );
+    return { kind: "resolved", value } as const;
+  });
+};
 
 // ---------------------------------------------------------------------------
 // CredentialProvider — read-only, resolves op:// URIs or vault-scoped lookups.
 //
 // v2: `get(id)` receives only an opaque `ProviderItemId` — no scope. The id is
-// either a fully-qualified `op://vault/item/field` URI or a bare item id that
-// is looked up across the configured vaults in order. The plugin's stored
-// config supplies the auth + vault bindings; the provider never writes
-// (writable: false).
+// a vault-qualified `op://` ref (what `list()` hands out) or a bare item
+// id/title that must locate exactly one item across the configured vaults.
+// The plugin's stored config supplies the auth + vault bindings; the provider
+// never writes (writable: false).
 // ---------------------------------------------------------------------------
 
 const makeProvider = (
@@ -232,19 +289,32 @@ const makeProvider = (
 
   get: (id: ProviderItemId): Effect.Effect<string | null, StorageFailure> =>
     ctx.storage.getConfig().pipe(
+      // An undecodable stored config reads as "not configured" here; the
+      // settings surface reports the decode problem.
+      Effect.catchTag("OnePasswordError", () => Effect.succeed(null)),
       Effect.flatMap((config) => {
         if (!config) return Effect.succeed(null as string | null);
 
-        const [first, ...rest] = candidateSecretUris(config, id);
-        if (first === undefined) return Effect.succeed(null as string | null);
-
         return getServiceFromConfig(config, timeoutMs, preferSdk).pipe(
-          Effect.flatMap((svc) => resolveFirstCandidate(svc, first, rest)),
-          Effect.map((v): string | null => v),
-          Effect.orElseSucceed(() => null),
+          Effect.flatMap((svc) => resolveConfiguredRef(svc, config, id)),
+          // Backend unreachability degrades to "no value", matching the other
+          // providers. Ambiguity does NOT: silently picking a vault (or
+          // silently failing) hides a real conflict, so it surfaces as a
+          // typed failure with the full explanation.
+          Effect.catch(() => Effect.succeed({ kind: "not-found" } as RefResolution)),
+          Effect.flatMap(
+            (resolution): Effect.Effect<string | null, StorageError> =>
+              resolution.kind === "ambiguous"
+                ? Effect.fail(
+                    new StorageError({
+                      message: ambiguityMessage(id, resolution.matches),
+                      cause: undefined,
+                    }),
+                  )
+                : Effect.succeed(resolution.kind === "resolved" ? resolution.value : null),
+          ),
         );
       }),
-      Effect.catch(() => Effect.succeed(null as string | null)),
     ),
 
   list: (): Effect.Effect<readonly ProviderEntry[], StorageFailure> =>
@@ -257,11 +327,13 @@ const makeProvider = (
               svc.listItems(vault.id).pipe(
                 Effect.map((items) =>
                   items.map(
+                    // Vault-qualified ids: picking an entry permanently
+                    // records which vault it came from, so identically-titled
+                    // items in different vaults can never collide.
                     (item): ProviderEntry => ({
-                      id: ProviderItemId.make(item.id),
-                      // With several vaults the vault name disambiguates
-                      // identically-titled items in pickers.
-                      name: config.vaults.length > 1 ? `${item.title} (${vault.name})` : item.title,
+                      id: ProviderItemId.make(`op://${vault.id}/${item.id}`),
+                      name: item.title,
+                      group: vault.name,
                     }),
                   ),
                 ),
@@ -347,15 +419,25 @@ const makeOnePasswordExtension = (
             message: "1Password is not configured",
           });
         }
-        const [first, ...rest] = candidateSecretUris(config, uri);
-        if (first === undefined) {
+        const svc = yield* getServiceFromConfig(config, timeoutMs, preferSdk);
+        const resolution = yield* resolveConfiguredRef(svc, config, uri);
+        if (resolution.kind === "resolved") return resolution.value;
+        if (resolution.kind === "outside-vaults") {
           return yield* new OnePasswordError({
             operation: "resolve",
             message: "1Password secret URI is outside the configured vaults",
           });
         }
-        const svc = yield* getServiceFromConfig(config, timeoutMs, preferSdk);
-        return yield* resolveFirstCandidate(svc, first, rest);
+        if (resolution.kind === "ambiguous") {
+          return yield* new OnePasswordError({
+            operation: "resolve",
+            message: ambiguityMessage(uri, resolution.matches),
+          });
+        }
+        return yield* new OnePasswordError({
+          operation: "resolve",
+          message: `1Password item "${uri}" was not found in the configured vaults`,
+        });
       }),
   };
 };

--- a/packages/plugins/onepassword/src/sdk/plugin.ts
+++ b/packages/plugins/onepassword/src/sdk/plugin.ts
@@ -20,8 +20,10 @@ import {
   OnePasswordAuth,
   OnePasswordConfig,
   RedactedOnePasswordConfig,
+  StoredOnePasswordConfig,
   Vault,
   ConnectionStatus,
+  normalizeStoredConfig,
   redactConfig,
 } from "./types";
 import { OnePasswordError } from "./errors";
@@ -42,11 +44,7 @@ const schemaToStaticToolSchema = <A, I>(schema: Schema.Decoder<A, I>): StaticToo
     I
   >;
 
-const OnePasswordConfigureInput = Schema.Struct({
-  auth: OnePasswordAuth,
-  vaultId: Schema.String,
-  name: Schema.String,
-});
+const OnePasswordConfigureInput = OnePasswordConfig;
 
 const OnePasswordConfigureOutput = Schema.Struct({
   configured: Schema.Boolean,
@@ -98,10 +96,12 @@ export type OnePasswordExtensionFailure = OnePasswordError | StorageFailure;
 // ---------------------------------------------------------------------------
 // Typed config store — single blob, JSON encoded, owner-partitioned. The
 // stored config carries the auth credential (desktop account name, or
-// service-account token) plus the selected vault. v1 keyed this by executor
+// service-account token) plus the selected vaults. v1 keyed this by executor
 // scope; v2 partitions by `owner` — the plugin-owned config row owns the
-// partition, mirroring the connection model. Blob I/O failures surface as
-// `StorageError`; decode failures stay `OnePasswordError`.
+// partition, mirroring the connection model. Reads also accept the legacy
+// single-`vaultId` shape and normalize it to the vaults array; saves always
+// write the current shape. Blob I/O failures surface as `StorageError`;
+// decode failures stay `OnePasswordError`.
 // ---------------------------------------------------------------------------
 
 export interface OnePasswordStore {
@@ -116,7 +116,7 @@ export interface OnePasswordStore {
   readonly deleteConfig: (owner: Owner) => Effect.Effect<void, StorageError>;
 }
 
-const decodeConfig = Schema.decodeUnknownEffect(Schema.fromJsonString(OnePasswordConfig));
+const decodeConfig = Schema.decodeUnknownEffect(Schema.fromJsonString(StoredOnePasswordConfig));
 
 const blobStorageError =
   (operation: string) =>
@@ -133,6 +133,7 @@ export const makeOnePasswordStore = (blobs: PluginBlobStore): OnePasswordStore =
       Effect.flatMap((raw) => {
         if (raw === null) return Effect.succeed(null);
         return decodeConfig(raw).pipe(
+          Effect.map(normalizeStoredConfig),
           Effect.mapError(
             () =>
               new OnePasswordError({
@@ -150,7 +151,7 @@ export const makeOnePasswordStore = (blobs: PluginBlobStore): OnePasswordStore =
         CONFIG_KEY,
         JSON.stringify({
           auth: config.auth,
-          vaultId: config.vaultId,
+          vaults: config.vaults,
           name: config.name,
         }),
         { owner },
@@ -177,22 +178,48 @@ const getServiceFromConfig = (
 ): Effect.Effect<OnePasswordService, OnePasswordError> =>
   makeOnePasswordService(resolveAuth(config.auth), { timeoutMs, preferSdk });
 
-const configuredVaultUri = (config: OnePasswordConfig, itemId: string): string | null => {
+/** Candidate `op://` URIs for an item id, in resolution order.
+ *
+ * A bare item id fans out to one candidate per configured vault (item ids are
+ * unique across an account, so at most one resolves). A fully-qualified
+ * `op://` URI is a single candidate when its vault segment names a configured
+ * vault (by id or by name — 1Password accepts either), and no candidate at
+ * all when it points outside the configured set. */
+export const candidateSecretUris = (
+  config: OnePasswordConfig,
+  itemId: string,
+): readonly string[] => {
   if (!itemId.startsWith("op://")) {
-    return `op://${config.vaultId}/${itemId}/${CREDENTIAL_FIELD}`;
+    return config.vaults.map((vault) => `op://${vault.id}/${itemId}/${CREDENTIAL_FIELD}`);
   }
   const match = itemId.match(/^op:\/\/([^/]+)\/.+/);
-  if (!match || match[1] !== config.vaultId) return null;
-  return itemId;
+  if (!match) return [];
+  const segment = match[1];
+  return config.vaults.some((vault) => vault.id === segment || vault.name === segment)
+    ? [itemId]
+    : [];
 };
 
+/** Try candidates in order; the first successful resolution wins. Fails with
+ *  the last backend error when every candidate fails. */
+const resolveFirstCandidate = (
+  svc: OnePasswordService,
+  first: string,
+  rest: readonly string[],
+): Effect.Effect<string, OnePasswordError> =>
+  rest.reduce(
+    (acc, uri) => acc.pipe(Effect.catch(() => svc.resolveSecret(uri))),
+    svc.resolveSecret(first),
+  );
+
 // ---------------------------------------------------------------------------
-// CredentialProvider — read-only, resolves op:// URIs or vaultId-based lookups.
+// CredentialProvider — read-only, resolves op:// URIs or vault-scoped lookups.
 //
 // v2: `get(id)` receives only an opaque `ProviderItemId` — no scope. The id is
 // either a fully-qualified `op://vault/item/field` URI or a bare item id that
-// the stored config's vault scopes. The plugin's stored config supplies the
-// auth + vault binding; the provider never writes (writable: false).
+// is looked up across the configured vaults in order. The plugin's stored
+// config supplies the auth + vault bindings; the provider never writes
+// (writable: false).
 // ---------------------------------------------------------------------------
 
 const makeProvider = (
@@ -208,11 +235,11 @@ const makeProvider = (
       Effect.flatMap((config) => {
         if (!config) return Effect.succeed(null as string | null);
 
-        const uri = configuredVaultUri(config, id);
-        if (uri === null) return Effect.succeed(null as string | null);
+        const [first, ...rest] = candidateSecretUris(config, id);
+        if (first === undefined) return Effect.succeed(null as string | null);
 
         return getServiceFromConfig(config, timeoutMs, preferSdk).pipe(
-          Effect.flatMap((svc) => svc.resolveSecret(uri)),
+          Effect.flatMap((svc) => resolveFirstCandidate(svc, first, rest)),
           Effect.map((v): string | null => v),
           Effect.orElseSucceed(() => null),
         );
@@ -225,10 +252,23 @@ const makeProvider = (
       Effect.flatMap((config) => {
         if (!config) return Effect.succeed([] as readonly ProviderEntry[]);
         return getServiceFromConfig(config, timeoutMs, preferSdk).pipe(
-          Effect.flatMap((svc) => svc.listItems(config.vaultId)),
-          Effect.map((items): readonly ProviderEntry[] =>
-            items.map((item) => ({ id: ProviderItemId.make(item.id), name: item.title })),
+          Effect.flatMap((svc) =>
+            Effect.forEach(config.vaults, (vault) =>
+              svc.listItems(vault.id).pipe(
+                Effect.map((items) =>
+                  items.map(
+                    (item): ProviderEntry => ({
+                      id: ProviderItemId.make(item.id),
+                      // With several vaults the vault name disambiguates
+                      // identically-titled items in pickers.
+                      name: config.vaults.length > 1 ? `${item.title} (${vault.name})` : item.title,
+                    }),
+                  ),
+                ),
+              ),
+            ),
           ),
+          Effect.map((groups): readonly ProviderEntry[] => groups.flat()),
         );
       }),
       Effect.catch(() => Effect.succeed([] as readonly ProviderEntry[])),
@@ -270,11 +310,19 @@ const makeOnePasswordExtension = (
           });
         }
         const svc = yield* getServiceFromConfig(config, timeoutMs, preferSdk);
-        const vaults = yield* svc.listVaults();
-        const vault = vaults.find((v) => v.id === config.vaultId);
+        const live = yield* svc.listVaults();
+        const liveById = new Map(live.map((v) => [v.id, v.title]));
+        const missing = config.vaults.filter((vault) => !liveById.has(vault.id));
         return ConnectionStatus.make({
           connected: true,
-          vaultName: vault?.title,
+          vaultNames: config.vaults.map((vault) => liveById.get(vault.id) ?? vault.name),
+          ...(missing.length > 0
+            ? {
+                error: `Configured vaults not found: ${missing
+                  .map((vault) => vault.name)
+                  .join(", ")}`,
+              }
+            : {}),
         });
       }),
 
@@ -299,15 +347,15 @@ const makeOnePasswordExtension = (
             message: "1Password is not configured",
           });
         }
-        const scopedUri = configuredVaultUri(config, uri);
-        if (scopedUri === null) {
+        const [first, ...rest] = candidateSecretUris(config, uri);
+        if (first === undefined) {
           return yield* new OnePasswordError({
             operation: "resolve",
-            message: "1Password secret URI is outside the configured vault",
+            message: "1Password secret URI is outside the configured vaults",
           });
         }
         const svc = yield* getServiceFromConfig(config, timeoutMs, preferSdk);
-        return yield* svc.resolveSecret(scopedUri);
+        return yield* resolveFirstCandidate(svc, first, rest);
       }),
   };
 };
@@ -345,7 +393,7 @@ export const onepasswordPlugin = definePlugin((options?: OnePasswordPluginOption
           tool({
             name: "status",
             description:
-              "Check whether the 1Password credential provider is configured and can reach its selected vault. This returns status only, never secret values.",
+              "Check whether the 1Password credential provider is configured and can reach its selected vaults. This returns status only, never secret values.",
             outputSchema: OnePasswordStatusOutputStd,
             execute: () => Effect.map(self.status(), ToolResult.ok),
           }),
@@ -368,7 +416,7 @@ export const onepasswordPlugin = definePlugin((options?: OnePasswordPluginOption
           tool({
             name: "configure",
             description:
-              "Configure the 1Password credential provider for the acting owner. Use desktop-app auth for local biometric access, or service-account auth with the token. The token is stored in the plugin's owner-partitioned config and never surfaced again.",
+              "Configure the 1Password credential provider for the acting owner with one or more vaults. Use desktop-app auth for local biometric access, or service-account auth with the token. The token is stored in the plugin's owner-partitioned config and never surfaced again.",
             annotations: {
               requiresApproval: true,
               approvalDescription: "Configure the 1Password credential provider",
@@ -377,7 +425,7 @@ export const onepasswordPlugin = definePlugin((options?: OnePasswordPluginOption
             outputSchema: OnePasswordConfigureOutputStd,
             execute: (input) =>
               Effect.as(
-                self.configure({ auth: input.auth, vaultId: input.vaultId, name: input.name }),
+                self.configure({ auth: input.auth, vaults: input.vaults, name: input.name }),
                 ToolResult.ok({ configured: true }),
               ),
           }),

--- a/packages/plugins/onepassword/src/sdk/types.ts
+++ b/packages/plugins/onepassword/src/sdk/types.ts
@@ -40,8 +40,9 @@ export type Vault = typeof Vault.Type;
 
 export const OnePasswordConfig = Schema.Struct({
   auth: OnePasswordAuth,
-  /** Vaults to scope operations to, in resolution-precedence order: bare item
-   *  ids are looked up vault by vault and the first hit wins. */
+  /** Vaults to scope operations to. Order is presentational only: refs are
+   *  vault-qualified, and a bare ref that matches in more than one vault is an
+   *  explicit ambiguity failure, never a precedence pick. */
   vaults: Schema.NonEmptyArray(Vault),
   /** Human label for the whole connection */
   name: Schema.String,

--- a/packages/plugins/onepassword/src/sdk/types.ts
+++ b/packages/plugins/onepassword/src/sdk/types.ts
@@ -25,17 +25,50 @@ export const OnePasswordAuth = Schema.Union([DesktopAppAuth, ServiceAccountAuth]
 export type OnePasswordAuth = typeof OnePasswordAuth.Type;
 
 // ---------------------------------------------------------------------------
+// Vault
+// ---------------------------------------------------------------------------
+
+export const Vault = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+});
+export type Vault = typeof Vault.Type;
+
+// ---------------------------------------------------------------------------
 // Stored config — persisted via KV
 // ---------------------------------------------------------------------------
 
 export const OnePasswordConfig = Schema.Struct({
   auth: OnePasswordAuth,
-  /** Vault to scope operations to */
-  vaultId: Schema.String,
-  /** Human label */
+  /** Vaults to scope operations to, in resolution-precedence order: bare item
+   *  ids are looked up vault by vault and the first hit wins. */
+  vaults: Schema.NonEmptyArray(Vault),
+  /** Human label for the whole connection */
   name: Schema.String,
 });
 export type OnePasswordConfig = typeof OnePasswordConfig.Type;
+
+/** Pre-multi-vault stored shape: a single vault id whose display name doubled
+ *  as the connection label. Still accepted on read; every save writes the
+ *  current shape, so a config row upgrades the first time it is re-saved. */
+export const LegacyOnePasswordConfig = Schema.Struct({
+  auth: OnePasswordAuth,
+  vaultId: Schema.String,
+  name: Schema.String,
+});
+export type LegacyOnePasswordConfig = typeof LegacyOnePasswordConfig.Type;
+
+export const StoredOnePasswordConfig = Schema.Union([OnePasswordConfig, LegacyOnePasswordConfig]);
+export type StoredOnePasswordConfig = typeof StoredOnePasswordConfig.Type;
+
+export const normalizeStoredConfig = (stored: StoredOnePasswordConfig): OnePasswordConfig =>
+  "vaultId" in stored
+    ? {
+        auth: stored.auth,
+        vaults: [{ id: stored.vaultId, name: stored.name }],
+        name: stored.name,
+      }
+    : stored;
 
 // ---------------------------------------------------------------------------
 // Redacted config — what `getConfig` returns to agents / the UI. The
@@ -56,7 +89,7 @@ export const RedactedOnePasswordAuth = Schema.Union([
 
 export const RedactedOnePasswordConfig = Schema.Struct({
   auth: RedactedOnePasswordAuth,
-  vaultId: Schema.String,
+  vaults: Schema.NonEmptyArray(Vault),
   name: Schema.String,
 });
 export type RedactedOnePasswordConfig = typeof RedactedOnePasswordConfig.Type;
@@ -67,19 +100,9 @@ export const redactConfig = (config: OnePasswordConfig): RedactedOnePasswordConf
     config.auth.kind === "desktop-app"
       ? { kind: "desktop-app", accountName: config.auth.accountName }
       : { kind: "service-account" },
-  vaultId: config.vaultId,
+  vaults: config.vaults,
   name: config.name,
 });
-
-// ---------------------------------------------------------------------------
-// Vault
-// ---------------------------------------------------------------------------
-
-export const Vault = Schema.Struct({
-  id: Schema.String,
-  name: Schema.String,
-});
-export type Vault = typeof Vault.Type;
 
 // ---------------------------------------------------------------------------
 // Connection status
@@ -87,7 +110,7 @@ export type Vault = typeof Vault.Type;
 
 export const ConnectionStatus = Schema.Struct({
   connected: Schema.Boolean,
-  vaultName: Schema.optional(Schema.String),
+  vaultNames: Schema.optional(Schema.Array(Schema.String)),
   error: Schema.optional(Schema.String),
 });
 export type ConnectionStatus = typeof ConnectionStatus.Type;

--- a/packages/react/src/api/atoms.tsx
+++ b/packages/react/src/api/atoms.tsx
@@ -132,7 +132,10 @@ export const providersAtom = ExecutorApiClient.query("providers", "list", {
 export const providerItemsAtom = (key: ProviderKey) =>
   ExecutorApiClient.query("providers", "items", {
     params: { key },
-    timeToLive: "30 seconds",
+    // Long retention on purpose: external-provider listings (1Password) are
+    // slow, so pickers render the last-known list instantly and revalidate in
+    // the background on mount instead of flashing a loading state each open.
+    timeToLive: "10 minutes",
     reactivityKeys: [ReactivityKey.providers],
   });
 

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -106,7 +106,14 @@ import {
 import { Input } from "./input";
 import { Label } from "./label";
 import { RadioGroup, RadioGroupItem } from "./radio-group";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./select";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "./combobox";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs";
 
 // ---------------------------------------------------------------------------
@@ -335,43 +342,64 @@ function PasteCredentialInputs(props: {
   );
 }
 
+type OnePasswordItem = {
+  readonly id: ProviderItemId;
+  readonly name: string;
+  readonly group?: string;
+};
+
 function OnePasswordItemSelect(props: {
   readonly value: string;
   readonly onChange: (value: string) => void;
 }) {
   const itemsResult = useAtomValue(providerItemsAtom(ONEPASSWORD_PROVIDER));
   const state = AsyncResult.matchWithError(
-    itemsResult as AsyncResult.AsyncResult<
-      readonly { readonly id: ProviderItemId; readonly name: string }[],
-      Error
-    >,
+    itemsResult as AsyncResult.AsyncResult<readonly OnePasswordItem[], Error>,
     {
       onInitial: () => ({
-        items: [] as readonly {
-          readonly id: ProviderItemId;
-          readonly name: string;
-        }[],
+        items: [] as readonly OnePasswordItem[],
         loading: true,
         error: null as string | null,
       }),
       onError: () => ({
-        items: [] as readonly {
-          readonly id: ProviderItemId;
-          readonly name: string;
-        }[],
+        items: [] as readonly OnePasswordItem[],
         loading: false,
         error: "Failed to load 1Password items",
       }),
       onDefect: () => ({
-        items: [] as readonly {
-          readonly id: ProviderItemId;
-          readonly name: string;
-        }[],
+        items: [] as readonly OnePasswordItem[],
         loading: false,
         error: "Failed to load 1Password items",
       }),
       onSuccess: ({ value }) => ({ items: value, loading: false, error: null }),
     },
+  );
+
+  const stateItems = state.items;
+  const sorted = useMemo(
+    () =>
+      [...stateItems].sort(
+        (a, b) => a.name.localeCompare(b.name) || (a.group ?? "").localeCompare(b.group ?? ""),
+      ),
+    [stateItems],
+  );
+  const byId = useMemo(() => {
+    const map = new Map<string, OnePasswordItem>();
+    for (const item of sorted) map.set(String(item.id), item);
+    return map;
+  }, [sorted]);
+  const ids = useMemo(() => sorted.map((item) => String(item.id)), [sorted]);
+
+  const filter = useCallback(
+    (id: string, query: string) => {
+      const needle = query.trim().toLowerCase();
+      if (needle === "") return true;
+      const item = byId.get(id);
+      return [item?.name ?? "", item?.group ?? ""].some((part) =>
+        part.toLowerCase().includes(needle),
+      );
+    },
+    [byId],
   );
 
   if (state.loading) {
@@ -386,18 +414,36 @@ function OnePasswordItemSelect(props: {
 
   return (
     <div className="space-y-1" data-ph-block>
-      <Select value={props.value} onValueChange={props.onChange}>
-        <SelectTrigger>
-          <SelectValue placeholder="Select secret" />
-        </SelectTrigger>
-        <SelectContent>
-          {state.items.map((item) => (
-            <SelectItem key={String(item.id)} value={String(item.id)}>
-              {item.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      <Combobox
+        items={ids}
+        value={props.value.length > 0 ? props.value : null}
+        filter={filter}
+        limit={100}
+        itemToStringLabel={(id: string) => byId.get(id)?.name ?? id}
+        onValueChange={(id) => {
+          if (id !== null) props.onChange(id);
+        }}
+      >
+        <ComboboxInput placeholder="Search 1Password items…" className="w-full" />
+        <ComboboxContent>
+          <ComboboxEmpty>No items match.</ComboboxEmpty>
+          <ComboboxList>
+            {(id: string) => {
+              const item = byId.get(id);
+              return (
+                <ComboboxItem key={id} value={id}>
+                  <span className="min-w-0 flex-1 truncate">{item?.name ?? id}</span>
+                  {item?.group && (
+                    <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
+                      {item.group}
+                    </span>
+                  )}
+                </ComboboxItem>
+              );
+            }}
+          </ComboboxList>
+        </ComboboxContent>
+      </Combobox>
     </div>
   );
 }

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import { useAtomRefresh, useAtomSet, useAtomValue } from "@effect/atom-react";
 import * as Exit from "effect/Exit";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import {
@@ -352,7 +352,20 @@ function OnePasswordItemSelect(props: {
   readonly value: string;
   readonly onChange: (value: string) => void;
 }) {
-  const itemsResult = useAtomValue(providerItemsAtom(ONEPASSWORD_PROVIDER));
+  const itemsAtom = providerItemsAtom(ONEPASSWORD_PROVIDER);
+  const itemsResult = useAtomValue(itemsAtom);
+  const refreshItems = useAtomRefresh(itemsAtom);
+
+  // Stale-while-revalidate: with a retained value the list renders instantly
+  // and one background refresh per mount picks up vault changes (refreshing
+  // keeps the previous value, so nothing flashes). A cold mount is already
+  // fetching — refreshing it would only restart the request. The ref carries
+  // the latest cached-ness into the effect without re-running it.
+  const isCachedRef = useRef(false);
+  isCachedRef.current = AsyncResult.isSuccess(itemsResult);
+  useEffect(() => {
+    if (isCachedRef.current) refreshItems();
+  }, [refreshItems]);
   const state = AsyncResult.matchWithError(
     itemsResult as AsyncResult.AsyncResult<readonly OnePasswordItem[], Error>,
     {


### PR DESCRIPTION
The 1Password credential provider was bound to exactly one vault. This makes the vault binding a set, with explicit per-vault addressing.

- Config stores a `vaults` array selected with checkboxes. The old single-`vaultId` shape is still read and normalizes to a one-vault list; the next save writes the new shape.
- Every picked item stores a vault-qualified `op://<vault>/<item>` ref, so identically-titled items in different vaults can never collide. There is no precedence order.
- A bare item id or name resolves only when it matches exactly one item across the selected vaults. A name that exists in more than one place fails with an error naming the matching vaults.
- The item picker is now a searchable combobox that shows each item's vault; entries carry a new optional `group` label on the generic provider-items surface.
- Vault and item listings are served stale-while-revalidate: reopening a picker renders the last-known list instantly and refreshes in the background instead of flashing a loading state.
- `status` reports `vaultNames` and flags configured vaults the account can no longer see.

## Demo

All data below is synthetic (recorded against a stubbed `op` CLI).

![multi-vault connect and explicit item picker](https://raw.githubusercontent.com/UsefulSoftwareCo/executor/e2e-media/onepassword-multi-vault-demo-c7da7a2c.gif)

Vault selection:

![vault multi-select](https://raw.githubusercontent.com/UsefulSoftwareCo/executor/e2e-media/onepassword-vault-picker-7e6afdbd.png)

Item search with per-vault provenance — the same title in two vaults stays unambiguous:

![searchable item picker with vault labels](https://raw.githubusercontent.com/UsefulSoftwareCo/executor/e2e-media/onepassword-item-picker-48028ad0.png)

## Testing

Plugin unit suite: config round-trip, legacy-blob upgrade, explicit resolution (qualified refs, unique bare match, cross-vault and same-vault ambiguity, not-found). Verified live against a local 1Password with two vaults: connect, edit, picker search, and instant reopen after the stale-while-revalidate change.