### PR TITLE
Open cap-eviction sessions at the build-slot cap

### DIFF
--- a/e2e/cloud/mcp-session-cap-eviction.test.ts
+++ b/e2e/cloud/mcp-session-cap-eviction.test.ts
@@ -151,6 +151,16 @@ scenario(
       // of them run any work, so every one is immediately eviction-eligible —
       // crossing the cap must pick at least one and tear it down through its
       // own stub.
+      //
+      // Concurrency stays at MAX_CONCURRENT_BUILDS (session-build-semaphore.ts,
+      // currently 4), not higher. A wider burst parks the surplus cold inits in
+      // the build-slot queue INSIDE the DO's `blockConcurrencyWhile` window;
+      // on a CI runner where four concurrent builds already saturate the CPU,
+      // queue wait plus build time crosses workerd's budget and the platform
+      // cancels the init and resets the DO ("blockConcurrencyWhile() ...
+      // waited for too long"), failing `initialize` with no session id. The
+      // burst width is incidental here — what this scenario pins is cap
+      // eviction, which only needs the TOTAL session count to cross the cap.
       const sessionIds = yield* Effect.forEach(
         Array.from({ length: SESSIONS_TO_OPEN }, (_, index) => index),
         (index) =>
@@ -159,7 +169,7 @@ scenario(
               openedSessionIds.push(sessionId);
             }),
           ),
-        { concurrency: 8 },
+        { concurrency: 4 },
       );
 
       expect(sessionIds.length, "every session opened").toBe(SESSIONS_TO_OPEN);


### PR DESCRIPTION
The cap-eviction scenario fails on nearly every main run since it landed: `openSession (session-4): no mcp-session-id header`. The scenario and the session-build semaphore merged within minutes of each other and were never tested together — the scenario's last green run predates the semaphore.

Mechanism, from the failed shard's boot.log: the scenario opened cold sessions 8 at a time, but only 4 build slots exist, so the surplus inits sat queued inside the Durable Object's `blockConcurrencyWhile` window. On a CI runner where four concurrent builds already saturate the CPU, queue wait plus build time crossed workerd's budget — `blockConcurrencyWhile() ... waited for too long`, the platform reset the DO, and `initialize` returned without a session id.

The burst width is incidental to what the scenario pins (cap eviction through a real cross-DO request, which only needs the total session count to cross the cap), so it now opens sessions at the build-slot cap. No assertions changed.

The queue-inside-`blockConcurrencyWhile` interaction itself is real but bounded in production: 10s max queue wait plus a 1-2s build fits the 30s budget. It only overflows when builds themselves crawl, which is the starved-CI condition.

Verified: the scenario passes locally with the change.