### PR TITLE
Point agent setup CTA to the setup docs

### DIFF
--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -197,7 +197,10 @@ Source (and the place to start if something breaks): https://github.com/UsefulSo
                     >
                   </span>
                 </button>
-                <a href="https://executor.sh/docs" class="btn-secondary">Read docs</a>
+                <a
+                  href="https://executor.sh/docs#set-up-with-your-agent"
+                  class="btn-secondary">Read docs</a
+                >
               </div>
             </div>
 


### PR DESCRIPTION
## Summary

- Link the “Read docs” action beside “Set up with your agent” directly to the matching setup section.
- Leave the site-wide and CLI documentation links pointed at the docs root.

## Test plan

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run --cwd apps/marketing typecheck`
- [x] `bun run --cwd apps/marketing build`
- [x] Verified locally that the CTA resolves to `https://executor.sh/docs#set-up-with-your-agent` with no browser console errors.
