### PR TITLE
fix(openapi): preserve vendor +json Content-Type on object bodies

### DIFF
--- a/.changeset/openapi-vendor-json-content-type.md
+++ b/.changeset/openapi-vendor-json-content-type.md
@@ -1,0 +1,5 @@
+---
+"@executor-js/plugin-openapi": patch
+---
+
+Preserve vendor +json Content-Type on OpenAPI object request bodies.

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -838,12 +838,9 @@ const applyRequestBody = (
   });
 
   if (isJsonContentType(contentType)) {
-    // Pre-serialized JSON strings pass through with the declared media
-    // type preserved (important for `application/vnd.foo+json` etc.).
-    if (typeof bodyValue === "string") {
-      return sent(HttpClientRequest.bodyText(request, bodyValue, contentType));
-    }
-    return sent(HttpClientRequest.bodyJsonUnsafe(request, bodyValue));
+    const text =
+      typeof bodyValue === "string" ? bodyValue : JSON.stringify(bodyValue);
+    return sent(HttpClientRequest.bodyText(request, text, contentType));
   }
 
   if (isFormUrlEncoded(contentType)) {

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -838,8 +838,7 @@ const applyRequestBody = (
   });
 
   if (isJsonContentType(contentType)) {
-    const text =
-      typeof bodyValue === "string" ? bodyValue : JSON.stringify(bodyValue);
+    const text = typeof bodyValue === "string" ? bodyValue : JSON.stringify(bodyValue);
     return sent(HttpClientRequest.bodyText(request, text, contentType));
   }
 

--- a/packages/plugins/openapi/src/sdk/non-json-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/non-json-body.test.ts
@@ -447,7 +447,7 @@ describe("OpenAPI non-JSON request body dispatch", () => {
     }),
   );
 
-    it.effect("application/vnd.api+json: object body keeps the declared content type", () =>
+  it.effect("application/vnd.api+json: object body keeps the declared content type", () =>
     Effect.gen(function* () {
       const { server, captured } = yield* startEchoServer({
         name: "createNote",
@@ -473,7 +473,7 @@ describe("OpenAPI non-JSON request body dispatch", () => {
       });
 
       expect(captured.contentType).toBe("application/vnd.api+json");
-      expect(JSON.parse(captured.body.toString("utf8"))).toEqual({ name: "Acme" });
+      expect(decodeJsonNameBody(captured.body.toString("utf8"))).toEqual({ name: "Acme" });
     }),
   );
 

--- a/packages/plugins/openapi/src/sdk/non-json-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/non-json-body.test.ts
@@ -447,6 +447,36 @@ describe("OpenAPI non-JSON request body dispatch", () => {
     }),
   );
 
+    it.effect("application/vnd.api+json: object body keeps the declared content type", () =>
+    Effect.gen(function* () {
+      const { server, captured } = yield* startEchoServer({
+        name: "createNote",
+        path: "/notes",
+        payload: JsonNameObject,
+        transformSpec: replaceRequestBodyContent("/notes", "post", {
+          "application/vnd.api+json": {
+            schema: {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+              },
+            },
+          },
+        }),
+      });
+
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+      const conn = yield* addOpenApiTestConnection(executor, server, { slug: "notes-jsonapi" });
+
+      yield* executor.execute(conn.address("body.createNote"), {
+        body: { name: "Acme" },
+      });
+
+      expect(captured.contentType).toBe("application/vnd.api+json");
+      expect(JSON.parse(captured.body.toString("utf8"))).toEqual({ name: "Acme" });
+    }),
+  );
+
   it.effect("multipart/form-data: only encoder-supported file shapes are advertised", () =>
     Effect.gen(function* () {
       const { server } = yield* startEchoServer({


### PR DESCRIPTION
Fixes #1930

## Why
`applyRequestBody` in `packages/plugins/openapi/src/sdk/invoke.ts` treats any `+json` type as JSON (`isJsonContentType`).

- String bodies used `bodyText(..., contentType)` and kept the declared type (`application/vnd.api+json`).
- Object bodies used `HttpClientRequest.bodyJsonUnsafe(...)`, which always sets `Content-Type: application/json`.

JSON:API and other vendor `+json` servers then return 415. Callers cannot pass a `Content-Type` header on the tool call.

## Change
Object JSON bodies now `JSON.stringify` and go through `bodyText` with the **declared** media type, same as strings.

Added a test in `non-json-body.test.ts`: object body + `application/vnd.api+json` asserts that exact Content-Type on the wire.

## Out of scope
Editable integration headers on `updateSpec` / configure. That is a separate feature. This PR only fixes the object-body header.