### PR TITLE
feat(api): publish the typed remote client

### DIFF
--- a/.changeset/public-executor-api-client.md
+++ b/.changeset/public-executor-api-client.md
@@ -1,0 +1,5 @@
+---
+"@executor-js/api": patch
+---
+
+Publish the runtime-neutral typed Executor HTTP client at `@executor-js/api/client`.

--- a/.changeset/public-executor-api-client.md
+++ b/.changeset/public-executor-api-client.md
@@ -2,4 +2,5 @@
 "@executor-js/api": patch
 ---
 
-Publish the runtime-neutral typed Executor HTTP client at `@executor-js/api/client`.
+Publish the runtime-neutral typed Executor HTTP client at `@executor-js/api/client` with a
+self-contained runtime schema bundle and clean public dependency boundary.

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -149,6 +149,7 @@ jobs:
           './apps/cli/dist/executor'
           './packages/core/storage-core'
           './packages/core/sdk'
+          './packages/core/api'
           './packages/core/config'
           './packages/core/execution'
           './packages/core/cli'

--- a/apps/host-selfhost/Dockerfile
+++ b/apps/host-selfhost/Dockerfile
@@ -12,7 +12,11 @@
 FROM oven/bun:1 AS prod-deps
 WORKDIR /app
 COPY . .
-RUN bun install --frozen-lockfile --production --ignore-scripts --filter @executor-js/host-selfhost \
+# The public API tarball exposes only the client, while its workspace server sources use
+# host-mcp and execution as build-time collaborators. Include API development dependencies
+# for this intermediate bundle stage; package-runtime copies only the runtime closure below.
+RUN bun install --frozen-lockfile --ignore-scripts \
+      --filter @executor-js/host-selfhost --filter @executor-js/api \
   && bun run apps/host-selfhost/scripts/package-runtime.ts
 
 FROM oven/bun:1 AS build

--- a/bun.lock
+++ b/bun.lock
@@ -484,14 +484,18 @@
         "@executor-js/execution": "workspace:*",
         "@executor-js/host-mcp": "workspace:*",
         "@executor-js/sdk": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
         "@types/node": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
+        "tsup": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/core/cli": {

--- a/bun.lock
+++ b/bun.lock
@@ -481,8 +481,6 @@
       "name": "@executor-js/api",
       "version": "1.4.70",
       "dependencies": {
-        "@executor-js/execution": "workspace:*",
-        "@executor-js/host-mcp": "workspace:*",
         "@executor-js/sdk": "workspace:*",
       },
       "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -485,6 +485,8 @@
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
+        "@executor-js/execution": "workspace:*",
+        "@executor-js/host-mcp": "workspace:*",
         "@types/node": "catalog:",
         "bun-types": "catalog:",
         "effect": "catalog:",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "turbo run test --filter=!@executor-js/e2e ${TURBO_TEST_CONCURRENCY:+--concurrency=$TURBO_TEST_CONCURRENCY}",
     "test:e2e": "bun run --cwd e2e test",
     "test:release:bootstrap": "vitest run tests/release-bootstrap-smoke.test.ts",
-    "build:packages": "bun run --filter='@executor-js/fumadb' build && bun run --filter='@executor-js/codemode-core' build && bun run --filter='@executor-js/runtime-quickjs' build && bun run --filter='@executor-js/sdk' build && bun run --filter='@executor-js/config' build && bun run --filter='@executor-js/execution' build && bun run --filter='@executor-js/cli' build && bun run --filter='@executor-js/plugin-*' build",
+    "build:packages": "bun run --filter='@executor-js/fumadb' build && bun run --filter='@executor-js/codemode-core' build && bun run --filter='@executor-js/runtime-quickjs' build && bun run --filter='@executor-js/sdk' build && bun run --filter='@executor-js/api' build && bun run --filter='@executor-js/config' build && bun run --filter='@executor-js/execution' build && bun run --filter='@executor-js/cli' build && bun run --filter='@executor-js/plugin-*' build",
     "typecheck": "turbo run typecheck",
     "typecheck:slow": "turbo run typecheck:slow",
     "ci": "bun run lint && bun run typecheck && bun run test",

