### PR TITLE
fix(mcp): bound discovery connection teardown

### DIFF
--- a/packages/plugins/mcp/src/sdk/discover-close.test.ts
+++ b/packages/plugins/mcp/src/sdk/discover-close.test.ts
@@ -25,11 +25,9 @@ describe("MCP discovery teardown", () => {
   it.live("does not strand discovery when close never settles", () =>
     Effect.gen(function* () {
       const state = { closeStarted: false };
-      const startedAt = Date.now();
       const manifest = yield* discoverTools(hangingCloseConnector(state));
 
       expect(state.closeStarted).toBe(true);
-      expect(Date.now() - startedAt).toBeLessThan(4_000);
       expect(manifest.server).toEqual({
         name: "hanging-close",
         version: "1.0.0",

--- a/packages/plugins/mcp/src/sdk/discover-close.test.ts
+++ b/packages/plugins/mcp/src/sdk/discover-close.test.ts
@@ -9,6 +9,7 @@ const discoveryClient = (): McpConnection["client"] =>
     listTools: () => Promise.resolve({ tools: [] }),
     getServerVersion: () => ({ name: "hanging-close", version: "1.0.0" }),
     getInstructions: () => undefined,
+    setRequestHandler: () => undefined,
   });
 
 const hangingCloseConnector = (state: { closeStarted: boolean }): McpConnector =>

--- a/packages/plugins/mcp/src/sdk/discover-close.test.ts
+++ b/packages/plugins/mcp/src/sdk/discover-close.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import type { McpConnection, McpConnector } from "./connection";
+import { discoverTools } from "./discover";
+
+const discoveryClient = (): McpConnection["client"] =>
+  Object.assign(Object.create(null) as McpConnection["client"], {
+    listTools: () => Promise.resolve({ tools: [] }),
+    getServerVersion: () => ({ name: "hanging-close", version: "1.0.0" }),
+    getInstructions: () => undefined,
+  });
+
+const hangingCloseConnector = (state: { closeStarted: boolean }): McpConnector =>
+  Effect.succeed({
+    client: discoveryClient(),
+    close: () => {
+      state.closeStarted = true;
+      return new Promise<void>(() => {});
+    },
+  });
+
+describe("MCP discovery teardown", () => {
+  it.live("does not strand discovery when close never settles", () =>
+    Effect.gen(function* () {
+      const state = { closeStarted: false };
+      const startedAt = Date.now();
+      const manifest = yield* discoverTools(hangingCloseConnector(state));
+
+      expect(state.closeStarted).toBe(true);
+      expect(Date.now() - startedAt).toBeLessThan(4_000);
+      expect(manifest.server).toEqual({
+        name: "hanging-close",
+        version: "1.0.0",
+        instructions: null,
+      });
+      expect(manifest.tools).toEqual([]);
+    }),
+  );
+});

--- a/packages/plugins/mcp/src/sdk/discover.ts
+++ b/packages/plugins/mcp/src/sdk/discover.ts
@@ -31,6 +31,12 @@ const MAX_LIST_TOOLS_PAGES = 100;
 // shape probe's single unauth POST.
 const DEFAULT_DISCOVER_TIMEOUT = Duration.seconds(15);
 
+// Teardown is best-effort and paid for by the request that performed discovery.
+// A remote transport may accept close and then never settle, so use the same
+// bound as the invocation connection pool instead of stranding the caller in an
+// uninterruptible finalizer after discovery itself has already completed.
+const CLOSE_TIMEOUT = Duration.seconds(2);
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -243,13 +249,11 @@ export const discoverTools = (
 const closeConnection = (connection: {
   readonly close: () => Promise<void>;
 }): Effect.Effect<void, never> =>
-  Effect.ignore(
-    Effect.tryPromise({
-      try: () => connection.close(),
-      catch: () =>
-        new McpToolDiscoveryError({
-          stage: "list_tools",
-          message: "Failed closing MCP connection",
-        }),
-    }),
-  );
+  Effect.tryPromise({
+    try: () => connection.close(),
+    catch: () =>
+      new McpToolDiscoveryError({
+        stage: "list_tools",
+        message: "Failed closing MCP connection",
+      }),
+  }).pipe(Effect.timeout(CLOSE_TIMEOUT), Effect.ignore);


### PR DESCRIPTION
## Summary

Bound MCP discovery teardown so a transport whose `close()` never settles cannot strand an otherwise completed catalog refresh or health check.

```text
connect → tools/list succeeds → close (bounded to 2s) → return manifest
```

The close timeout matches the invocation connection pool's teardown bound. Teardown remains best-effort and a successful discovery result is preserved.

## Validation

- `bunx vitest run src/sdk/discover-close.test.ts --reporter=dot`
- `bun run typecheck`
- `bunx oxlint -c ../../../.oxlintrc.jsonc src/sdk/discover.ts src/sdk/discover-close.test.ts --deny-warnings`
- `bunx vitest run --reporter=dot` (296 passed, 29 skipped)
