### PR TITLE
Move pkg-pr-new mac leg and graph-slices to Blacksmith

### DIFF
--- a/.github/workflows/graph-slices.yml
+++ b/.github/workflows/graph-slices.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   slices:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -36,7 +36,7 @@ jobs:
         include:
           - runner: blacksmith-4vcpu-ubuntu-2404
             target: executor-linux-x64
-          - runner: macos-14
+          - runner: blacksmith-6vcpu-macos-latest
             target: executor-darwin-arm64
     runs-on: ${{ matrix.runner }}
     steps:


### PR DESCRIPTION
Follow-up to #1902.

- pkg-pr-new darwin leg: macos-14 (GitHub-hosted) -> blacksmith-6vcpu-macos-latest. The mac leg gates the Publish preview check on every PR (~4-6 min today).
- graph-slices: ubuntu-latest -> blacksmith-4vcpu-ubuntu-2404, matching the rest of the linux jobs.

Not moved on purpose: release.yml and publish-executor-package.yml publish to npm with --provenance, which the npm registry only accepts from GitHub-hosted runners. They stay on ubuntu-latest.

This PR's own Publish check exercises the new mac leg.