--- a/packages/core/api/package.json
+++ b/packages/core/api/package.json
@@ -42,6 +42,8 @@
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
+    "@executor-js/execution": "workspace:*",
+    "@executor-js/host-mcp": "workspace:*",
     "@types/node": "catalog:",
     "bun-types": "catalog:",
     "effect": "catalog:",

--- a/packages/core/api/package.json
+++ b/packages/core/api/package.json
@@ -32,14 +32,12 @@
     }
   },
   "scripts": {
-    "build": "tsup && tsc --project tsconfig.build.json",
+    "build": "tsup",
     "typecheck": "tsgo --noEmit",
     "typecheck:slow": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {
-    "@executor-js/execution": "workspace:*",
-    "@executor-js/host-mcp": "workspace:*",
     "@executor-js/sdk": "workspace:*"
   },
   "devDependencies": {

--- a/packages/core/api/package.json
+++ b/packages/core/api/package.json
@@ -1,14 +1,38 @@
 {
   "name": "@executor-js/api",
   "version": "1.4.70",
-  "private": true,
+  "homepage": "https://github.com/UsefulSoftwareCo/executor/tree/main/packages/core/api",
+  "bugs": {
+    "url": "https://github.com/UsefulSoftwareCo/executor/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/UsefulSoftwareCo/executor.git",
+    "directory": "packages/core/api"
+  },
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
     "./client": "./src/client.ts",
     "./server": "./src/server.ts"
   },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      "./client": {
+        "import": {
+          "types": "./dist/client.d.ts",
+          "default": "./dist/client.js"
+        }
+      }
+    }
+  },
   "scripts": {
+    "build": "tsup && tsc --project tsconfig.build.json",
     "typecheck": "tsgo --noEmit",
     "typecheck:slow": "tsc --noEmit",
     "test": "vitest run"
@@ -16,14 +40,18 @@
   "dependencies": {
     "@executor-js/execution": "workspace:*",
     "@executor-js/host-mcp": "workspace:*",
-    "@executor-js/sdk": "workspace:*",
-    "effect": "catalog:"
+    "@executor-js/sdk": "workspace:*"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
+    "tsup": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/core/api/src/client.test.ts
+++ b/packages/core/api/src/client.test.ts
@@ -47,29 +47,36 @@ describe("makeExecutorApiClient", () => {
     }),
   );
 
-  it.effect("declares only the typed client as its public packed surface", () =>
+  it.effect("declares a public client boundary with no private workspace dependencies", () =>
     Effect.gen(function* () {
-      const source = yield* Effect.promise(() =>
-        readFile(new URL("../package.json", import.meta.url), "utf8"),
-      );
+      const [source, changesetsSource] = yield* Effect.all([
+        Effect.promise(() => readFile(new URL("../package.json", import.meta.url), "utf8")),
+        Effect.promise(() =>
+          readFile(new URL("../../../../.changeset/config.json", import.meta.url), "utf8"),
+        ),
+      ]);
       const manifest = decodeJson(source) as {
         readonly private?: boolean;
         readonly license?: string;
         readonly files?: ReadonlyArray<string>;
         readonly scripts?: Readonly<Record<string, string>>;
         readonly dependencies?: Readonly<Record<string, string>>;
+        readonly devDependencies?: Readonly<Record<string, string>>;
+        readonly optionalDependencies?: Readonly<Record<string, string>>;
         readonly peerDependencies?: Readonly<Record<string, string>>;
         readonly publishConfig?: {
           readonly access?: string;
           readonly exports?: Readonly<Record<string, unknown>>;
         };
       };
+      const changesets = decodeJson(changesetsSource) as {
+        readonly ignore?: ReadonlyArray<string>;
+      };
 
       expect(manifest).toMatchObject({
         license: "MIT",
         files: ["dist"],
-        scripts: { build: "tsup && tsc --project tsconfig.build.json" },
-        dependencies: { "@executor-js/host-mcp": "workspace:*" },
+        scripts: { build: "tsup" },
         peerDependencies: { effect: "catalog:" },
         publishConfig: {
           access: "public",
@@ -83,6 +90,14 @@ describe("makeExecutorApiClient", () => {
           },
         },
       });
+      expect(manifest.dependencies).toEqual({ "@executor-js/sdk": "workspace:*" });
+      const declaredDependencies = [
+        ...Object.keys(manifest.dependencies ?? {}),
+        ...Object.keys(manifest.devDependencies ?? {}),
+        ...Object.keys(manifest.optionalDependencies ?? {}),
+        ...Object.keys(manifest.peerDependencies ?? {}),
+      ];
+      expect(declaredDependencies.filter((name) => changesets.ignore?.includes(name))).toEqual([]);
       expect(manifest.private).not.toBe(true);
     }),
   );

--- a/packages/core/api/src/client.test.ts
+++ b/packages/core/api/src/client.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer, Ref, Schema } from "effect";
+import { readFile } from "node:fs/promises";
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+
+import { makeExecutorApiClient } from "@executor-js/api/client";
+
+const encodeJson = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
+const decodeJson = Schema.decodeUnknownSync(Schema.fromJsonString(Schema.Unknown));
+
+describe("makeExecutorApiClient", () => {
+  it.effect("calls the typed Executor API at the configured remote with explicit headers", () =>
+    Effect.gen(function* () {
+      const requests = yield* Ref.make<ReadonlyArray<HttpClientRequest.HttpClientRequest>>([]);
+      const httpClient = HttpClient.make((request) =>
+        Effect.gen(function* () {
+          yield* Ref.update(requests, (captured) => [...captured, request]);
+          return HttpClientResponse.fromWeb(
+            request,
+            new Response(encodeJson([]), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+          );
+        }),
+      );
+      const client = yield* makeExecutorApiClient({
+        baseUrl: "https://executor.example/api",
+        headers: { authorization: "Bearer service-token" },
+        transformClient: HttpClient.mapRequest((request) =>
+          HttpClientRequest.setHeader(request, "x-executor-org", "acme"),
+        ),
+      }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient)(httpClient)));
+
+      const integrations = yield* client.integrations.list();
+      const [captured] = yield* Ref.get(requests);
+
+      expect(integrations).toEqual([]);
+      expect(captured).toMatchObject({
+        method: "GET",
+        url: "https://executor.example/api/integrations",
+        headers: {
+          authorization: "Bearer service-token",
+          "x-executor-org": "acme",
+        },
+      });
+    }),
+  );
+
+  it.effect("declares only the typed client as its public packed surface", () =>
+    Effect.gen(function* () {
+      const source = yield* Effect.promise(() =>
+        readFile(new URL("../package.json", import.meta.url), "utf8"),
+      );
+      const manifest = decodeJson(source) as {
+        readonly private?: boolean;
+        readonly license?: string;
+        readonly files?: ReadonlyArray<string>;
+        readonly scripts?: Readonly<Record<string, string>>;
+        readonly dependencies?: Readonly<Record<string, string>>;
+        readonly peerDependencies?: Readonly<Record<string, string>>;
+        readonly publishConfig?: {
+          readonly access?: string;
+          readonly exports?: Readonly<Record<string, unknown>>;
+        };
+      };
+
+      expect(manifest).toMatchObject({
+        license: "MIT",
+        files: ["dist"],
+        scripts: { build: "tsup && tsc --project tsconfig.build.json" },
+        dependencies: { "@executor-js/host-mcp": "workspace:*" },
+        peerDependencies: { effect: "catalog:" },
+        publishConfig: {
+          access: "public",
+          exports: {
+            "./client": {
+              import: {
+                types: "./dist/client.d.ts",
+                default: "./dist/client.js",
+              },
+            },
+          },
+        },
+      });
+      expect(manifest.private).not.toBe(true);
+    }),
+  );
+});

--- a/packages/core/api/src/client.test.ts
+++ b/packages/core/api/src/client.test.ts
@@ -47,7 +47,7 @@ describe("makeExecutorApiClient", () => {
     }),
   );
 
