### PR TITLE
Route pricing to marketing

### DIFF
--- a/apps/cloud/src/edge/marketing.test.ts
+++ b/apps/cloud/src/edge/marketing.test.ts
@@ -12,6 +12,7 @@ describe("isMarketingPath", () => {
     "/home",
     "/privacy",
     "/terms",
+    "/pricing",
     "/about-executor",
     "/google-oauth",
     "/google-workspace",
@@ -64,6 +65,12 @@ describe("marketingProxyRequest", () => {
     });
 
     expect(marketingProxyRequest(request)?.url).toBe("https://executor.sh/blog/post");
+  });
+
+  it("routes /pricing to the marketing worker", () => {
+    const request = new Request("https://executor.sh/pricing");
+
+    expect(marketingProxyRequest(request)?.url).toBe("https://executor.sh/pricing");
   });
 
   it("rewrites the public home alias to the marketing root", () => {

--- a/apps/cloud/src/edge/marketing.ts
+++ b/apps/cloud/src/edge/marketing.ts
@@ -14,6 +14,7 @@ const MARKETING_PATHS = [
   "/setup",
   "/privacy",
   "/terms",
+  "/pricing",
   "/about-executor",
   "/google-oauth",
   "/google-workspace",


### PR DESCRIPTION
## Summary
- route /pricing through the marketing worker on executor.sh
- add a focused edge routing test for /pricing

## Verification
- bun test apps/cloud/src/edge/marketing.test.ts
- bun run --cwd apps/marketing build