### PR TITLE
test(execution): fix flaky tool-invoker test

### DIFF
--- a/.changeset/tool-invoker-test-timeout.md
+++ b/.changeset/tool-invoker-test-timeout.md
@@ -1,0 +1,5 @@
+---
+"@executor-js/execution": patch
+---
+
+Give the sandbox describe/invoke contract test a 10s timeout so it does not flake on slow CI.

--- a/packages/core/execution/src/tool-invoker.test.ts
+++ b/packages/core/execution/src/tool-invoker.test.ts
@@ -905,39 +905,42 @@ describe("tool discovery", () => {
     }),
   );
 
-  it.effect("describes a return type that accepts the sandbox invocation result", () =>
-    Effect.gen(function* () {
-      const executor = yield* makeSearchExecutor();
-      const engine = createExecutionEngine({ executor, codeExecutor });
+  it.effect(
+    "describes a return type that accepts the sandbox invocation result",
+    () =>
+      Effect.gen(function* () {
+        const executor = yield* makeSearchExecutor();
+        const engine = createExecutionEngine({ executor, codeExecutor });
 
-      const execution = yield* engine.execute(
-        [
-          'const details = await tools.describe.tool({ path: "github.org.main.getRepositoryDetails" });',
-          "const result = await tools.github.org.main.getRepositoryDetails({ owner: 'executor', repo: 'executor' });",
-          "return {",
-          "  outputTypeScript: details.outputTypeScript,",
-          "  typeScriptDefinitions: details.typeScriptDefinitions,",
-          "  result,",
-          "};",
-        ].join("\n"),
-        { onElicitation: acceptAll },
-      );
+        const execution = yield* engine.execute(
+          [
+            'const details = await tools.describe.tool({ path: "github.org.main.getRepositoryDetails" });',
+            "const result = await tools.github.org.main.getRepositoryDetails({ owner: 'executor', repo: 'executor' });",
+            "return {",
+            "  outputTypeScript: details.outputTypeScript,",
+            "  typeScriptDefinitions: details.typeScriptDefinitions,",
+            "  result,",
+            "};",
+          ].join("\n"),
+          { onElicitation: acceptAll },
+        );
 
-      expect(execution.error).toBeUndefined();
-      const observed = execution.result as DescribedToolContract & { readonly result: unknown };
-      const diagnostics = typeCheckDescribedInvocation(
-        observed,
-        observed.result,
-        [
-          "function readDefaultBranch(result: ToolOutput): string {",
-          "  if (!result.ok) return result.error.message;",
-          "  return result.data.defaultBranch;",
-          "}",
-          "readDefaultBranch(invokedResult);",
-        ].join("\n"),
-      );
-      expect(diagnostics).toEqual([]);
-    }),
+        expect(execution.error).toBeUndefined();
+        const observed = execution.result as DescribedToolContract & { readonly result: unknown };
+        const diagnostics = typeCheckDescribedInvocation(
+          observed,
+          observed.result,
+          [
+            "function readDefaultBranch(result: ToolOutput): string {",
+            "  if (!result.ok) return result.error.message;",
+            "  return result.data.defaultBranch;",
+            "}",
+            "readDefaultBranch(invokedResult);",
+          ].join("\n"),
+        );
+        expect(diagnostics).toEqual([]);
+      }),
+    { timeout: 10000 },
   );
 
   it.effect(


### PR DESCRIPTION
## Description
Fixes #1928 - Flaky test in src/tool-invoker.test.ts.

## Problem
The test "describes a return type that accepts the sandbox invocation result" times out on CI.

## Solution
Added `{ timeout: 10000 }` to the test.

## Testing
- ✅ 39/39 tests passing
- ✅ Test completes within timeout

Closes #1928