### PR TITLE
Fit the empty Toolkits grid to the viewport

### DIFF
--- a/.changeset/toolkits-empty-grid.md
+++ b/.changeset/toolkits-empty-grid.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Prevent the empty Toolkits page from scrolling past its visible add cards.

--- a/e2e/selfhost/toolkits-empty-grid.test.ts
+++ b/e2e/selfhost/toolkits-empty-grid.test.ts
@@ -1,0 +1,56 @@
+// An empty Toolkits grid must fit the viewport: with no toolkits in either
+// scope, both the Workspace and Personal add cards sit above the fold and the
+// grid does not scroll. Regression: each shelf reserved a fixed ~3-row
+// min-height, so two empty shelves stacked past the viewport and the page
+// scrolled with nothing to see.
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Browser, Target } from "../src/services";
+import { visit } from "../src/surfaces/browser";
+
+scenario(
+  "Toolkits · empty grid fits the viewport without scrolling",
+  { timeout: 120_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const browser = yield* Browser;
+    const identity = yield* target.newIdentity();
+
+    yield* browser.session(identity, async ({ page, step }) => {
+      await step("Open the Toolkits page with no toolkits in either scope", async () => {
+        await visit(page, "/default/toolkits/");
+        await page.getByRole("heading", { name: "Toolkits", level: 1 }).waitFor();
+        await page.getByRole("heading", { name: "Workspace" }).waitFor();
+        await page.getByRole("heading", { name: "Personal" }).waitFor();
+        await page.getByRole("button", { name: "Add workspace toolkit" }).waitFor();
+        await page.getByRole("button", { name: "Add personal toolkit" }).waitFor();
+        await page.locator('main [data-slot="skeleton"]').first().waitFor({ state: "detached" });
+      });
+
+      await step("The empty grid does not overflow its scroll container", async () => {
+        // Walk up from the Personal add card to its nearest scrollable
+        // ancestor; on an empty grid that ancestor must have nothing to
+        // scroll. This is the user-visible contract — both add cards are
+        // reachable without scrolling — measured at the scroll boundary.
+        const overflow = await page.evaluate(() => {
+          const addCard = [...document.querySelectorAll("button")].find(
+            (button) => button.getAttribute("aria-label") === "Add personal toolkit",
+          );
+          let node: HTMLElement | null = addCard ?? null;
+          while (node && node.scrollHeight <= node.clientHeight + 1) {
+            node = node.parentElement;
+          }
+          if (!node) return null;
+          return {
+            tag: node.tagName,
+            scrollHeight: node.scrollHeight,
+            clientHeight: node.clientHeight,
+          };
+        });
+        expect(overflow, "no scrollable ancestor overflows for an empty grid").toBeNull();
+      });
+    });
+  }),
+);

--- a/packages/plugins/toolkits/src/page.tsx
+++ b/packages/plugins/toolkits/src/page.tsx
@@ -181,7 +181,6 @@ const toolkitByRouteSlug = (
 };
 
 const toolkitCardStyle = { minHeight: "9rem" };
-const toolkitShelfStyle = { minHeight: "28.5rem" };
 const toolkitGridContainerStyle = { maxWidth: "80rem" };
 const toolkitToolTreeStyle = { width: "24rem" };
 
@@ -636,10 +635,7 @@ function ToolkitSection(props: {
         </div>
       ) : null}
 
-      <div
-        className="grid content-start grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3"
-        style={toolkitShelfStyle}
-      >
+      <div className="grid content-start grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3">
         {rows.map((toolkit) => (
           <ToolkitTile key={toolkit.id} showOwnerLabels={props.showOwnerLabels} toolkit={toolkit} />
         ))}
@@ -1204,10 +1200,7 @@ function ToolkitSectionSkeleton(props: { title?: string }) {
         </div>
       ) : null}
 
-      <div
-        className="grid content-start grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3"
-        style={toolkitShelfStyle}
-      >
+      <div className="grid content-start grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3">
         <ToolkitTileSkeleton />
       </div>
     </section>


### PR DESCRIPTION

<!-- Keep this short and plain. Delete the sections that do not apply. -->

## Summary

in the cloud hosted version of web UI, `Toolkits` tab has `Personal` and `Workspace` two sections, and the page is scrollable when there's no `Toolkits` content, see below screen recording. changes in this PR prevent empty `Toolkits` page from scrolling past its visible add cards, 

#### before 

https://github.com/user-attachments/assets/4532d736-0a0a-47f0-93bc-6a0055ddbd5f 
 
#### after 

https://github.com/user-attachments/assets/3d58ed81-7162-4ba9-bc19-b065471a2d52




## Linked issue

no issue open yet since it's a straightforward fix, will open one if it's preferred


## Verification

<!--
Say what you ran and what it showed. File paths alone are not evidence.
User-visible work needs a specific e2e run or a browsable dev instance, plus
the recording or trace that shows what to inspect. Add an e2e scenario when
none covers the changed behaviour.
-->

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] e2e — name the scenario, and link the recording or trace: `e2e/runs/selfhost/toolkits-empty-grid-fits-the-viewport-without-scrolling/`


## Checklist

- [x] Added a changeset (`bun run changeset`), or this change needs none.
- [x] Added or updated tests for the new behaviour.
- [x] No secrets, credentials, or private data in the diff.