-  it.effect("declares a public client boundary with no private workspace dependencies", () =>
+  it.effect("declares a public client boundary with no private runtime dependencies", () =>
     Effect.gen(function* () {
       const [source, changesetsSource] = yield* Effect.all([
         Effect.promise(() => readFile(new URL("../package.json", import.meta.url), "utf8")),
@@ -91,13 +91,18 @@ describe("makeExecutorApiClient", () => {
         },
       });
       expect(manifest.dependencies).toEqual({ "@executor-js/sdk": "workspace:*" });
-      const declaredDependencies = [
+      expect(manifest.devDependencies).toMatchObject({
+        "@executor-js/execution": "workspace:*",
+        "@executor-js/host-mcp": "workspace:*",
+      });
+      const publishableDependencies = [
         ...Object.keys(manifest.dependencies ?? {}),
-        ...Object.keys(manifest.devDependencies ?? {}),
         ...Object.keys(manifest.optionalDependencies ?? {}),
         ...Object.keys(manifest.peerDependencies ?? {}),
       ];
-      expect(declaredDependencies.filter((name) => changesets.ignore?.includes(name))).toEqual([]);
+      expect(publishableDependencies.filter((name) => changesets.ignore?.includes(name))).toEqual(
+        [],
+      );
       expect(manifest.private).not.toBe(true);
     }),
   );

--- a/packages/core/api/src/client.ts
+++ b/packages/core/api/src/client.ts
@@ -1,4 +1,11 @@
-export { ExecutorApi, CoreExecutorApi } from "./api";
+import type { Effect } from "effect";
+import { HttpClient, HttpClientRequest } from "effect/unstable/http";
+import type { Headers } from "effect/unstable/http";
+import { HttpApiClient } from "effect/unstable/httpapi";
+
+import { CoreExecutorApi, ExecutorApi } from "./api";
+
+export { CoreExecutorApi, ExecutorApi };
 export { ToolsApi } from "./tools/api";
 export { IntegrationsApi } from "./integrations/api";
 export { ConnectionsApi } from "./connections/api";
@@ -14,6 +21,46 @@ export {
   AccountNoOrganization,
   AccountUnauthorized,
 } from "./account/api";
+
+/** The exact typed client generated from Executor's first-party HTTP API. */
+export type ExecutorApiClient = HttpApiClient.ForApi<typeof ExecutorApi>;
+
+type HttpApiClientOptions = NonNullable<Parameters<typeof HttpApiClient.make>[1]>;
+
+export interface ExecutorApiClientOptions {
+  readonly baseUrl: string | URL;
+  /** Static request headers, including Authorization when the credential is fixed. */
+  readonly headers?: Headers.Input;
+  /** Dynamic auth or transport customization, applied after static headers. */
+  readonly transformClient?: HttpApiClientOptions["transformClient"];
+  readonly transformResponse?: HttpApiClientOptions["transformResponse"];
+}
+
+/**
+ * Build the first-party typed remote client. The caller supplies the concrete
+ * HttpClient layer, keeping this entry point server-safe and runtime-neutral.
+ */
+export const makeExecutorApiClient = (
+  options: ExecutorApiClientOptions,
+): Effect.Effect<ExecutorApiClient, never, HttpClient.HttpClient> => {
+  const headers = options.headers;
+  return HttpApiClient.make(ExecutorApi, {
+    baseUrl: options.baseUrl,
+    transformClient:
+      headers === undefined && options.transformClient === undefined
+        ? undefined
+        : (client) => {
+            const withHeaders =
+              headers === undefined
+                ? client
+                : HttpClient.mapRequest(client, (request) =>
+                    HttpClientRequest.setHeaders(request, headers),
+                  );
+            return options.transformClient?.(withHeaders) ?? withHeaders;
+          },
+    transformResponse: options.transformResponse,
+  });
+};
 export {
   AdminUsersApi,
   AdminUsersHttpApi,

--- a/packages/core/api/tsconfig.build.json
+++ b/packages/core/api/tsconfig.build.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "emitDeclarationOnly": true
-  },
-  "include": ["src/client.ts"],
-  "exclude": ["src/**/*.test.ts"]
-}

--- a/packages/core/api/tsconfig.build.json
+++ b/packages/core/api/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true
+  },
+  "include": ["src/client.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/core/api/tsup.config.ts
+++ b/packages/core/api/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    client: "src/client.ts",
+  },
+  format: ["esm"],
+  dts: false,
+  sourcemap: true,
+  clean: true,
+  external: [/^@executor-js\//, /^effect/, /^@effect\//],
+});

