### PR TITLE
Release Codex plugin integrations as a patch

### DIFF
--- a/.changeset/codex-plugins-as-integrations.md
+++ b/.changeset/codex-plugins-as-integrations.md
@@ -1,7 +1,7 @@
 ---
-"executor": minor
-"@executor-js/plugin-mcp": minor
-"@executor-js/sdk": minor
+"executor": patch
+"@executor-js/plugin-mcp": patch
+"@executor-js/sdk": patch
 ---
 
 Add locally installed OpenAI Codex plugins as one-click integrations: Messages


### PR DESCRIPTION
The changeset added in #1858 declared `minor`, which took the CLI to 1.7.0 in the pending Version Packages PR. Staying on the patch line instead: this drops it back to 1.6.4.

Nothing has published yet — npm is still on 1.6.3 and #1832 is unmerged — so this only changes the pending version, not a released one.

Changeset text only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)