### PR TITLE
docs(sdk): invoke tools by address, not id

### DIFF
--- a/packages/core/sdk/README.md
+++ b/packages/core/sdk/README.md
@@ -42,7 +42,7 @@ const executor = await createExecutor({ onElicitation: "accept-all" });
 const tools = await executor.tools.list();
 const target = tools[0];
 if (target) {
-  const result = await executor.tools.invoke(target.id, {
+  const result = await executor.tools.invoke(target.address, {
     /* args matching target.inputSchema */
   });
   console.log(result);
@@ -54,7 +54,7 @@ await executor.close();
 Pass an `options` object only if you need to override the executor-level handler for a single call (rare — typically used by hosts that bridge per-client elicitation channels):
 
 ```ts
-await executor.tools.invoke(target.id, args, {
+await executor.tools.invoke(target.address, args, {
   onElicitation: customHandler,
 });
 ```


### PR DESCRIPTION
## Why
`Tool` in `packages/core/sdk/src/tool.ts` has `address` (`ToolAddress`) and no `id`.
The SDK README called `executor.tools.invoke(target.id, ...)`.

## Change
`packages/core/sdk/README.md`: both invoke examples now use `target.address`.

Plugin README address strings were already correct. Docs only.