### PR TITLE
fix(mcp): bootstrap Computer Use through trusted runtime

### DIFF
--- a/.changeset/codex-computer-use-runtime.md
+++ b/.changeset/codex-computer-use-runtime.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Load Codex Computer Use through its installed plugin wrapper so the `node_repl` runtime grants the capabilities required by `@oai/sky`.

--- a/e2e/local/codex-plugins.test.ts
+++ b/e2e/local/codex-plugins.test.ts
@@ -43,6 +43,15 @@ const CHROME_CLIENT_RELATIVE = join(
   "scripts",
   "browser-client.mjs",
 );
+const COMPUTER_USE_CLIENT_RELATIVE = join(
+  "plugins",
+  "cache",
+  "openai-bundled",
+  "computer-use",
+  "1.0.0",
+  "scripts",
+  "computer-use-client.mjs",
+);
 const APP_SERVER_FIXTURE = fileURLToPath(
   new URL("./fixtures/codex-app-server.mjs", import.meta.url),
 );
@@ -76,7 +85,12 @@ const makeCodexHome = (): string => {
     mode: 0o755,
   });
 
-  // Chrome's bundled browser client, behind the `latest` symlink Codex keeps.
+  // Plugin-owned runtime clients: Computer Use's versioned trusted-runtime
+  // wrapper and Chrome's browser client behind the `latest` symlink Codex keeps.
+  const computerUseClient = join(home, COMPUTER_USE_CLIENT_RELATIVE);
+  mkdirSync(join(computerUseClient, ".."), { recursive: true });
+  writeFileSync(computerUseClient, "export const setupComputerUseRuntime = async () => ({});\n");
+
   const chromeClient = join(home, CHROME_CLIENT_RELATIVE);
   mkdirSync(join(chromeClient, ".."), { recursive: true });
   writeFileSync(chromeClient, "export const setupBrowserRuntime = async () => ({});\n");
@@ -156,12 +170,13 @@ scenario(
             server: "messages",
           });
           // Computer Use and Chrome have no server of their own: both are
