### PR TITLE
fix(selfhost): opt out of CIMD client ids on private networks

### DIFF
--- a/.changeset/oauth-disable-cimd-selfhost.md
+++ b/.changeset/oauth-disable-cimd-selfhost.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Add `EXECUTOR_OAUTH_DISABLE_CIMD` for self-hosts on private networks: suppresses Client ID Metadata Document support in OAuth probe results, so automatic connects use dynamic client registration or manual setup instead of a CIMD client_id URL the provider cannot fetch.

--- a/apps/host-selfhost/.env.example
+++ b/apps/host-selfhost/.env.example
@@ -41,3 +41,13 @@
 # "true". Enabling it lets users configure MCP servers whose commands execute
 # on this host.
 # EXECUTOR_ALLOW_STDIO_MCP=true
+
+# --- OAuth on private networks ------------------------------------------------
+# Automatic OAuth prefers Client ID Metadata Documents (CIMD) when a provider
+# advertises them: the client_id is then a URL on THIS instance that the
+# provider's authorization server must fetch. If this instance is not publicly
+# reachable (private LAN, VPN, tailnet), providers reject that client_id as
+# invalid_client. CIMD is skipped only when this is explicitly set to the
+# exact string "true"; connects then use dynamic client registration or
+# manual setup.
+# EXECUTOR_OAUTH_DISABLE_CIMD=true

