### PR TITLE
Raise free-tier execution rate limit to 10k/hour

### DIFF
--- a/apps/cloud/src/engine/execution-rate-limit.ts
+++ b/apps/cloud/src/engine/execution-rate-limit.ts
@@ -47,7 +47,7 @@ export const RATE_LIMIT_WINDOW_MS = 3_600_000;
 // against the largest customer is a losing game, so the number no longer tries
 // to describe them — paid orgs are exempt below, and this now has only
 // free-tier abuse to cover, which is what it was picked for.
-export const EXECUTIONS_PER_ORG_PER_HOUR = 1000;
+export const EXECUTIONS_PER_ORG_PER_HOUR = 10_000;
 // Counter DO slower than this => fail open rather than stall executions.
 const RATE_LIMIT_CHECK_TIMEOUT_MS = 2_000;
 // Exemption lookup slower than this => treat as unresolved.

--- a/e2e/setup/execution-limits.ts
+++ b/e2e/setup/execution-limits.ts
@@ -5,7 +5,7 @@
 //
 // Picking the value is a squeeze from both sides. It must be LOW enough that
 // the backstop scenario can exhaust it with real sequential executions (prod's
-// 1000/hour cannot be reached in a test), and HIGH enough that no other
+// 10,000/hour cannot be reached in a test), and HIGH enough that no other
 // scenario trips it: the counter is per organization and every `execute` a
 // scenario runs counts against its org, so this must exceed the busiest
 // single-org scenario's execute count (currently toolkits-mcp at ~8) with


### PR DESCRIPTION
The hourly abuse backstop caps free orgs at 1000 executions per hour. A single agent session crossed it today, and the block message gives the client no way to continue.

Raise the cap to 10,000 per hour. Paid orgs stay exempt. The e2e override is unchanged, so scenario behavior is unaffected.