-          // projected onto `node_repl`, and Chrome carries the client module
-          // its surface imports, resolved through the `latest` symlink.
+          // projected onto `node_repl` and carry the plugin-owned client module
+          // their surface imports.
           expect(byId.get("codex-computer-use")?.appServer).toEqual({
             presetId: "codex-computer-use",
             server: "node_repl",
             surface: "sky",
+            modulePath: join(codexHome, COMPUTER_USE_CLIENT_RELATIVE),
           });
           expect(byId.get("codex-chrome")?.appServer).toEqual({
             presetId: "codex-chrome",

--- a/packages/plugins/mcp/src/sdk/appserver-connector.test.ts
+++ b/packages/plugins/mcp/src/sdk/appserver-connector.test.ts
@@ -14,6 +14,8 @@ import { createMcpConnector, type StdioConnectorInput } from "./connection";
 // ---------------------------------------------------------------------------
 
 const fixture = fileURLToPath(new URL("./appserver-test-server.ts", import.meta.url));
+const COMPUTER_USE_MODULE =
+  "/codex/plugins/cache/openai-bundled/computer-use/1.0.0/scripts/computer-use-client.mjs";
 
 const appServerInput = (
   server: string,
@@ -30,6 +32,9 @@ const withConnection = (input: StdioConnectorInput) =>
   Effect.acquireRelease(createMcpConnector(input).pipe(Effect.orDie), (connection) =>
     Effect.promise(connection.close),
   );
+
+const computerUseInput = (): StdioConnectorInput =>
+  appServerInput("node_repl", { surface: "sky", modulePath: COMPUTER_USE_MODULE });
 
 describe("codex app-server bridge", () => {
   it.effect("handshakes, follows status pagination, and lists the server's tools", () =>
@@ -177,7 +182,7 @@ describe("codex app-server bridge", () => {
   it.effect("the sky surface lists typed Computer Use tools, not the raw REPL", () =>
     Effect.scoped(
       Effect.gen(function* () {
-        const connection = yield* withConnection(appServerInput("node_repl", { surface: "sky" }));
+        const connection = yield* withConnection(computerUseInput());
 
         const tools = yield* Effect.promise(() => connection.client.listTools());
         const names = tools.tools.map(({ name }) => name);
@@ -195,7 +200,7 @@ describe("codex app-server bridge", () => {
   it.effect("a sky tool call compiles to one node_repl program carrying its arguments", () =>
     Effect.scoped(
       Effect.gen(function* () {
-        const connection = yield* withConnection(appServerInput("node_repl", { surface: "sky" }));
+        const connection = yield* withConnection(computerUseInput());
 
         // Quotes in the arguments matter: they are embedded into a JS source
         // text, so the encoding has to survive them exactly.
@@ -205,9 +210,16 @@ describe("codex app-server bridge", () => {
         );
         // The fixture echoes the program the bridge compiled.
         const program = (result.content as readonly { readonly text: string }[])[0]!.text;
-        expect(program, "imports the bundled sky package idempotently").toContain(
-          'globalThis.sky ??= (await import("@oai/sky")).sky;',
+        expect(program, "loads the plugin-owned trusted runtime wrapper").toContain(
+          `await import(${JSON.stringify(COMPUTER_USE_MODULE)})`,
         );
+        expect(program, "uses the wrapper's supported bootstrap contract").toContain(
+          "await setupComputerUseRuntime({ globals: globalThis });",
+        );
+        expect(
+          program,
+          'does not trigger "Sky Computer Use requires the trusted nodeRepl runtime"',
+        ).not.toContain('import("@oai/sky")');
         expect(program, "calls the mapped method with the arguments verbatim").toContain(
           `await sky.type_text(JSON.parse(${JSON.stringify(JSON.stringify(args))}))`,
         );
@@ -224,7 +236,7 @@ describe("codex app-server bridge", () => {
   it.effect("an argument-less sky tool calls its method with no argument object", () =>
     Effect.scoped(
       Effect.gen(function* () {
-        const connection = yield* withConnection(appServerInput("node_repl", { surface: "sky" }));
+        const connection = yield* withConnection(computerUseInput());
 
         const result = yield* Effect.promise(() =>
           connection.client.callTool({ name: "list_apps", arguments: {} }),
@@ -238,7 +250,7 @@ describe("codex app-server bridge", () => {
   it.effect("a tool outside the sky surface is refused rather than sent to the REPL", () =>
     Effect.scoped(
       Effect.gen(function* () {
-        const connection = yield* withConnection(appServerInput("node_repl", { surface: "sky" }));
+        const connection = yield* withConnection(computerUseInput());
 
         const outcome = yield* Effect.promise(() =>
           connection.client.callTool({ name: "js", arguments: { code: "process.exit(0)" } }).then(

--- a/packages/plugins/mcp/src/sdk/appserver-connector.ts
+++ b/packages/plugins/mcp/src/sdk/appserver-connector.ts
@@ -88,8 +88,8 @@ export type AppServerTransportConfig = StdioTransportConfig & {
    *  `browser` is Chrome (`codex-browser-tools.ts`). Absent exposes the
    *  server's own tools verbatim. */
   readonly surface?: "sky" | "browser";
-  /** Absolute path to the module a projected surface imports (Chrome's
-   *  `browser-client.mjs`); resolved per machine by the scanner. */
+  /** Absolute path to the plugin-owned module a projected surface imports;
+   *  resolved per machine by the scanner. */
   readonly modulePath?: string;
 };
 
@@ -565,7 +565,10 @@ class AppServerClientTransport implements Transport {
     if (this.#config.surface === "sky") {
       const tool = findSkyTool(name);
       if (tool === undefined) return "unknown-tool";
-      return { code: skyCallProgram(tool, args), title: `Computer Use: ${tool.name}` };
+      return {
+        code: skyCallProgram(tool, args, this.#config.modulePath ?? ""),
+        title: `Computer Use: ${tool.name}`,
+      };
     }
     if (this.#config.surface === "browser") {
       const tool = findBrowserTool(name);

--- a/packages/plugins/mcp/src/sdk/codex-plugins.test.ts
+++ b/packages/plugins/mcp/src/sdk/codex-plugins.test.ts
@@ -11,11 +11,11 @@ import { scanCodexPlugins } from "./codex-plugins";
 //   <home>/computer-use/Codex Computer Use.app/…/SkyComputerUseClient   (curated)
 //   <home>/plugins/cache/<source>/<name>/<version>/.codex-plugin/plugin.json
 //
-// The three curated plugins must always be reported — available when the
-// client binary exists, with a setup hint when it does not — and the cache
+// The curated plugins must always be reported — available when their required
+// client content exists, with a setup hint when it does not — and the cache
 // scan must pick each plugin's newest version, resolve its relative command
-// and cwd against that version dir, skip remote (http) servers, and never
-// fail the whole scan on a malformed entry.
+// and cwd against that version dir, skip remote (http) servers, and never fail
+// the whole scan on a malformed entry.
 // ---------------------------------------------------------------------------
 
 const CLIENT_RELATIVE = join(
@@ -99,6 +99,26 @@ const writeChromePlugin = (home: string): void => {
   writeFileSync(file, "export const setupBrowserRuntime = async () => ({});\n");
 };
 
+const writeComputerUsePlugin = (
+  home: string,
+  version = "1.0.0",
+  source = "openai-bundled",
+): string => {
+  const file = join(
+    home,
+    "plugins",
+    "cache",
+    source,
+    "computer-use",
+    version,
+    "scripts",
+    "computer-use-client.mjs",
+  );
+  mkdirSync(join(file, ".."), { recursive: true });
+  writeFileSync(file, "export const setupComputerUseRuntime = async () => ({});\n");
+  return file;
+};
+
 /** A fake `codex` CLI inside the temp home, passed explicitly so the scan
  *  never resolves the machine's real install through PATH. */
 const writeCodexCli = (home: string): string => {
@@ -111,6 +131,7 @@ describe("scanCodexPlugins", () => {
   it("reports the curated plugins as app-server recipes when Codex is fully installed", () => {
     const home = makeHome();
     writeExecutable(join(home, CLIENT_RELATIVE));
+    const computerUseClient = writeComputerUsePlugin(home);
     writeChromePlugin(home);
     const cli = writeCodexCli(home);
 
@@ -136,13 +157,18 @@ describe("scanCodexPlugins", () => {
     }
     // Computer Use and Chrome have no MCP server of their own in current
     // Codex: both ship as node-repl content, so they target `node_repl` with a
-    // projected surface. Chrome additionally carries the module its surface
-    // imports, resolved through the version-proof `latest` symlink.
+    // projected surface. Each carries the plugin-owned module its surface
+    // imports; Chrome's is resolved through the version-proof `latest` symlink.
     // Each entry also carries its own preset id, so a macOS permission
     // failure can name the exact grant that plugin needs.
     expect(curated.map((entry) => entry.appServer)).toEqual([
       { presetId: "codex-messages", server: "messages" },
-      { presetId: "codex-computer-use", server: "node_repl", surface: "sky" },
+      {
+        presetId: "codex-computer-use",
+        server: "node_repl",
+        surface: "sky",
+        modulePath: computerUseClient,
+      },
       {
         presetId: "codex-chrome",
         server: "node_repl",
@@ -212,6 +238,39 @@ describe("scanCodexPlugins", () => {
 
     expect(byId.get("codex-messages")?.available).toBe(true);
     expect(byId.get("codex-chrome")?.available).toBe(false);
+  });
+
+  it("resolves the trusted Computer Use wrapper from the newest installed cache version", () => {
+    const home = makeHome();
+    writeExecutable(join(home, CLIENT_RELATIVE));
+    const older = writeComputerUsePlugin(home, "1.0.9", "openai-bundled");
+    const newest = writeComputerUsePlugin(home, "1.0.10", "openai-curated-remote");
+    const cli = writeCodexCli(home);
+
+    const computerUse = scanCodexPlugins({ codexHome: home, codexCli: cli }).find(
+      (entry) => entry.id === "codex-computer-use",
+    );
+
+    expect(computerUse?.available).toBe(true);
+    expect(computerUse?.appServer?.modulePath).toBe(newest);
+    expect(computerUse?.appServer?.modulePath).not.toBe(older);
+  });
+
+  it("does not fall back to a stale wrapper when the newest plugin lacks one", () => {
+    const home = makeHome();
+    writeExecutable(join(home, CLIENT_RELATIVE));
+    writeComputerUsePlugin(home, "1.0.9");
+    mkdirSync(join(home, "plugins", "cache", "openai-bundled", "computer-use", "1.0.10"), {
+      recursive: true,
+    });
+    const cli = writeCodexCli(home);
+
+    const computerUse = scanCodexPlugins({ codexHome: home, codexCli: cli }).find(
+      (entry) => entry.id === "codex-computer-use",
+    );
+
+    expect(computerUse?.available).toBe(false);
+    expect(computerUse?.appServer?.modulePath).toBeUndefined();
   });
 
   it("scans cached plugins, resolving command and cwd against the newest version", () => {

--- a/packages/plugins/mcp/src/sdk/codex-plugins.ts
+++ b/packages/plugins/mcp/src/sdk/codex-plugins.ts
@@ -249,6 +249,31 @@ const readIconDataUri = (file: string): string | undefined =>
     return `data:${mime};base64,${fs.readFileSync(file).toString("base64")}`;
   }, undefined);
 
+/** A plugin-owned file from the newest installed cache version, regardless of
+ *  which catalog source supplied it. */
+const latestCachedPluginFile = (
+  codexHome: string,
+  pluginName: string,
+  ...relativeParts: readonly string[]
+): string | undefined => {
+  const cacheDir = path.join(codexHome, "plugins", "cache");
+  const versions = listDirs(cacheDir).flatMap((sourceName) => {
+    const pluginDir = path.join(cacheDir, sourceName, pluginName);
+    return listDirs(pluginDir).map((version) => ({
+      version,
+      file: path.join(pluginDir, version, ...relativeParts),
+    }));
+  });
+  const latest = versions.sort((a, b) => compareVersionsDesc(a.version, b.version))[0]?.file;
+  return latest !== undefined && isReadableFile(latest) ? latest : undefined;
+};
+
+/** Computer Use's trusted runtime bootstrap. The plugin owns this wrapper and
+ *  updates it alongside its bundled runtime; importing `@oai/sky` directly
+ *  bypasses the trusted node_repl module boundary. */
+const computerUseClientPath = (codexHome: string): string | undefined =>
+  latestCachedPluginFile(codexHome, "computer-use", "scripts", "computer-use-client.mjs");
+
 interface CodexPluginDisplay {
   readonly icon?: string;
   readonly displayName?: string;
@@ -396,6 +421,7 @@ export const scanCodexPlugins = (options?: {
 
   const codexCli = resolveCodexCli(options?.codexCli);
   const computerUseApp = isExecutableFile(clientBinaryPath(codexHome));
+  const computerUseClient = computerUseClientPath(codexHome);
   const browserClient = browserClientPath(codexHome);
   const chromePlugin = isReadableFile(browserClient);
 
@@ -409,7 +435,10 @@ export const scanCodexPlugins = (options?: {
 
   const curated: readonly CodexPluginEntry[] = CURATED_CODEX_PLUGINS.map((entry) => {
     const display = curatedDisplayMetadata(codexHome, entry.pluginName);
-    const available = codexCli !== undefined && requirementMet[entry.requires];
+    const available =
+      codexCli !== undefined &&
+      requirementMet[entry.requires] &&
+      (entry.surface !== "sky" || computerUseClient !== undefined);
     return {
       id: entry.id,
       name: entry.name,
@@ -424,6 +453,9 @@ export const scanCodexPlugins = (options?: {
         presetId: entry.id,
         server: entry.server,
         ...(entry.surface === undefined ? {} : { surface: entry.surface }),
+        ...(entry.surface === "sky" && computerUseClient !== undefined
+          ? { modulePath: computerUseClient }
+          : {}),
         ...(entry.surface === "browser" ? { modulePath: browserClient } : {}),
       },
       ...(available

--- a/packages/plugins/mcp/src/sdk/codex-sky-tools.ts
+++ b/packages/plugins/mcp/src/sdk/codex-sky-tools.ts
@@ -4,13 +4,13 @@
 // Computer Use is NOT a plain MCP server in current Codex: its plugin ships as
 // a `node-repl` content variant, so Codex never starts the `computer-use`
 // server (asking for it answers "unknown MCP server"). What actually drives a
-// Mac is the `node_repl` server's `js` tool running the plugin's bundled
-// `@oai/sky` package — that is what ChatGPT itself does, and Codex tags those
+// Mac is the `node_repl` server's `js` tool running the plugin's trusted
+// runtime wrapper — that is what ChatGPT itself does, and Codex tags those
 // calls `toolSurface: { kind: "computerUse" }`.
 //
 // Handing an agent a raw JavaScript REPL would be a poor tool catalog: it
 // moves the whole API contract into prose and makes every call a code-writing
-// exercise. So the bridge projects `@oai/sky` as ordinary, typed MCP tools —
+// exercise. So the bridge projects the Sky API as ordinary, typed MCP tools —
 // one per method, with real input schemas — and compiles each call back into
 // the one `node_repl.js` execution that performs it. Callers see
 // `list_apps` / `click` / `type_text`; the REPL stays an implementation
@@ -20,9 +20,6 @@
 // ---------------------------------------------------------------------------
 
 import { jsLiteral, writeJsonResult } from "./codex-repl";
-
-/** Bundled package the REPL imports; `sky` is its single exported entry. */
-const SKY_PACKAGE = "@oai/sky";
 
 type JsonSchema = Record<string, unknown>;
 
@@ -239,20 +236,27 @@ export const findSkyTool = (name: string): SkyToolDefinition | undefined =>
 /**
  * The `node_repl` program that performs one sky call.
  *
- * `??=` rather than a separate bootstrap step because the REPL's state is
+ * The guarded bootstrap stays in every call because the REPL's state is
  * persistent but its LIFETIME is not ours to assume: the thread may be new,
  * reused, or reset between calls, and a call that assumed a warm global would
- * fail exactly when the pool handed back a fresh one. Importing is cheap once
- * warm, so this is idempotent rather than conditional on bookkeeping.
+ * fail exactly when the pool handed back a fresh one. The plugin wrapper is
+ * idempotent, so a warm session skips it without separate bookkeeping.
  *
  * The result is written as JSON through `nodeRepl.write`, which is how the
  * REPL returns anything at all; `undefined` (the action methods) becomes
  * `null` so a caller always gets a well-formed body.
  */
-export const skyCallProgram = (tool: SkyToolDefinition, args: unknown): string => {
+export const skyCallProgram = (
+  tool: SkyToolDefinition,
+  args: unknown,
+  modulePath: string,
+): string => {
   const call = tool.takesArgs ? `sky.${tool.method}(${jsLiteral(args)})` : `sky.${tool.method}()`;
   return [
-    `globalThis.sky ??= (await import(${JSON.stringify(SKY_PACKAGE)})).sky;`,
+    "if (!globalThis.sky) {",
+    `  const { setupComputerUseRuntime } = await import(${JSON.stringify(modulePath)});`,
+    "  await setupComputerUseRuntime({ globals: globalThis });",
+    "}",
     writeJsonResult([], `await ${call}`),
   ].join("\n");
 };


### PR DESCRIPTION
## Why Computer Use stayed blocked

Executor 1.6.7 compiled Computer Use calls into a direct `await import("@oai/sky")` inside Codex's `node_repl`. The current Computer Use plugin explicitly requires callers to load its cache-owned `scripts/computer-use-client.mjs` wrapper instead. A direct package import bypasses that trusted module boundary, so Sky sees no privileged `globalThis.nodeRepl` and the access probe returns:

```text
Sky Computer Use requires the trusted nodeRepl runtime
```

This happens after `codex app-server` has already reached the configured `node_repl` server. Switching Executor's PATH from a standalone `codex-cli 0.151.0` to the Codex app's bundled `0.147.0-alpha.6.5` therefore does not change the failing import context.

## TL;DR

Resolve the newest installed Computer Use plugin wrapper and carry that absolute path into the app-server recipe. Sky calls now invoke the wrapper's supported `setupComputerUseRuntime({ globals: globalThis })` bootstrap and keep Computer Use unavailable when the newest cached plugin does not provide it, rather than using a stale or untrusted fallback.

## What changed?

- Scan every installed Codex plugin cache source for the newest Computer Use version and resolve its own runtime wrapper.
- Attach that wrapper as the Sky surface's `modulePath`; do not advertise Computer Use as available if the newest version lacks it.
- Bootstrap each fresh/reused REPL session through the wrapper before invoking a typed Sky tool. The wrapper remains authoritative for how its matching bundled runtime is loaded.
- Add a patch changeset and regressions for cross-source numeric version selection, missing-newest-wrapper behavior, and the generated app-server program.

## Verification

- [x] `bun run format:check` — all 2,040 matched files use the expected format.
- [x] `bun run lint` — 0 warnings and 0 errors; changelog-stub check passed.
- [x] `bun run --cwd packages/plugins/mcp typecheck` — passed.
- [x] `bun run --cwd packages/plugins/mcp test -- src/sdk/codex-plugins.test.ts src/sdk/appserver-connector.test.ts` — 2 files, 29 tests passed.
- [x] Manual installed-runtime reproduction on macOS — direct `@oai/sky` import returned the exact trusted-runtime error above; loading the installed plugin wrapper crossed that check and continued to Computer Use service startup.

## Reviewer focus

The important boundary is that the wrapper comes from the newest installed Computer Use cache version. Falling back to an older cached wrapper could pair code with the wrong bundled runtime, so the scanner reports the card unavailable when the newest version is incomplete.

## Checklist

- [x] Added a changeset.
- [x] Added or updated tests for the new behavior.
- [x] No secrets, credentials, or private data in the diff.
