### PR TITLE
fix(e2e): honor the 503 restart envelope in the cap-eviction helper

### DIFF
--- a/e2e/cloud/mcp-session-cap-eviction.test.ts
+++ b/e2e/cloud/mcp-session-cap-eviction.test.ts
@@ -73,21 +73,42 @@ const openSession = async (
   label: string,
   recordSession: (sessionId: string) => void,
 ): Promise<string> => {
-  const initialized = await postJson(mcpUrl, bearer, {
-    jsonrpc: "2.0" as const,
-    id: "initialize",
-    method: "initialize",
-    params: {
-      protocolVersion: PROTOCOL_VERSION,
-      capabilities: {},
-      clientInfo: { name: `executor-e2e-cap-eviction-${label}`, version: "0.0.1" },
-    },
-  });
-  const sessionId = initialized.headers.get("mcp-session-id");
-  if (!sessionId) {
+  // The platform can reset a session Durable Object while its initialize
+  // is in flight, and the server answers that with the documented restart
+  // envelope (503, -32001, "MCP session is restarting, please retry") — the
+  // same contract a streamable-http client follows: same request, after the
+  // advertised delay. Treat it as transient here instead of failing the
+  // scenario on a retryable platform blip.
+  const RESTART_ATTEMPTS = 8;
+  const RESTART_DELAY_MS = 250;
+  let minted: { readonly response: Response; readonly sessionId: string } | undefined;
+  for (let attempt = 0; attempt < RESTART_ATTEMPTS; attempt += 1) {
+    const response = await postJson(mcpUrl, bearer, {
+      jsonrpc: "2.0" as const,
+      id: "initialize",
+      method: "initialize",
+      params: {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: `executor-e2e-cap-eviction-${label}`, version: "0.0.1" },
+      },
+    });
+    const candidate = response.headers.get("mcp-session-id");
+    if (candidate !== null && candidate.length > 0) {
+      minted = { response, sessionId: candidate };
+      break;
+    }
+    const body = await response.text().catch(() => "");
+    const isRestart = response.status === 503 && body.includes("MCP session is restarting");
+    if (!isRestart) break;
+    if (attempt === RESTART_ATTEMPTS - 1) break;
+    await new Promise((resolve) => setTimeout(resolve, RESTART_DELAY_MS));
+  }
+  if (!minted) {
     // oxlint-disable-next-line executor/no-error-constructor -- boundary: e2e setup precondition.
     throw new Error(`openSession (${label}): no mcp-session-id header`);
   }
+  const { response: initialized, sessionId } = minted;
   // Recorded the moment the id exists — BEFORE the body read and status
   // assertion below, either of which can throw with the session already live
   // on the server. The cleanup finalizer needs the id on every one of those


### PR DESCRIPTION
## What

Adds a retry backstop to `openSession` in `cloud/mcp-session-cap-eviction.test.ts`: when the server answers `initialize` with the documented restart envelope (503, JSON-RPC -32001, `"MCP session is restarting, please retry"` — the contract `agent-handler` emits for a platform DO reset), the helper retries the same request after a short delay instead of failing the scenario on a retryable platform blip.

## Context

The original root-cause half of this PR (opening concurrency) was superseded by #1907, which landed sequential admission and has the shard green on main. What remains here is only the retry: the exact behavior a real streamable-http client follows for that response, kept so the test's failure mode stays aligned with client behavior if the envelope ever recurs.

## Verification

- `cloud/mcp-session-cap-eviction` passes locally on this branch (rebased onto current main).
- `oxlint` and `tsc --noEmit` clean on the touched package.