--- a/packages/core/api/tsup.config.ts
+++ b/packages/core/api/tsup.config.ts
@@ -5,8 +5,11 @@ export default defineConfig({
     client: "src/client.ts",
   },
   format: ["esm"],
-  dts: false,
+  dts: {
+    resolve: true,
+  },
   sourcemap: true,
   clean: true,
   external: [/^@executor-js\//, /^effect/, /^@effect\//],
+  noExternal: ["@executor-js/sdk/shared"],
 });

--- a/scripts/publish-packages.ts
+++ b/scripts/publish-packages.ts
@@ -31,6 +31,7 @@ const PUBLIC_PACKAGE_DIRS = [
   "packages/kernel/core",
   "packages/kernel/runtime-quickjs",
   "packages/core/sdk",
+  "packages/core/api",
   "packages/core/config",
   "packages/core/execution",
   "packages/core/cli",
@@ -103,8 +104,8 @@ type MutablePackageJson = {
  * Resolves `workspace:*` dependencies between public packages to concrete
  * versions before packing. Returns a restore function that reverts package.json.
  *
- * Workspace-only `@executor-js/*` peer deps (e.g. `@executor-js/api`,
- * `@executor-js/react`) that aren't in `publishable` are stripped from
+ * Workspace-only `@executor-js/*` peer deps (e.g. `@executor-js/react`) that
+ * aren't in `publishable` are stripped from
  * `peerDependencies` (and `peerDependenciesMeta`) entirely — they don't
  * exist on npm, so leaving them in the packed manifest would emit
  * install-time warnings for unresolvable packages.
@@ -126,7 +127,7 @@ const applyWorkspaceVersions = async (
         mutated = true;
       } else if (isInternalScope(key) && !publishable.has(key)) {
         // Workspace-only `@executor-js/*` regular dep that we don't
-        // publish (e.g. `@executor-js/api`). Strip it: it's not in the
+        // publish (e.g. `@executor-js/react`). Strip it: it's not in the
         // shipped runtime entries (those imports live in
         // `src/api/*` / `src/react/*` which don't make it into the
         // packed dist), and leaving it in would 404 at install time.
@@ -141,8 +142,8 @@ const applyWorkspaceVersions = async (
   /**
    * Peer-deps variant of `renameDepBlock`: resolve workspace specifiers for
    * publishable peers, but DROP non-publishable `@executor-js/*` peers.
-   * They reference workspace-only packages (`@executor-js/api`,
-   * `@executor-js/react`) that don't exist on npm, so leaving them in
+   * They reference workspace-only packages (`@executor-js/react`) that don't
+   * exist on npm, so leaving them in
    * the packed manifest emits install-time warnings for unresolvable
    * packages. Non-`@executor-js` peers (`react`, `@tanstack/*`,
    * `@effect-atom/*`, etc.) are real npm packages and pass through

--- a/scripts/smoke-test-packed.ts
+++ b/scripts/smoke-test-packed.ts
@@ -245,6 +245,139 @@ const smokeTestPackage = async (
   }
 };
 
+/**
+ * Exercise the API tarball as an external consumer actually receives it: the
+ * API itself is the only local tarball, and npm resolves every encoded runtime
+ * dependency from the registry. The batch smoke above intentionally replaces
+ * the full workspace graph with local tarballs; that is useful, but it can hide
+ * a client import that relies on an SDK export which has not been published.
+ */
+const smokeTestApiCleanDependencyGraph = async (
+  tarballs: Tarballs,
+  catalog: Readonly<Record<string, string>>,
+  failures: SmokeFailure[],
+): Promise<void> => {
+  const packageName = "@executor-js/api";
+  const tarballPath = tarballs.get(packageName);
+  if (!tarballPath) {
+    failures.push({ pkg: packageName, subpath: "<clean-install>", reason: "no tarball produced" });
+    return;
+  }
+
+  const tmp = await mkdtemp(join(tmpdir(), "executor-api-clean-smoke-"));
+  try {
+    const fixture = {
+      name: "executor-api-clean-smoke-fixture",
+      version: "0.0.0",
+      private: true,
+      type: "module",
+      dependencies: {
+        [packageName]: `file:${tarballPath}`,
+        effect: catalog.effect,
+        typescript: catalog.typescript,
+      },
+    };
+    await writeFile(join(tmp, "package.json"), `${JSON.stringify(fixture, null, 2)}\n`);
+    await writeFile(
+      join(tmp, "consumer.ts"),
+      [
+        'import { makeExecutorApiClient } from "@executor-js/api/client";',
+        'import type { ExecutorApiClient } from "@executor-js/api/client";',
+        "void makeExecutorApiClient;",
+        "const client: ExecutorApiClient | undefined = undefined;",
+        "void client;",
+        "",
+      ].join("\n"),
+    );
+
+    const install = await $`npm install --no-audit --no-fund --legacy-peer-deps`
+      .cwd(tmp)
+      .quiet()
+      .nothrow();
+    if (install.exitCode !== 0) {
+      failures.push({
+        pkg: packageName,
+        subpath: "<clean-install>",
+        reason: install.stderr.toString().trim().split("\n").slice(-3).join("\n"),
+      });
+      return;
+    }
+
+    const installedApi = await readPackageJson(
+      join(tmp, "node_modules", ...packageName.split("/")),
+    );
+    const sdkVersion = installedApi.dependencies?.["@executor-js/sdk"];
+    if (!sdkVersion) {
+      failures.push({
+        pkg: packageName,
+        subpath: "<clean-install>",
+        reason: "packed manifest has no encoded @executor-js/sdk dependency",
+      });
+      return;
+    }
+
+    const lock = JSON.parse(await readFile(join(tmp, "package-lock.json"), "utf8")) as {
+      readonly packages?: Readonly<Record<string, { readonly resolved?: string }>>;
+    };
+    const sdkResolution = lock.packages?.["node_modules/@executor-js/sdk"]?.resolved;
+    if (!sdkResolution?.startsWith("https://registry.npmjs.org/")) {
+      failures.push({
+        pkg: packageName,
+        subpath: "<clean-install>",
+        reason: `SDK did not resolve from the public registry: ${sdkResolution ?? "missing"}`,
+      });
+      return;
+    }
+
+    const installedApiRoot = join(tmp, "node_modules", ...packageName.split("/"));
+    const clientSource = await readFile(join(installedApiRoot, "dist", "client.js"), "utf8");
+    if (/\bfrom\s+["']@executor-js\//u.test(clientSource)) {
+      failures.push({
+        pkg: packageName,
+        subpath: "<clean-import>",
+        reason: "runtime client still imports a workspace package instead of its bundled schemas",
+      });
+      return;
+    }
+
+    const probe =
+      await $`node --input-type=module --eval ${`await import(${JSON.stringify(`${packageName}/client`)});`}`
+        .cwd(tmp)
+        .quiet()
+        .nothrow();
+    if (probe.exitCode !== 0) {
+      const stderr = probe.stderr.toString();
+      const missingExportMatch = stderr.match(MISSING_EXPORT_RE);
+      const reason = missingExportMatch
+        ? `published '${missingExportMatch[1]}' does not export '${missingExportMatch[2]}'`
+        : firstMeaningfulLine(stderr);
+      failures.push({ pkg: packageName, subpath: "<clean-import>", reason });
+      console.log(`  FAIL ${packageName}/client — ${reason}`);
+      return;
+    }
+
+    const typecheck =
+      await $`npm exec --no -- tsc --noEmit --module ESNext --moduleResolution Bundler --target ESNext --skipLibCheck consumer.ts`
+        .cwd(tmp)
+        .quiet()
+        .nothrow();
+    if (typecheck.exitCode !== 0) {
+      failures.push({
+        pkg: packageName,
+        subpath: "<clean-types>",
+        reason: firstMeaningfulLine(
+          `${typecheck.stdout.toString()}\n${typecheck.stderr.toString()}`,
+        ),
+      });
+      return;
+    }
+
+    console.log(`  ok  ${packageName}/client (clean registry graph + types, SDK ${sdkVersion})`);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+};
+
 const main = async () => {
   const rootPackage = await readPackageJson(repoRoot);
   console.log("[smoke] packing public packages via publish-packages.ts --dry-run");
@@ -270,6 +403,8 @@ const main = async () => {
     console.log(`[smoke] ${pkg.name}`);
     await smokeTestPackage(pkgDir, tarballs, rootPackage.catalog ?? {}, failures);
   }
+  console.log("[smoke] @executor-js/api clean dependency graph");
+  await smokeTestApiCleanDependencyGraph(tarballs, rootPackage.catalog ?? {}, failures);
 
   if (failures.length === 0) {
     console.log("[smoke] all packages OK");

--- a/scripts/smoke-test-packed.ts
+++ b/scripts/smoke-test-packed.ts
@@ -37,6 +37,7 @@ const PUBLIC_PACKAGE_DIRS = [
   "packages/kernel/core",
   "packages/kernel/runtime-quickjs",
   "packages/core/sdk",
+  "packages/core/api",
   "packages/core/config",
   "packages/core/execution",
   "packages/core/cli",
@@ -52,7 +53,10 @@ const PUBLIC_PACKAGE_DIRS = [
 type PackageJson = {
   name: string;
   version: string;
+  catalog?: Record<string, string>;
+  dependencies?: Record<string, string>;
   exports?: Record<string, unknown>;
+  peerDependencies?: Record<string, string>;
 };
 
 const readPackageJson = async (pkgDir: string): Promise<PackageJson> => {
@@ -109,6 +113,7 @@ type Tarballs = ReadonlyMap<string, string>;
 const smokeTestPackage = async (
   pkgDir: string,
   tarballs: Tarballs,
+  catalog: Readonly<Record<string, string>>,
   failures: SmokeFailure[],
 ): Promise<void> => {
   const pkg = await readPackageJson(pkgDir);
@@ -135,7 +140,17 @@ const smokeTestPackage = async (
       version: "0.0.0",
       private: true,
       type: "module",
-      dependencies: { [pkg.name]: `file:${tarballPath}` },
+      dependencies: {
+        [pkg.name]: `file:${tarballPath}`,
+        ...(pkg.name === "@executor-js/api" && pkg.peerDependencies?.effect
+          ? {
+              effect:
+                pkg.peerDependencies.effect === "catalog:"
+                  ? catalog.effect
+                  : pkg.peerDependencies.effect,
+            }
+          : {}),
+      },
       overrides,
     };
     await writeFile(join(tmp, "package.json"), `${JSON.stringify(fixture, null, 2)}\n`);
@@ -156,6 +171,25 @@ const smokeTestPackage = async (
     // Read the installed manifest — that's the real published view
     // (publishConfig.exports applied, workspace specifiers resolved).
     const installedPkg = await readPackageJson(join(tmp, "node_modules", ...pkg.name.split("/")));
+    if (pkg.name === "@executor-js/api") {
+      if (installedPkg.dependencies?.["@executor-js/host-mcp"] !== undefined) {
+        failures.push({
+          pkg: pkg.name,
+          subpath: "<install>",
+          reason: "published client manifest retains private @executor-js/host-mcp",
+        });
+        return;
+      }
+      const publishedSubpaths = Object.keys(installedPkg.exports ?? {});
+      if (publishedSubpaths.length !== 1 || publishedSubpaths[0] !== "./client") {
+        failures.push({
+          pkg: pkg.name,
+          subpath: "<install>",
+          reason: `published API surface is ${publishedSubpaths.join(", ") || "empty"}`,
+        });
+        return;
+      }
+    }
     const subpaths = subpathsToTest(installedPkg);
     if (subpaths.length === 0) {
       failures.push({
@@ -212,6 +246,7 @@ const smokeTestPackage = async (
 };
 
 const main = async () => {
+  const rootPackage = await readPackageJson(repoRoot);
   console.log("[smoke] packing public packages via publish-packages.ts --dry-run");
   await $`bun run scripts/publish-packages.ts --dry-run`.cwd(repoRoot);
 
@@ -233,7 +268,7 @@ const main = async () => {
     }
     const pkg = await readPackageJson(pkgDir);
     console.log(`[smoke] ${pkg.name}`);
-    await smokeTestPackage(pkgDir, tarballs, failures);
+    await smokeTestPackage(pkgDir, tarballs, rootPackage.catalog ?? {}, failures);
   }
 
   if (failures.length === 0) {


### PR DESCRIPTION
Makes the existing generic Executor remote client consumable as the public @executor-js/api/client package.\n\nThe public package exposes only the client entrypoint, depends only on the published SDK plus Effect peer compatibility, and bundles the shared runtime schemas needed to work with the currently published SDK. It does not expose or depend on host-mcp, execution, server routes, or any hosted-product handoff.\n\nRelease safety includes Changesets validation, package-boundary tests, the repository packed-package batch smoke, and a separate no-override clean-consumer smoke that installs only the API tarball while resolving the SDK from npm.\n\nValidated with 120 API tests, API typecheck, repository typecheck, lint, format, release workflow tests, changeset status, release:check, and both package smoke paths.