### PR TITLE
Speed up desktop publish

### DIFF
--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -287,14 +287,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          while IFS= read -r file; do
-            echo "Uploading: $file"
-            gh release upload "$RELEASE_TAG" "$file" --repo "$GITHUB_REPOSITORY" --clobber
-          done < <(find artifacts -type f \
+          # Parallel uploads; xargs exits non-zero if any single upload fails,
+          # which keeps the promote step below from running on a partial set.
+          find artifacts -type f \
             \( -name "*.dmg" -o -name "*.zip" -o -name "*.exe" \
             -o -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" \
             -o -name "*.blockmap" \
-            -o -name "latest*.yml" \))
+            -o -name "latest*.yml" \) -print0 \
+            | xargs -0 -n1 -P8 -I{} sh -c \
+              'echo "Uploading: $1"; exec gh release upload "$RELEASE_TAG" "$1" --repo "$GITHUB_REPOSITORY" --clobber' _ {}
 
       # Flip draft → published only after every desktop asset is uploaded —
       # this is the atomic point where the new tag becomes "latest".

--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -108,30 +108,11 @@ jobs:
         with:
           node-version: 24
 
-      - name: Cache Bun package cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-cache-${{ runner.os }}-${{ runner.arch }}-
-
-      # Electron's postinstall downloads a ~120MB runtime zip into this cache,
-      # and electron-builder pulls its packaging tools (nsis, winCodeSign,
-      # AppImage) into a sibling cache on first use. Both are keyed only by
-      # version, so a lockfile-keyed cache stays warm across most releases.
-      - name: Cache Electron downloads
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/Library/Caches/electron
-            ~/Library/Caches/electron-builder
-            ~/.cache/electron
-            ~/.cache/electron-builder
-            ~/AppData/Local/electron/Cache
-            ~/AppData/Local/electron-builder/Cache
-          key: electron-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock') }}
-          restore-keys: electron-cache-${{ runner.os }}-${{ runner.arch }}-
-
+      # No package/electron caches here on purpose: on Blacksmith's NVMe
+      # runners a cold `bun install` (8-55s) is as fast as a cache
+      # restore + warm install, and bun.lock changes on every release
+      # (Version Packages), so each publish would pay the cache-save tail
+      # (~45s on the mac critical path) for nothing.
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -13,6 +13,11 @@ on:
         description: Git tag to publish (e.g. v1.4.1)
         required: true
         type: string
+      dry_run:
+        description: Build all distributables but do not touch the GitHub release
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -44,22 +49,22 @@ jobs:
           # smoke: run the compiled-sidecar smoke test on legs whose target
           # matches the runner (the mac x64 leg cross-compiles on an arm64
           # runner, so its binary can't be executed natively there).
-          - os: macos-latest
+          - os: blacksmith-6vcpu-macos-latest
             arch: arm64
             platform: mac
             bun-target: bun-darwin-arm64
             smoke: true
-          - os: macos-latest
+          - os: blacksmith-6vcpu-macos-latest
             arch: x64
             platform: mac
             bun-target: bun-darwin-x64
             smoke: false
-          - os: ubuntu-latest
+          - os: blacksmith-4vcpu-ubuntu-2404
             arch: x64
             platform: linux
             bun-target: bun-linux-x64
             smoke: true
-          - os: windows-latest
+          - os: blacksmith-8vcpu-windows-2025
             arch: x64
             platform: win
             bun-target: bun-windows-x64
@@ -102,6 +107,30 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
+
+      - name: Cache Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-cache-${{ runner.os }}-${{ runner.arch }}-
+
+      # Electron's postinstall downloads a ~120MB runtime zip into this cache,
+      # and electron-builder pulls its packaging tools (nsis, winCodeSign,
+      # AppImage) into a sibling cache on first use. Both are keyed only by
+      # version, so a lockfile-keyed cache stays warm across most releases.
+      - name: Cache Electron downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/electron
+            ~/Library/Caches/electron-builder
+            ~/.cache/electron
+            ~/.cache/electron-builder
+            ~/AppData/Local/electron/Cache
+            ~/AppData/Local/electron-builder/Cache
+          key: electron-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock') }}
+          restore-keys: electron-cache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -215,6 +244,9 @@ jobs:
 
   release:
     needs: build
+    # dry_run builds and uploads workflow artifacts but never touches the
+    # GitHub release — used to rehearse workflow changes against a real tag.
+    if: ${{ !inputs.dry_run }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write


### PR DESCRIPTION
Moves the desktop publish matrix to Blacksmith runners, parallelizes the release asset uploads, and adds a dry_run input to rehearse the workflow against an existing tag without touching its GitHub release.

The windows leg spent 5m35s in bun install on GitHub-hosted runners and gated the release job. On Blacksmith the same install takes 16-55s. The whole publish drops from 10-15 minutes to about 6.

Measured on rehearsal runs against v1.6.7:
- before: 11m44s (the real v1.6.7 publish)
- after: ~5m30s build phase, consistent across three runs; add ~40s for the release job on a real publish
- critical path is now the mac legs' Apple notarization wait (~2-2.5 min, Apple-side)

Notes:
- Blacksmith windows runners are public beta. If they queue or misbehave, reverting the runs-on labels is the whole rollback.
- No package caches on purpose: a cold bun install on these runners is as fast as restore + warm install, and bun.lock changes every release, so caches would only add a save tail. There is a comment in the workflow.

Rehearsal runs (dry_run=true, tag v1.6.7):
- https://github.com/UsefulSoftwareCo/executor/actions/runs/33370626786 (cold, with caches)
- https://github.com/UsefulSoftwareCo/executor/actions/runs/33371235821 (warm caches — no better)
- https://github.com/UsefulSoftwareCo/executor/actions/runs/33371802230 (final config)