### PR TITLE
Deflake dialog outside-dismiss scenario

### DIFF
--- a/e2e/scenarios/dialog-outside-dismiss.test.ts
+++ b/e2e/scenarios/dialog-outside-dismiss.test.ts
@@ -34,6 +34,18 @@ scenario(
       // The overlay covers the whole viewport and the dialog panel is centered,
       // so the top-left corner is always outside the panel.
       const clickOutside = async () => {
+        // "Visible" is not "listening": Radix arms outside-pointerdown
+        // dismissal via a document listener it attaches in a passive effect
+        // plus a 0ms timer after the content mounts (DismissableLayer). A
+        // busy renderer can service the injected click ahead of that pending
+        // timer, and a pre-arming pointerdown is never seen at all — the
+        // field-free confirm then stays open and the detach wait times out.
+        // Synchronize on the page's own task queue instead of sleeping: the
+        // modal scroll lock proves the effect flush ran (the arming timer is
+        // queued by then), and one 0ms timer round-trip proves that timer
+        // fired, because same-source timers run in FIFO order.
+        await page.waitForFunction(() => document.body.hasAttribute("data-scroll-locked"));
+        await page.evaluate(() => new Promise((resolve) => setTimeout(resolve, 0)));
         await page.mouse.click(8, 8);
         // Dismissal is synchronous with the pointer event; this beat only gives
         // a wrongly-dismissed dialog time to actually unmount before the


### PR DESCRIPTION
The scenario failed its last step on every selfhost CI run since the merge (main and four PR branches, all at the same assertion): the field-free revoke confirm stayed open after the outside click, and the detach wait timed out.

The trace from a failing run shows the click was dispatched 2ms after the dialog reported visible, and the DOM afterwards is byte-identical — the pointerdown was never seen by anything. "Visible" is not "listening": Radix arms outside-pointerdown dismissal via a document listener attached in a passive effect plus a 0ms timer after the content mounts. At the click moment the body already carried the modal scroll lock (the effect flush had run), so only that timer was pending; a busy renderer services injected input ahead of pending timers, and a pre-arming pointerdown simply vanishes. The test clicked once, so a missed click meant open forever. The keep-open steps could also pass vacuously the same way.

The fix synchronizes instead of sleeping: wait for the modal scroll lock (proves the arming timer is queued), then one 0ms timer round-trip through the page (same-source timers are FIFO, so the arming timer has fired), then click. Applies to all three outside clicks, which also makes the keep-open assertions provably non-vacuous. Assertions unchanged.

Not reproducible on an idle 18-core machine after 40+ attempts, including CPU throttling and saturation — the inversion needs a backlogged renderer main thread. An instrumented run that timestamps listener attachment confirmed the synchronization orders every click after arming (30/30 under saturation). Fixed scenario 10x green, plus 5x green under CPU saturation. Test-only change.