--- a/apps/host-selfhost/src/config.ts
+++ b/apps/host-selfhost/src/config.ts
@@ -34,6 +34,12 @@ export interface SelfHostConfig {
    * internal network unless an operator opts in.
    */
   readonly allowLocalNetwork: boolean;
+  /**
+   * Forwarded to `HostConfigShape.oauthDisableClientIdMetadataDocuments`: skip
+   * CIMD in automatic OAuth connects, for deployments whose web origin
+   * providers cannot fetch (private LAN, VPN, or tailnet).
+   */
+  readonly oauthDisableClientIdMetadataDocuments: boolean;
   // Better Auth session secret. Always resolved (env, else generated + persisted
   // under the data dir) so a single-container deploy boots with no env; the auth
   // layer still validates an explicitly-set env secret is long enough.
@@ -165,6 +171,7 @@ export const loadConfig = (): SelfHostConfig => {
     webBaseUrl,
     trustedOrigins: resolveTrustedOrigins(webBaseUrl),
     allowLocalNetwork: process.env.EXECUTOR_ALLOW_LOCAL_NETWORK === "true",
+    oauthDisableClientIdMetadataDocuments: process.env.EXECUTOR_OAUTH_DISABLE_CIMD === "true",
     authSecret: resolveAuthSecret(),
     bootstrapAdminEmail: process.env.EXECUTOR_BOOTSTRAP_ADMIN_EMAIL,
     bootstrapAdminPassword: process.env.EXECUTOR_BOOTSTRAP_ADMIN_PASSWORD,

--- a/apps/host-selfhost/src/execution.ts
+++ b/apps/host-selfhost/src/execution.ts
@@ -30,8 +30,9 @@ import { loadConfig } from "./config";
 //   - PluginsProvider      -> fresh `executor.config.ts#plugins()` per call,
 //                            matching per-request plugin instances (avoids
 //                            cross-request plugin state).
-//   - HostConfig           -> `{ allowLocalNetwork, webBaseUrl }` from
-//                            `loadConfig()`.
+//   - HostConfig           -> deployment knobs from `loadConfig()` plus the
+//                            selfhost callback path and analytics hooks (see
+//                            `SelfHostHostConfig` below).
 //   - CodeExecutorProvider -> `makeQuickJsExecutor()`.
 //   - EngineDecorator      -> execution analytics (anonymous per-install
 //                             counters; see ./analytics.ts).
@@ -55,6 +56,7 @@ export const SelfHostHostConfig: Layer.Layer<HostConfig> = Layer.sync(HostConfig
     allowLocalNetwork: config.allowLocalNetwork,
     webBaseUrl: config.webBaseUrl,
     oauthCallbackPath: "/api/oauth/callback",
+    oauthDisableClientIdMetadataDocuments: config.oauthDisableClientIdMetadataDocuments,
     toolsSyncTtlMs: config.toolsSyncTtlMs,
     onIntegrationChange: (event) =>
       selfHostAnalytics.record(

--- a/apps/host-selfhost/src/executor-config.test.ts
+++ b/apps/host-selfhost/src/executor-config.test.ts
@@ -6,9 +6,11 @@ import executorConfig from "../executor.config";
 const ENV_NAME = "EXECUTOR_ALLOW_STDIO_MCP";
 const SECRET_ENV_NAME = "EXECUTOR_SECRET_KEY";
 const TTL_ENV_NAME = "EXECUTOR_TOOLS_SYNC_TTL_MS";
+const DISABLE_CIMD_ENV_NAME = "EXECUTOR_OAUTH_DISABLE_CIMD";
 const originalValue = process.env[ENV_NAME];
 const originalSecret = process.env[SECRET_ENV_NAME];
 const originalTtl = process.env[TTL_ENV_NAME];
+const originalDisableCimd = process.env[DISABLE_CIMD_ENV_NAME];
 
 beforeEach(() => {
   process.env[SECRET_ENV_NAME] = originalSecret ?? "executor-config-test-secret";
@@ -29,6 +31,11 @@ afterEach(() => {
     delete process.env[TTL_ENV_NAME];
   } else {
     process.env[TTL_ENV_NAME] = originalTtl;
+  }
+  if (originalDisableCimd === undefined) {
+    delete process.env[DISABLE_CIMD_ENV_NAME];
+  } else {
+    process.env[DISABLE_CIMD_ENV_NAME] = originalDisableCimd;
   }
 });
 
@@ -64,6 +71,22 @@ test("stdio MCP stays disabled unless the opt-in is exactly true", () => {
 test("stdio MCP is enabled when the opt-in is exactly true", () => {
   process.env[ENV_NAME] = "true";
   expect(allowStdio()).toBe(true);
+});
+
+test("CIMD stays enabled unless the opt-out is exactly true", () => {
+  delete process.env[DISABLE_CIMD_ENV_NAME];
+  expect(loadConfig().oauthDisableClientIdMetadataDocuments).toBe(false);
+
+  process.env[DISABLE_CIMD_ENV_NAME] = "1";
+  expect(loadConfig().oauthDisableClientIdMetadataDocuments).toBe(false);
+
+  process.env[DISABLE_CIMD_ENV_NAME] = "TRUE";
+  expect(loadConfig().oauthDisableClientIdMetadataDocuments).toBe(false);
+});
+
+test("CIMD is disabled when the opt-out is exactly true", () => {
+  process.env[DISABLE_CIMD_ENV_NAME] = "true";
+  expect(loadConfig().oauthDisableClientIdMetadataDocuments).toBe(true);
 });
 
 test("an unset tools-sync TTL leaves the SDK default in place", () => {

--- a/e2e/selfhost/mcp-oauth-disable-cimd.test.ts
+++ b/e2e/selfhost/mcp-oauth-disable-cimd.test.ts
@@ -1,0 +1,160 @@
+// Selfhost-only: EXECUTOR_OAUTH_DISABLE_CIMD is the private-network operator
+// opt-out for automatic OAuth connects. A CIMD client_id is a URL on the
+// deployment itself that the provider's authorization server must fetch, which
+// a host that is not publicly reachable can never serve. With the flag set, a
+// server that advertises Client ID Metadata Documents alongside dynamic
+// registration is connected through DCR instead: the probe reports CIMD
+// unsupported, a dynamic-registration request mints the client, and
+// authorization starts with that minted client_id, never the hosted
+// metadata-document URL.
+//
+// Why this scenario boots its OWN instance instead of using the shared one:
+// the opt-out is a BOOT-TIME operator knob, and setting it on the shared
+// instance would invert what mcp-oauth-cimd-connect.test.ts asserts underneath
+// every other selfhost scenario. A dedicated instance on its own port and data
+// dir keeps the flag contained to this file (the same pattern as
+// mcp-session-idle-eviction.test.ts).
+import { randomBytes } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { makeGreetingMcpServer, serveMcpServerWithOAuth } from "@executor-js/plugin-mcp/testing";
+import { OAuthTestServer } from "@executor-js/sdk/testing";
+
+import { scenario } from "../src/scenario";
+import { claimAndBoot } from "../src/ports";
+import { Browser, RunDir } from "../src/services";
+import { visit } from "../src/surfaces/browser";
+import { isBootReadinessTimeout } from "../setup/boot";
+import { bootSelfhost } from "../setup/selfhost.boot";
+import { SELFHOST_ADMIN, signInSession } from "../targets/selfhost";
+
+/** The test server's login page is plain text with Basic-auth POST — nothing a
+ *  browser can click. Complete it out of band and hand back the callback URL. */
+const submitProviderLogin = async (loginUrl: string): Promise<string> => {
+  const credentials = Buffer.from("alice:password").toString("base64");
+  const response = await fetch(loginUrl, {
+    method: "POST",
+    redirect: "manual",
+    headers: { authorization: `Basic ${credentials}` },
+  });
+  const location = response.headers.get("location");
+  if (response.status !== 302 || !location) {
+    throw new Error(`provider login did not redirect (${response.status})`);
+  }
+  return new URL(location, loginUrl).toString();
+};
+
+scenario(
+  "MCP OAuth · EXECUTOR_OAUTH_DISABLE_CIMD connects through dynamic registration",
+  // Own vite dev boot (cold on a fresh checkout) needs materially more than
+  // the project's 180s default; same budget as mcp-session-idle-eviction.
+  { timeout: 420_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const browser = yield* Browser;
+      const runDir = yield* RunDir;
+      const oauth = yield* OAuthTestServer;
+      const server = yield* serveMcpServerWithOAuth(
+        () => makeGreetingMcpServer({ name: "no-cimd-connect-mcp" }),
+        { path: "/mcp" },
+      );
+
+      const dataDir = mkdtempSync(join(tmpdir(), "executor-selfhost-no-cimd-"));
+
+      // A distinct env var (not E2E_SELFHOST_PORT, which the shared instance
+      // has already published into this worker's env) so the claim actually
+      // probes and locks a free port instead of returning the shared one.
+      const booted = yield* Effect.promise(() =>
+        claimAndBoot(
+          [{ envVar: "E2E_SELFHOST_NO_CIMD_PORT", offset: 7, label: "selfhost no-cimd vite dev" }],
+          async (ports) => {
+            const port = ports.E2E_SELFHOST_NO_CIMD_PORT!;
+            const baseUrl = `http://localhost:${port}`;
+            const procs = await bootSelfhost({
+              port,
+              webBaseUrl: baseUrl,
+              admin: SELFHOST_ADMIN,
+              dataDir,
+              logFile: join(runDir, "no-cimd-boot.log"),
+              oauthDisableCimd: true,
+            });
+            return { teardown: procs.teardown, value: baseUrl };
+          },
+          { label: "selfhost no-cimd", retryWhen: isBootReadinessTimeout },
+        ),
+      );
+
+      yield* Effect.gen(function* () {
+        const baseUrl = booted.value;
+        // Sign into THIS scenario's instance. The identity carries no cookies
+        // on purpose: browser.session pins injected cookies to the shared
+        // target's baseUrl, and localhost cookies are port-blind, so a second
+        // Better Auth cookie would silently replace whichever landed first.
+        // One sign-in, one cookie, one origin.
+        const { cookies } = yield* Effect.promise(() => signInSession(baseUrl, SELFHOST_ADMIN));
+        const identity = { label: SELFHOST_ADMIN.email, credentials: SELFHOST_ADMIN };
+        const displayName = `No CIMD MCP ${randomBytes(3).toString("hex")}`;
+
+        yield* browser.session(identity, async ({ page, step }) => {
+          await page.context().addCookies(cookies.map((cookie) => ({ ...cookie, url: baseUrl })));
+
+          await step("Add an OAuth-protected MCP integration", async () => {
+            const addUrl = new URL("/integrations/add/mcp", baseUrl);
+            addUrl.searchParams.set("url", server.endpoint);
+            await visit(page, addUrl.toString());
+            await page.getByText("How does this server authenticate?").waitFor({ timeout: 30_000 });
+            await page.getByPlaceholder("e.g. Linear").fill(displayName);
+            await page.getByRole("button", { name: "Add integration" }).click();
+            await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, { timeout: 30_000 });
+            await page.getByText("Connections").first().waitFor();
+          });
+
+          await step("Connect registers a dynamic client instead of CIMD", async () => {
+            await page.getByRole("button", { name: "Add connection" }).first().click();
+            await page.getByRole("heading", { name: /Add connection/ }).waitFor();
+
+            const popupPromise = page.waitForEvent("popup", { timeout: 30_000 });
+            await page.getByRole("button", { name: "Connect", exact: true }).click();
+            const popup = await popupPromise;
+            await popup.waitForURL((url) => url.pathname === "/login", { timeout: 30_000 });
+
+            // The test AS login page is plain text driven by Basic-auth POST, so
+            // complete it out of band and drive the popup to the callback — the
+            // same journey a user's click-through consent takes.
+            const callbackUrl = await submitProviderLogin(popup.url());
+            await popup.goto(callbackUrl);
+          });
+
+          await step("The DCR-minted connection lands healthy", async () => {
+            await page.getByLabel("Status: Healthy").waitFor({ timeout: 30_000 });
+          });
+        });
+
+        const requests = yield* oauth.requests;
+        expect(
+          requests.filter((request) => request.method === "POST" && request.path === "/register"),
+          "the flag routes the automatic connect through dynamic registration",
+        ).toHaveLength(1);
+        const authorize = requests.find(
+          (request) => request.method === "GET" && request.path === "/authorize",
+        );
+        expect(authorize, "the popup reached the discovered authorization endpoint").toBeDefined();
+        expect(
+          authorize?.query["client_id"],
+          "authorization uses the client the registration minted, not a metadata-document URL",
+        ).toMatch(/^client_[0-9a-f-]+$/);
+      }).pipe(
+        Effect.ensuring(
+          Effect.promise(async () => {
+            await booted.teardown();
+            rmSync(dataDir, { recursive: true, force: true });
+          }),
+        ),
+      );
+    }),
+  ).pipe(Effect.provide(OAuthTestServer.layer({ clientIdMetadataDocumentSupported: true }))),
+);

--- a/e2e/setup/selfhost.boot.ts
+++ b/e2e/setup/selfhost.boot.ts
@@ -28,6 +28,11 @@ export interface SelfhostBootOptions {
    *  the eviction scenario proves in seconds what otherwise takes 30 minutes.
    *  Omit for production; the app then uses the store's own default. */
   readonly mcpSessionIdleTtlMs?: number;
+  /** Set EXECUTOR_OAUTH_DISABLE_CIMD, the private-network operator opt-out:
+   *  automatic OAuth connects skip Client ID Metadata Documents and use
+   *  dynamic client registration. Omit for the production default (CIMD
+   *  honored as discovered). */
+  readonly oauthDisableCimd?: boolean;
 }
 
 export const bootSelfhost = async (options: SelfhostBootOptions): Promise<BootedProcesses> => {
@@ -64,6 +69,7 @@ export const bootSelfhost = async (options: SelfhostBootOptions): Promise<Booted
           ...(options.mcpSessionIdleTtlMs !== undefined
             ? { EXECUTOR_MCP_SESSION_IDLE_TTL_MS: String(options.mcpSessionIdleTtlMs) }
             : {}),
+          ...(options.oauthDisableCimd === true ? { EXECUTOR_OAUTH_DISABLE_CIMD: "true" } : {}),
         },
         logFile: options.logFile,
       },

--- a/packages/core/api/src/server/scoped-executor.ts
+++ b/packages/core/api/src/server/scoped-executor.ts
@@ -116,6 +116,14 @@ export interface HostConfigShape {
    */
   readonly enterpriseManagedRollout?: ExecutorConfig["enterpriseManagedRollout"];
   /**
+   * Forwarded to `ExecutorConfig.oauthDisableClientIdMetadataDocuments`:
+   * suppress CIMD support in `oauth.probe` results so automatic connect flows
+   * use dynamic client registration or manual setup instead. Declared here,
+   * not per-request, because it describes the deployment. Omitted, CIMD is
+   * offered as discovered.
+   */
+  readonly oauthDisableClientIdMetadataDocuments?: boolean;
+  /**
    * Forwarded verbatim to `ExecutorConfig.toolsSyncTtlMs`: how long a
    * connection's persisted remote tool catalog stays fresh. Omit to take the
    * SDK default (15 minutes); `null` disables time-based re-sync. Declared
@@ -320,6 +328,7 @@ export const makeScopedExecutor = <
       oauthCallbackStateOrgSlug: orgSlug,
       firstPartyOAuthClients: config.firstPartyOAuthClients,
       enterpriseManagedRollout: config.enterpriseManagedRollout,
+      oauthDisableClientIdMetadataDocuments: config.oauthDisableClientIdMetadataDocuments,
       coreTools: {
         webBaseUrl,
         orgSlug,

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -706,6 +706,13 @@ export interface ExecutorConfig<TPlugins extends readonly AnyPlugin[] = readonly
   readonly oauthCallbackStateOrgSlug?: string;
   readonly oauthEndpointUrlPolicy?: OAuthEndpointUrlPolicy;
   /**
+   * Forwarded to `OAuthServiceDeps.disableClientIdMetadataDocuments`: suppress
+   * Client ID Metadata Document support in `oauth.probe` results, so automatic
+   * connect flows use dynamic client registration or manual setup instead.
+   * See that field for why a private-network deployment needs this.
+   */
+  readonly oauthDisableClientIdMetadataDocuments?: boolean;
+  /**
    * Host-owned rollout gate for enterprise-managed authorization (the MCP EMA
    * profile). Core declares the port and depends on no feature-flag or
    * analytics vendor; a host that operates one supplies an implementation.
@@ -6140,6 +6147,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       httpClientLayer: config.httpClientLayer,
       fetch: config.fetch,
       endpointUrlPolicy: config.oauthEndpointUrlPolicy,
+      disableClientIdMetadataDocuments: config.oauthDisableClientIdMetadataDocuments,
       // Connect-time only. The refresh path above (`performEnterpriseManagedRefresh`)
       // deliberately never sees this — it follows the enterprise state persisted
       // on the connection.

--- a/packages/core/sdk/src/oauth-client.ts
+++ b/packages/core/sdk/src/oauth-client.ts
@@ -384,7 +384,9 @@ export interface OAuthProbeResult {
    *  a public ("none") client when the server allows it. */
   readonly tokenEndpointAuthMethodsSupported?: readonly string[];
   /** Draft OAuth Client ID Metadata Document support, advertised by providers
-   *  such as PostHog as `client_id_metadata_document_supported`. */
+   *  such as PostHog as `client_id_metadata_document_supported`. False when the
+   *  host suppresses CIMD (`OAuthServiceDeps.disableClientIdMetadataDocuments`)
+   *  even if the server advertises it. */
   readonly clientIdMetadataDocumentSupported?: boolean;
 }
 

--- a/packages/core/sdk/src/oauth-probe-cimd.test.ts
+++ b/packages/core/sdk/src/oauth-probe-cimd.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { makeTestWorkspaceHarness, memoryCredentialsPlugin } from "./test-config";
+import { serveOAuthTestServer } from "./testing/oauth-test-server";
+
+// `oauth.probe` reports Client ID Metadata Document support as discovered, but a
+// host can suppress it (`oauthDisableClientIdMetadataDocuments`): a CIMD
+// `client_id` is a URL on the deployment itself that the provider's
+// authorization server must fetch, which a host on a private network can never
+// serve. With the flag set the probe reports CIMD unsupported while still
+// surfacing the registration endpoint, so automatic connect flows take the DCR
+// arm instead of starting a CIMD authorization the provider rejects as
+// `invalid_client`.
+
+const plugins = [memoryCredentialsPlugin()] as const;
+
+describe("oauth.probe CIMD suppression", () => {
+  it.effect("reports discovered CIMD support by default", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({
+          scopes: ["read"],
+          clientIdMetadataDocumentSupported: true,
+        });
+        const { executor } = yield* makeTestWorkspaceHarness({ plugins });
+
+        const probe = yield* executor.oauth.probe({ url: server.mcpResourceUrl });
+        expect(probe.clientIdMetadataDocumentSupported).toBe(true);
+        expect(probe.registrationEndpoint).toBe(server.registrationEndpoint);
+      }),
+    ),
+  );
+
+  it.effect("oauthDisableClientIdMetadataDocuments suppresses CIMD, keeps DCR discoverable", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({
+          scopes: ["read"],
+          clientIdMetadataDocumentSupported: true,
+        });
+        const { executor } = yield* makeTestWorkspaceHarness({
+          plugins,
+          oauthDisableClientIdMetadataDocuments: true,
+        });
+
+        const probe = yield* executor.oauth.probe({ url: server.mcpResourceUrl });
+        expect(probe.clientIdMetadataDocumentSupported).toBe(false);
+        // The registration endpoint still surfaces, so the automatic connect
+        // flow falls through to dynamic client registration.
+        expect(probe.registrationEndpoint).toBe(server.registrationEndpoint);
+      }),
+    ),
+  );
+});

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -226,6 +226,16 @@ export interface OAuthServiceDeps {
   readonly fetch?: typeof globalThis.fetch;
   readonly endpointUrlPolicy?: OAuthEndpointUrlPolicy;
   /**
+   * Suppress Client ID Metadata Document support in `probe` results. A CIMD
+   * `client_id` is a URL on this deployment that the provider's authorization
+   * server must fetch; a host whose web origin is not publicly reachable (a
+   * private-network self-host) can never serve that fetch, so it sets this
+   * flag and automatic connect flows fall through to dynamic client
+   * registration or manual setup instead of starting a CIMD authorization the
+   * provider rejects as `invalid_client`. Discovery is otherwise untouched.
+   */
+  readonly disableClientIdMetadataDocuments?: boolean;
+  /**
    * Host-owned rollout gate for enterprise-managed authorization (see
    * {@link EnterpriseManagedRollout}). Consulted ONCE per `id_jag` connect,
    * before discovery, and never again — not after the IdP has ruled, and not on
@@ -2258,6 +2268,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         registrationEndpoint: as.metadata.registration_endpoint ?? null,
         tokenEndpointAuthMethodsSupported: as.metadata.token_endpoint_auth_methods_supported,
         clientIdMetadataDocumentSupported:
+          deps.disableClientIdMetadataDocuments !== true &&
           as.metadata.client_id_metadata_document_supported === true,
       } satisfies OAuthProbeResult;
     }).pipe(Effect.provide(httpClientLayer));

--- a/packages/core/sdk/src/test-config.ts
+++ b/packages/core/sdk/src/test-config.ts
@@ -134,6 +134,7 @@ export type TestConfigOptions<TPlugins extends readonly AnyPlugin[] = readonly [
   readonly onIntegrationChange?: ExecutorConfig<TPlugins>["onIntegrationChange"];
   readonly firstPartyOAuthClients?: ExecutorConfig<TPlugins>["firstPartyOAuthClients"];
   readonly enterpriseManagedRollout?: ExecutorConfig<TPlugins>["enterpriseManagedRollout"];
+  readonly oauthDisableClientIdMetadataDocuments?: ExecutorConfig<TPlugins>["oauthDisableClientIdMetadataDocuments"];
 };
 
 export const makeTestConfig = <const TPlugins extends readonly AnyPlugin[] = readonly []>(
@@ -176,6 +177,7 @@ export const makeTestConfig = <const TPlugins extends readonly AnyPlugin[] = rea
     oauthCallbackStateOrgSlug: options?.oauthCallbackStateOrgSlug,
     firstPartyOAuthClients: options?.firstPartyOAuthClients,
     enterpriseManagedRollout: options?.enterpriseManagedRollout,
+    oauthDisableClientIdMetadataDocuments: options?.oauthDisableClientIdMetadataDocuments,
   };
 };
 


### PR DESCRIPTION
## Summary

A CIMD `client_id` is a URL on the deployment itself that the provider's authorization server must fetch. A self-host that is not publicly reachable (LAN, VPN, tailnet) can never serve that fetch, and since #1732 the automatic connect flow prefers CIMD with no fallback, so connects to providers that advertise it (Granola, Linear, Cloudflare) dead-end on `invalid_client`. This adds `EXECUTOR_OAUTH_DISABLE_CIMD=true` for the self-host: it suppresses CIMD support in the server-side `oauth.probe` result, so automatic connects fall through to dynamic client registration (or manual setup). Filtering at the probe needs no SPA changes, so it works with the prebuilt image, where the CIMD base URL is a build-time define.

## Linked issue

Fixes #1910

## Verification

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (new: `packages/core/sdk/src/oauth-probe-cimd.test.ts` 2/2, `apps/host-selfhost/src/executor-config.test.ts` 24/24 including exact-string opt-out cases)
- [x] e2e - `MCP OAuth · EXECUTOR_OAUTH_DISABLE_CIMD connects through dynamic registration` (new scenario, boots its own instance with the flag): `cd e2e && bunx vitest run --project selfhost selfhost/mcp-oauth-disable-cimd.test.ts`. The connect completes healthy through exactly one `POST /register`, and the authorize request carries the minted `client_...` id, not a metadata-document URL.
- Red-proof: the same scenario without the flag fails with `expected [] to have a length of 1` (zero registration requests), and its trace shows `client_id=http://localhost:<port>/api/oauth/client-id-metadata/default.json`.
- The existing `mcp-oauth-cimd-connect` scenario still passes, so default behavior is unchanged: the flag is opt-in and no host sets it unless the operator does.
- Against real providers from a tailnet-only self-host: the reproduction transcripts in the linked issue show Granola rejecting the private CIMD `client_id` as `invalid_client` while accepting DCR from the same host.

**Real provider check.** The same build was pointed at Granola's live MCP (`https://mcp.granola.ai/mcp`) from a host whose origin the provider cannot fetch, through the actual Add integration -> Connect flow, once per configuration:

- Without the flag, the popup dead-ends on `mcp-auth.granola.ai/oauth2/error?error=application_not_found`:

<img width="640" height="760" alt="granola-BEFORE-noflag-error" src="https://github.com/user-attachments/assets/7398ab9a-2762-418a-8852-a6f573564739" />

- With `EXECUTOR_OAUTH_DISABLE_CIMD=true`, the popup reaches Granola's sign-in page with a live authorization session for the DCR-minted client and the host's own callback as the `redirect_uri`:

<img width="640" height="760" alt="granola-AFTER-flag-signin" src="https://github.com/user-attachments/assets/49294f34-52f2-4ea8-bf58-83de88348150" />

## Checklist

- [x] Added a changeset (`bun run changeset`), or this change needs none.
- [x] Added or updated tests for the new behaviour.
- [x] No secrets, credentials, or private data in the diff.

## Choices worth a look

**An explicit opt-in flag, not reachability auto-detection.** The host cannot reliably know whether its web origin is fetchable from an arbitrary provider's network, and a probe-time reachability check would add latency and a new failure mode to every connect. The operator knows; one env var lets them say it.

**Probe-side filtering, not client plumbing.** `VITE_EXECUTOR_CIMD_CLIENT_ID_METADATA_BASE_URL` looks adjacent but does not solve this: it is a build-time Vite define (unavailable in the published image), and the hosted `local.json` it could point at declares loopback-only `redirect_uris` with `application_type: "native"`, which can never match a self-host's HTTPS callback. Suppressing CIMD in the probe result changes only what automatic connects choose; discovery output is otherwise untouched and nothing server-side rejects an explicitly configured CIMD client.

**Scope.** This covers probe-driven automatic connects (MCP). OpenAPI integrations persist `supportsClientIdMetadataDocument` into their auth template at add-time and read it back without probing, so an OpenAPI integration added before the flag was set keeps its CIMD client; that path is out of scope here and called out in the issue.

**CI note.** The new scenario boots its own vite dev instance (the flag is a boot-time knob; setting it on the shared instance would invert what `mcp-oauth-cimd-connect` asserts underneath every other scenario). That adds one own-boot scenario to the `selfhost-docker` gate as well, same pattern as `mcp-session-idle-eviction`.

