### PR TITLE
Fix sdk root imports in file-secrets and keychain plugins

### DIFF
--- a/.changeset/fix-plugin-sdk-root-imports.md
+++ b/.changeset/fix-plugin-sdk-root-imports.md
@@ -1,0 +1,6 @@
+---
+"@executor-js/plugin-file-secrets": patch
+"@executor-js/plugin-keychain": patch
+---
+
+Import plugin-authoring symbols from `@executor-js/sdk/core` instead of the package root. The published root is the Promise surface and does not export `StorageError`, `definePlugin`, `PluginCtx`, or `Plugin`, so both packages failed to load when installed from npm.

--- a/packages/plugins/file-secrets/src/index.ts
+++ b/packages/plugins/file-secrets/src/index.ts
@@ -9,7 +9,7 @@ import {
   ProviderKey,
   StorageError,
   type CredentialProvider,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 
 // ---------------------------------------------------------------------------
 // Auth file location

--- a/packages/plugins/file-secrets/src/promise.ts
+++ b/packages/plugins/file-secrets/src/promise.ts
@@ -1,4 +1,4 @@
-import { type Plugin } from "@executor-js/sdk";
+import { type Plugin } from "@executor-js/sdk/core";
 
 import {
   fileSecretsPlugin as fileSecretsPluginEffect,
@@ -9,7 +9,7 @@ import {
 export type { FileSecretsPluginConfig } from "./index";
 
 // Explicit return type so the emitted dist/promise.d.ts references
-// `import("@executor-js/sdk").Plugin` rather than the Promise-surface
+// `import("@executor-js/sdk/core").Plugin` rather than the Promise-surface
 // root specifier (which doesn't re-export Plugin).
 export const fileSecretsPlugin = (
   config?: FileSecretsPluginConfig,

--- a/packages/plugins/keychain/src/index.ts
+++ b/packages/plugins/keychain/src/index.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 
-import { definePlugin, type CredentialProvider, type PluginCtx } from "@executor-js/sdk";
+import { definePlugin, type CredentialProvider, type PluginCtx } from "@executor-js/sdk/core";
 
 import {
   deletePassword,

--- a/packages/plugins/keychain/src/promise.ts
+++ b/packages/plugins/keychain/src/promise.ts
@@ -1,4 +1,4 @@
-import { type Plugin } from "@executor-js/sdk";
+import { type Plugin } from "@executor-js/sdk/core";
 
 import {
   keychainPlugin as keychainPluginEffect,
@@ -9,7 +9,7 @@ import {
 export type { KeychainPluginConfig } from "./index";
 
 // Explicit return type so the emitted dist/promise.d.ts references
-// `import("@executor-js/sdk").Plugin` rather than the Promise-surface
+// `import("@executor-js/sdk/core").Plugin` rather than the Promise-surface
 // root specifier (which doesn't re-export Plugin).
 export const keychainPlugin = (
   config?: KeychainPluginConfig,

--- a/packages/plugins/keychain/src/provider.ts
+++ b/packages/plugins/keychain/src/provider.ts
@@ -5,7 +5,7 @@ import {
   ProviderKey,
   type CredentialProvider,
   type ProviderItemId,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 
 import type { KeychainError } from "./errors";
 import { getPassword, setPassword, deletePassword } from "./keyring";

--- a/scripts/smoke-test-packed.ts
+++ b/scripts/smoke-test-packed.ts
@@ -78,6 +78,13 @@ type SmokeFailure = {
 
 const PRIVATE_PACKAGE_RE = /Cannot find package '(@executor-js\/[^']+)'/;
 
+// `import { X } from "@executor-js/sdk"` where the published entry doesn't
+// export `X` — the packed bundle references a symbol that only exists on a
+// different subpath (or in the dev-time workspace view). This is a bundle
+// bug, never a missing-peer environment issue, so it's a hard failure.
+const MISSING_EXPORT_RE =
+  /The requested module '([^']+)' does not provide an export named '([^']+)'/;
+
 const firstMeaningfulLine = (stderr: string): string => {
   const lines = stderr
     .split("\n")
@@ -180,6 +187,17 @@ const smokeTestPackage = async (
           reason: `published bundle imports private workspace package '${offending}'`,
         });
         console.log(`  FAIL ${spec} — references private '${offending}'`);
+        continue;
+      }
+      const missingExportMatch = stderr.match(MISSING_EXPORT_RE);
+      if (missingExportMatch) {
+        const [, module, symbol] = missingExportMatch;
+        failures.push({
+          pkg: pkg.name,
+          subpath,
+          reason: `published '${module}' does not export '${symbol}'`,
+        });
+        console.log(`  FAIL ${spec} — '${module}' does not export '${symbol}'`);
         continue;
       }
       const peerMatch =


### PR DESCRIPTION
Fixes #1833

`plugin-file-secrets` and `plugin-keychain` imported `StorageError`, `definePlugin`, `PluginCtx`, and `Plugin` from the `@executor-js/sdk` root. In the workspace, the root and `/core` both resolve to `src/index.ts`, so everything worked in-repo. The published root is the Promise surface (`dist/index.js`), which does not export those symbols, so both packages failed to load when installed from npm.

## Change

- Import the plugin-authoring symbols from `@executor-js/sdk/core`, the same way `plugin-onepassword` does. This covers all five affected files; `ProviderKey`, `ProviderItemId`, and `CredentialProvider` move with them since `/core` exports the full Effect surface.
- Harden `scripts/smoke-test-packed.ts`: a `does not provide an export named` failure is now a hard FAIL. It was previously downgraded to a skip, which is how this shipped past the release smoke gate.

A browser e2e is meaningless for a packaging bug — nothing user-visible changes in the app. The repro below is at the published surface, the way an npm consumer resolves the packages.

## Red (before the fix)

Packed all public packages via `publish-packages.ts --dry-run`, installed the two plugin tarballs into a fresh fixture with npm `overrides` pinning every `@executor-js/*` dep to its local tarball, then imported with node:

```
== import plugin-file-secrets
SyntaxError: The requested module '@executor-js/sdk' does not provide an export named 'StorageError'
== import plugin-keychain
SyntaxError: The requested module '@executor-js/sdk' does not provide an export named 'StorageError'
```

## Green (after the fix)

Same pack-and-install fixture:

```
== import plugin-file-secrets
OK exports: fileSecretsPlugin
== import plugin-keychain
OK exports: keychainPlugin
== import /core subpaths
OK core subpaths
```

Gates: `format:check`, `lint`, `typecheck`, and package tests for both plugins (18 + 3) all pass.